### PR TITLE
fix(ci): get PR branch correctly for issue_comment events

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -15,6 +15,19 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Get PR branch
+        id: get-pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('pr_branch', pr.head.ref);
+            console.log(`PR branch: ${pr.head.ref}`);
+
       - name: Trigger build via repository dispatch
         run: |
           curl -X POST \
@@ -26,7 +39,7 @@ jobs:
               "client_payload": {
                 "pr_number": "${{ github.event.issue.number }}",
                 "comment_id": "${{ github.event.comment.id }}",
-                "ref": "${{ github.event.pull_request.head.ref }}"
+                "ref": "${{ steps.get-pr.outputs.pr_branch }}"
               }
             }'
 


### PR DESCRIPTION
## Summary

Fixes the issue where `/build` command was building from `main` instead of the PR branch.

## Problem

In `issue_comment` events, `github.event.pull_request.head.ref` is not available (it's only available in `pull_request` events). This caused the build workflow to default to `main` branch.

## Solution

Add a step to fetch PR data from GitHub API to get the correct branch name using `jq` to extract `.head.ref`.

## Changes

- Added `Get PR branch` step that calls GitHub API
- Uses the extracted branch in the repository dispatch payload

## Testing

After merging, test by writing `/build` in any open PR - it should now build from the correct branch.