### PR TITLE
fix(ci): add contents write permission for repository dispatch

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -11,7 +11,7 @@ jobs:
       github.event.issue.pull_request != null
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
## Summary

- Fix 403 error when triggering repository dispatch from PR Commands workflow
- Change `contents: read` to `contents: write` to allow triggering other workflows

## Testing

After merging, test by writing `/build` in any open PR.