### PR TITLE
ci: add PR checks workflow for lint and test

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,36 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/web/**"
+      - ".github/workflows/pr-checks.yml"
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: apps/web/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm prisma generate
+
+      - run: pnpm lint
+
+      - run: pnpm test


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-checks.yml` to run lint and test on PRs targeting `main`
- Triggers on `apps/web/**` changes (matching the existing build-push path filter)
- Runs pnpm install, prisma generate, lint, and test in a single job on Node 24

Closes #95

## Test plan
- [x] Verify workflow triggers on this PR (self-triggering via paths filter)
- [x] Confirm lint and test steps pass (green check)
- [ ] Optionally push a lint error or failing test to verify failures block merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)