### PR TITLE
fix(connectors): harden custom endpoint test against SSRF

### DIFF
--- a/apps/web/src/app/api/u/[slug]/connectors/[id]/test/route.ts
+++ b/apps/web/src/app/api/u/[slug]/connectors/[id]/test/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { prisma } from '@/lib/prisma'
 import { getAuthenticatedUser } from '@/lib/auth'
-import { validateSameOrigin } from '@/lib/csrf'
 import { decryptConfig } from '@/lib/connectors/crypto'
 import { getConnectorAuthType, getConnectorOAuthConfig } from '@/lib/connectors/oauth-config'
 import type { ConnectorType } from '@/lib/connectors/types'
 import { validateConnectorType } from '@/lib/connectors/validators'
+import { validateSameOrigin } from '@/lib/csrf'
+import { prisma } from '@/lib/prisma'
+import { validateConnectorTestEndpoint } from '@/lib/security/ssrf'
 
 export interface TestConnectionResult {
   ok: boolean
@@ -46,7 +47,8 @@ function isOAuthPending(type: ConnectorType, config: Record<string, unknown>): b
 
 async function testConnection(
   type: ConnectorType,
-  config: Record<string, unknown>
+  config: Record<string, unknown>,
+  options: { customEndpointUrl?: URL } = {}
 ): Promise<TestConnectionResult> {
   try {
     switch (type) {
@@ -124,9 +126,10 @@ async function testConnection(
           headers.Authorization = `Bearer ${auth}`
         }
 
-        const response = await fetchWithTimeout(endpoint, {
+        const response = await fetchWithTimeout(options.customEndpointUrl ?? endpoint, {
           method: 'GET',
           headers,
+          redirect: 'manual',
         })
 
         if (!response.ok) {
@@ -217,7 +220,19 @@ export async function POST(
     return NextResponse.json({ error: 'unsupported_connector_type' }, { status: 400 })
   }
 
-  const result = await testConnection(connector.type, config)
+  let customEndpointUrl: URL | undefined
+  if (connector.type === 'custom') {
+    const endpoint = typeof config.endpoint === 'string' ? config.endpoint : ''
+    if (endpoint) {
+      const endpointValidation = await validateConnectorTestEndpoint(endpoint)
+      if (!endpointValidation.ok) {
+        return NextResponse.json({ error: endpointValidation.error }, { status: 400 })
+      }
+      customEndpointUrl = endpointValidation.url
+    }
+  }
+
+  const result = await testConnection(connector.type, config, { customEndpointUrl })
 
   return NextResponse.json(result)
 }

--- a/apps/web/src/lib/security/ssrf.ts
+++ b/apps/web/src/lib/security/ssrf.ts
@@ -1,0 +1,143 @@
+import { lookup } from 'node:dns/promises'
+import { BlockList, isIP } from 'node:net'
+
+type LookupAddress = {
+  address: string
+  family: number
+}
+
+export type LookupHost = (hostname: string) => Promise<LookupAddress[]>
+
+type EndpointValidationError = 'invalid_endpoint' | 'blocked_endpoint'
+
+type EndpointValidationResult =
+  | { ok: true; url: URL }
+  | { ok: false; error: EndpointValidationError }
+
+const BLOCKED_SUBNETS = new BlockList()
+
+BLOCKED_SUBNETS.addSubnet('127.0.0.0', 8, 'ipv4')
+BLOCKED_SUBNETS.addSubnet('10.0.0.0', 8, 'ipv4')
+BLOCKED_SUBNETS.addSubnet('172.16.0.0', 12, 'ipv4')
+BLOCKED_SUBNETS.addSubnet('192.168.0.0', 16, 'ipv4')
+BLOCKED_SUBNETS.addSubnet('169.254.0.0', 16, 'ipv4')
+BLOCKED_SUBNETS.addSubnet('0.0.0.0', 8, 'ipv4')
+
+BLOCKED_SUBNETS.addSubnet('::', 128, 'ipv6')
+BLOCKED_SUBNETS.addSubnet('::1', 128, 'ipv6')
+BLOCKED_SUBNETS.addSubnet('fc00::', 7, 'ipv6')
+BLOCKED_SUBNETS.addSubnet('fe80::', 10, 'ipv6')
+
+async function defaultLookupHost(hostname: string): Promise<LookupAddress[]> {
+  return lookup(hostname, { all: true, verbatim: true })
+}
+
+function isLocalHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname.endsWith('.localhost')
+}
+
+function normalizeHostname(hostname: string): string {
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    return hostname.slice(1, -1)
+  }
+  return hostname
+}
+
+function extractMappedIpv4Address(address: string): string | null {
+  const lowered = address.toLowerCase()
+
+  const dotted = lowered.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)
+  if (dotted?.[1]) {
+    return isIP(dotted[1]) === 4 ? dotted[1] : null
+  }
+
+  const hex = lowered.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)
+  if (!hex?.[1] || !hex[2]) return null
+
+  const high = Number.parseInt(hex[1], 16)
+  const low = Number.parseInt(hex[2], 16)
+  if (!Number.isFinite(high) || !Number.isFinite(low)) return null
+
+  const octets = [
+    (high >> 8) & 0xff,
+    high & 0xff,
+    (low >> 8) & 0xff,
+    low & 0xff,
+  ]
+
+  return octets.join('.')
+}
+
+function isBlockedIpAddress(address: string): boolean {
+  const family = isIP(address)
+
+  if (family === 4) {
+    return BLOCKED_SUBNETS.check(address, 'ipv4')
+  }
+
+  if (family === 6) {
+    if (BLOCKED_SUBNETS.check(address, 'ipv6')) {
+      return true
+    }
+
+    const mappedIpv4 = extractMappedIpv4Address(address)
+    return mappedIpv4 ? BLOCKED_SUBNETS.check(mappedIpv4, 'ipv4') : false
+  }
+
+  return false
+}
+
+export async function validateConnectorTestEndpoint(
+  rawEndpoint: string,
+  options: { lookupHost?: LookupHost } = {}
+): Promise<EndpointValidationResult> {
+  const endpoint = rawEndpoint.trim()
+  if (!endpoint) {
+    return { ok: false, error: 'invalid_endpoint' }
+  }
+
+  let parsedUrl: URL
+  try {
+    parsedUrl = new URL(endpoint)
+  } catch {
+    return { ok: false, error: 'invalid_endpoint' }
+  }
+
+  if (parsedUrl.protocol !== 'https:') {
+    return { ok: false, error: 'invalid_endpoint' }
+  }
+
+  const hostname = normalizeHostname(parsedUrl.hostname.toLowerCase())
+  if (!hostname) {
+    return { ok: false, error: 'invalid_endpoint' }
+  }
+
+  if (isLocalHostname(hostname)) {
+    return { ok: false, error: 'blocked_endpoint' }
+  }
+
+  if (isBlockedIpAddress(hostname)) {
+    return { ok: false, error: 'blocked_endpoint' }
+  }
+
+  if (isIP(hostname) === 0) {
+    const lookupHost = options.lookupHost ?? defaultLookupHost
+
+    let addresses: LookupAddress[]
+    try {
+      addresses = await lookupHost(hostname)
+    } catch {
+      return { ok: false, error: 'invalid_endpoint' }
+    }
+
+    if (!Array.isArray(addresses) || addresses.length === 0) {
+      return { ok: false, error: 'invalid_endpoint' }
+    }
+
+    if (addresses.some((entry) => isBlockedIpAddress(entry.address))) {
+      return { ok: false, error: 'blocked_endpoint' }
+    }
+  }
+
+  return { ok: true, url: parsedUrl }
+}

--- a/apps/web/tests/connectors-test-route.test.ts
+++ b/apps/web/tests/connectors-test-route.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetAuthenticatedUser = vi.fn()
+vi.mock('@/lib/auth', () => ({
+  getAuthenticatedUser: (...args: unknown[]) => mockGetAuthenticatedUser(...args),
+}))
+
+const mockValidateSameOrigin = vi.fn()
+vi.mock('@/lib/csrf', () => ({
+  validateSameOrigin: (...args: unknown[]) => mockValidateSameOrigin(...args),
+}))
+
+const mockUserFindUnique = vi.fn()
+const mockConnectorFindFirst = vi.fn()
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: (...args: unknown[]) => mockUserFindUnique(...args),
+    },
+    connector: {
+      findFirst: (...args: unknown[]) => mockConnectorFindFirst(...args),
+    },
+  },
+}))
+
+const mockDecryptConfig = vi.fn()
+vi.mock('@/lib/connectors/crypto', () => ({
+  decryptConfig: (...args: unknown[]) => mockDecryptConfig(...args),
+}))
+
+const mockValidateConnectorTestEndpoint = vi.fn()
+vi.mock('@/lib/security/ssrf', () => ({
+  validateConnectorTestEndpoint: (...args: unknown[]) => mockValidateConnectorTestEndpoint(...args),
+}))
+
+function session(slug: string) {
+  return { user: { id: 'user-1', email: 'alice@example.com', slug, role: 'USER' }, sessionId: 'session-1' }
+}
+
+async function callTestRoute(slug = 'alice', id = 'conn-1') {
+  const { POST } = await import('@/app/api/u/[slug]/connectors/[id]/test/route')
+
+  const request = new Request(`http://localhost/api/u/${slug}/connectors/${id}/test`, {
+    method: 'POST',
+    headers: {
+      host: 'localhost',
+      origin: 'http://localhost',
+    },
+  })
+
+  const response = await POST(request as never, { params: Promise.resolve({ slug, id }) })
+  return { status: response.status, body: await response.json() }
+}
+
+describe('POST /api/u/[slug]/connectors/[id]/test SSRF hardening', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+
+    mockGetAuthenticatedUser.mockResolvedValue(session('alice'))
+    mockValidateSameOrigin.mockReturnValue({ ok: true })
+    mockUserFindUnique.mockResolvedValue({ id: 'user-1' })
+    mockConnectorFindFirst.mockResolvedValue({
+      id: 'conn-1',
+      userId: 'user-1',
+      type: 'custom',
+      enabled: true,
+      config: 'encrypted-config',
+    })
+    mockDecryptConfig.mockReturnValue({ endpoint: 'https://api.example.com/mcp' })
+    mockValidateConnectorTestEndpoint.mockResolvedValue({ ok: true, url: new URL('https://api.example.com/mcp') })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('ok', { status: 200 })))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns 400 for blocked custom endpoints without issuing outbound fetch', async () => {
+    mockValidateConnectorTestEndpoint.mockResolvedValueOnce({ ok: false, error: 'blocked_endpoint' })
+
+    const { status, body } = await callTestRoute('alice', 'conn-1')
+
+    expect(status).toBe(400)
+    expect(body).toEqual({ error: 'blocked_endpoint' })
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for invalid custom endpoints', async () => {
+    mockValidateConnectorTestEndpoint.mockResolvedValueOnce({ ok: false, error: 'invalid_endpoint' })
+
+    const { status, body } = await callTestRoute('alice', 'conn-1')
+
+    expect(status).toBe(400)
+    expect(body).toEqual({ error: 'invalid_endpoint' })
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('uses redirect manual when testing allowed custom endpoints', async () => {
+    const { status, body } = await callTestRoute('alice', 'conn-1')
+
+    expect(status).toBe(200)
+    expect(body).toMatchObject({ ok: true, tested: true })
+    expect(mockValidateConnectorTestEndpoint).toHaveBeenCalledWith('https://api.example.com/mcp')
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      new URL('https://api.example.com/mcp'),
+      expect.objectContaining({
+        method: 'GET',
+        redirect: 'manual',
+      })
+    )
+  })
+})

--- a/apps/web/tests/ssrf.test.ts
+++ b/apps/web/tests/ssrf.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { validateConnectorTestEndpoint } from '@/lib/security/ssrf'
+
+describe('validateConnectorTestEndpoint', () => {
+  it('accepts a public https endpoint', async () => {
+    const lookupHost = vi.fn().mockResolvedValue([{ address: '93.184.216.34', family: 4 }])
+
+    const result = await validateConnectorTestEndpoint('https://api.example.com/mcp', { lookupHost })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.url.toString()).toBe('https://api.example.com/mcp')
+    }
+    expect(lookupHost).toHaveBeenCalledWith('api.example.com')
+  })
+
+  it('rejects invalid endpoint urls', async () => {
+    const lookupHost = vi.fn()
+
+    const result = await validateConnectorTestEndpoint('not-a-url', { lookupHost })
+
+    expect(result).toEqual({ ok: false, error: 'invalid_endpoint' })
+    expect(lookupHost).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-https protocols', async () => {
+    const lookupHost = vi.fn()
+
+    const result = await validateConnectorTestEndpoint('http://api.example.com/mcp', { lookupHost })
+
+    expect(result).toEqual({ ok: false, error: 'invalid_endpoint' })
+    expect(lookupHost).not.toHaveBeenCalled()
+  })
+
+  it('rejects localhost endpoints', async () => {
+    const lookupHost = vi.fn()
+
+    const result = await validateConnectorTestEndpoint('https://localhost/mcp', { lookupHost })
+
+    expect(result).toEqual({ ok: false, error: 'blocked_endpoint' })
+    expect(lookupHost).not.toHaveBeenCalled()
+  })
+
+  it('rejects private ipv4 literal endpoints', async () => {
+    const lookupHost = vi.fn()
+
+    const result = await validateConnectorTestEndpoint('https://127.0.0.1/mcp', { lookupHost })
+
+    expect(result).toEqual({ ok: false, error: 'blocked_endpoint' })
+    expect(lookupHost).not.toHaveBeenCalled()
+  })
+
+  it('rejects unspecified ipv4 literal endpoints', async () => {
+    const lookupHost = vi.fn()
+
+    const result = await validateConnectorTestEndpoint('https://0.0.0.0/mcp', { lookupHost })
+
+    expect(result).toEqual({ ok: false, error: 'blocked_endpoint' })
+    expect(lookupHost).not.toHaveBeenCalled()
+  })
+
+  it('rejects loopback ipv6 literal endpoints', async () => {
+    const lookupHost = vi.fn()
+
+    const result = await validateConnectorTestEndpoint('https://[::1]/mcp', { lookupHost })
+
+    expect(result).toEqual({ ok: false, error: 'blocked_endpoint' })
+    expect(lookupHost).not.toHaveBeenCalled()
+  })
+
+  it('rejects unspecified ipv6 literal endpoints', async () => {
+    const lookupHost = vi.fn()
+
+    const result = await validateConnectorTestEndpoint('https://[::]/mcp', { lookupHost })
+
+    expect(result).toEqual({ ok: false, error: 'blocked_endpoint' })
+    expect(lookupHost).not.toHaveBeenCalled()
+  })
+
+  it('rejects ipv4-mapped ipv6 private endpoints', async () => {
+    const lookupHost = vi.fn()
+
+    const result = await validateConnectorTestEndpoint('https://[::ffff:7f00:1]/mcp', { lookupHost })
+
+    expect(result).toEqual({ ok: false, error: 'blocked_endpoint' })
+    expect(lookupHost).not.toHaveBeenCalled()
+  })
+
+  it('rejects hostnames that resolve to private addresses', async () => {
+    const lookupHost = vi.fn().mockResolvedValue([{ address: '10.0.0.5', family: 4 }])
+
+    const result = await validateConnectorTestEndpoint('https://internal.example/mcp', { lookupHost })
+
+    expect(result).toEqual({ ok: false, error: 'blocked_endpoint' })
+  })
+
+  it('rejects hostnames that resolve to private ipv6 addresses', async () => {
+    const lookupHost = vi.fn().mockResolvedValue([{ address: 'fd00::1', family: 6 }])
+
+    const result = await validateConnectorTestEndpoint('https://internal-v6.example/mcp', { lookupHost })
+
+    expect(result).toEqual({ ok: false, error: 'blocked_endpoint' })
+  })
+
+  it('rejects hostnames with mixed public and private dns answers', async () => {
+    const lookupHost = vi.fn().mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '192.168.1.10', family: 4 },
+    ])
+
+    const result = await validateConnectorTestEndpoint('https://mixed.example/mcp', { lookupHost })
+
+    expect(result).toEqual({ ok: false, error: 'blocked_endpoint' })
+  })
+
+  it('rejects endpoints when dns lookup fails', async () => {
+    const lookupHost = vi.fn().mockRejectedValue(new Error('ENOTFOUND'))
+
+    const result = await validateConnectorTestEndpoint('https://unknown.example/mcp', { lookupHost })
+
+    expect(result).toEqual({ ok: false, error: 'invalid_endpoint' })
+  })
+})


### PR DESCRIPTION
## Summary
- Validate custom connector test endpoints before outbound requests and reject unsafe targets with explicit `invalid_endpoint` / `blocked_endpoint` errors.
- Add SSRF guardrails in a dedicated helper: HTTPS-only, localhost/private/link-local blocking, DNS resolution checks, and IPv4/IPv6 edge-case coverage.
- Prevent redirect-following in custom connector test requests with `redirect: 'manual'`.
- Add focused test coverage for SSRF validation and connector test route behavior.

## Verification
- `pnpm -C apps/web test`
- `pnpm -C apps/web lint` (passes with one pre-existing warning in `apps/web/src/components/connectors/connectors-page-client.tsx:114`)