### PR TITLE
fix(web): resolve TypeScript errors breaking CI build

### DIFF
--- a/apps/web/src/app/api/u/[slug]/providers/route.ts
+++ b/apps/web/src/app/api/u/[slug]/providers/route.ts
@@ -41,7 +41,7 @@ export async function GET(
   const credentials = await prisma.providerCredential.findMany({
     where: {
       userId: user.id,
-      providerId: { in: PROVIDERS },
+      providerId: { in: [...PROVIDERS] },
     },
     select: {
       providerId: true,

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -194,7 +194,6 @@ export async function POST(
                 
                 // Filter events for our session only
                 if (eventSessionId && eventSessionId !== sessionId) {
-                  eventType = ''
                   eventData = ''
                   continue
                 }

--- a/apps/web/src/components/workspace/chat-panel.tsx
+++ b/apps/web/src/components/workspace/chat-panel.tsx
@@ -456,10 +456,11 @@ function ToolGroup({
 
   const toolLabel = getToolLabel(tool);
   const lastPart = parts[parts.length - 1];
-  const headerDisplay = getToolDisplay(tool, lastPart?.state.input, lastPart?.state.title || lastPart?.name || toolLabel);
+  const lastPartTitle = lastPart && "title" in lastPart.state ? lastPart.state.title : undefined;
+  const headerDisplay = getToolDisplay(tool, lastPart?.state.input, lastPartTitle || lastPart?.name || toolLabel);
   const summary = totalCount > 1
     ? `${totalCount} ${totalCount === 1 ? "call" : "calls"}${headerDisplay.summary ? ` · ${headerDisplay.summary}` : ""}`
-    : headerDisplay.summary || lastPart?.state.title || lastPart?.name || tool;
+    : headerDisplay.summary || lastPartTitle || lastPart?.name || tool;
   const showSummary = totalCount > 1 || (!!summary && summary !== tool);
 
   return (
@@ -519,8 +520,9 @@ function ToolGroup({
               const itemRunning = part.state.status === "running" || part.state.status === "pending";
               const itemError = part.state.status === "error";
               const itemComplete = part.state.status === "completed";
-              const detail = getToolDisplay(tool, part.state.input, part.state.title || part.name);
-              const title = detail.label || part.state.title || part.name;
+              const partTitle = "title" in part.state ? part.state.title : undefined;
+              const detail = getToolDisplay(tool, part.state.input, partTitle || part.name);
+              const title = detail.label || partTitle || part.name;
               
               return (
                 <div key={part.id} className="flex items-start gap-2 text-xs">
@@ -550,7 +552,7 @@ function ToolGroup({
                         </span>
                       )}
                     </div>
-                    {itemError && part.state.error && (
+                    {itemError && "error" in part.state && part.state.error && (
                       <div className="mt-0.5 text-[11px] text-destructive">{part.state.error}</div>
                     )}
                   </div>

--- a/apps/web/src/hooks/use-workspace.ts
+++ b/apps/web/src/hooks/use-workspace.ts
@@ -525,9 +525,10 @@ export function useWorkspace({
             ? part.state.input.subagent_type
             : undefined;
 
+        const stateTitle = "title" in part.state ? part.state.title : undefined;
         const toolDetail = taskAgent
-          ? `to ${taskAgent}${part.state.title ? ` - ${part.state.title}` : ""}`
-          : part.state.title;
+          ? `to ${taskAgent}${stateTitle ? ` - ${stateTitle}` : ""}`
+          : stateTitle;
 
         if (part.state.status === "error") {
           return {
@@ -760,7 +761,7 @@ export function useWorkspace({
                       !assistantMessageId
                     ) {
                       assistantMessageId = data.id;
-                      flushBufferedParts(assistantMessageId);
+                      if (assistantMessageId) flushBufferedParts(assistantMessageId);
                     }
                     break;
                   }
@@ -1020,15 +1021,16 @@ export function useWorkspace({
       } | null;
       if (!response.ok || !data?.agents) return;
 
-      setAgentCatalog(data.agents);
+      const agents = data.agents;
+      setAgentCatalog(agents);
       setActiveAgentId((current) => {
         if (current) {
-          const resolvedCurrent = findAgentInCatalog(data.agents, current);
+          const resolvedCurrent = findAgentInCatalog(agents, current);
           if (resolvedCurrent) {
             return resolvedCurrent.id;
           }
         }
-        const primary = data.agents.find((agent) => agent.isPrimary);
+        const primary = agents.find((agent) => agent.isPrimary);
         return primary?.id ?? current;
       });
     } catch {


### PR DESCRIPTION
## Summary
- Fixes all TypeScript type errors that have been causing the **Build & Push Web Image** CI workflow to fail since Feb 5th
- Spread readonly `PROVIDERS` tuple (`as const`) into a mutable array for Prisma's `in` operator
- Remove reference to undefined `eventType` variable in stream route session filtering
- Properly narrow `ToolState` discriminated union before accessing `title`/`error` properties in chat-panel and use-workspace
- Add null guard for `assistantMessageId` before passing to `flushBufferedParts`
- Capture `data.agents` in a local const so TypeScript narrows the type inside callbacks

## Test plan
- [ ] CI build passes (the "Build & Push Web Image" workflow should go green)
- [ ] Workspace chat panel renders tool groups correctly (title/error display)
- [ ] Streaming chat works end-to-end (session filtering in stream route)
- [ ] Provider list API returns credentials correctly
- [ ] Agent catalog loads and syncs on workspace open

🤖 Generated with [Claude Code](https://claude.com/claude-code)