### PR TITLE
fix(web): TypeScript union type error in opencode actions

### DIFF
--- a/apps/web/src/actions/opencode.ts
+++ b/apps/web/src/actions/opencode.ts
@@ -375,7 +375,7 @@ export async function listMessagesAction(slug: string, sessionId: string): Promi
       const parts = transformParts(m.parts ?? [])
       const rawTimestamp = m.info.time?.created
       const isAssistant = m.info.role === 'assistant'
-      const pending = isAssistant && !m.info.time?.completed
+      const pending = isAssistant && !((m.info.time as { completed?: number })?.completed)
       return {
         id: m.info.id,
         sessionId,


### PR DESCRIPTION
## Summary

- Fix TypeScript build error where `completed` property was not recognized on union type `{ created: number; } | { created: number; completed?: number; }`
- Used type assertion to safely access the optional `completed` property

## Context

This fixes the failing GitHub Actions build on main branch.

## Test plan

- [ ] CI build passes
- [ ] No runtime regressions in message listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)