### PR TITLE
chore(infra): add PR checks workflow (lint + test)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,6 +3,9 @@ name: PR Checks
 on:
   pull_request:
     branches: [main]
+    paths:
+      - "apps/web/**"
+      - ".github/workflows/pr-checks.yml"
 
 jobs:
   web-lint-test:


### PR DESCRIPTION
## Summary
- Add GitHub Actions PR workflow that runs `pnpm lint` and `pnpm test` in `apps/web/`.

## Why
- Prevent regressions by running lint/test before merging.
- Make OSS contributions easier to review safely.

## Testing
- Local: `pnpm -C apps/web lint` (currently emits an existing warning, no errors)
- Local: `pnpm -C apps/web test` (203 passed, 15 skipped)

Closes #95