### PR TITLE
feat(infra): support building web image directly on VPS

### DIFF
--- a/infra/deploy/.env.example
+++ b/infra/deploy/.env.example
@@ -34,7 +34,13 @@ ARCHE_SEED_TEST_SLUG=peter
 # Optional overrides
 # IMAGE_PREFIX=ghcr.io/peaberry-studio/arche/
 # WEB_VERSION=latest
+# WEB_IMAGE=ghcr.io/peaberry-studio/arche/web:latest
 # OPENCODE_IMAGE=arche-workspace:latest
 # For PR-image testing, for example:
 # WEB_VERSION=pr-124
+# WEB_IMAGE=ghcr.io/peaberry-studio/arche/web:pr-124
 # OPENCODE_IMAGE=ghcr.io/peaberry-studio/arche/workspace:pr-124
+
+# Build images directly on the VPS (no registry pull):
+# WEB_IMAGE=arche-web:latest
+# OPENCODE_IMAGE=arche-workspace:latest

--- a/infra/deploy/README.md
+++ b/infra/deploy/README.md
@@ -72,7 +72,7 @@ Edit files in `apps/web/src/` and Next.js hot reloads automatically.
 
 ### Remote mode
 
-Deploys to a VPS via SSH using Ansible. The playbook provisions Podman (if missing), renders the compose and env templates, pulls images from GHCR, runs migrations, and seeds the database.
+Deploys to a VPS via SSH using Ansible. The playbook provisions Podman (if missing), renders the compose and env templates, deploys images (from GHCR or local VPS builds), runs migrations, and seeds the database.
 
 - Domain: any single hostname (apex or subdomain), with TLS via ACME HTTP challenge
 - HTTPS on port 443, HTTP redirects to HTTPS
@@ -152,8 +152,12 @@ No DNS provider token is required. Traefik uses ACME HTTP challenge on entrypoin
 |----------|---------|
 | `IMAGE_PREFIX` | `ghcr.io/peaberry-studio/arche/` |
 | `WEB_VERSION` | `latest` |
+| `WEB_IMAGE` | `<IMAGE_PREFIX>web:<WEB_VERSION>` |
 | `OPENCODE_IMAGE` | `arche-workspace:latest` |
 | `PODMAN_SOCKET_PATH` | Auto-detected (see below) |
+
+To build the web image directly on the VPS, set `WEB_IMAGE=arche-web:latest`.
+To build the workspace image directly on the VPS, set `OPENCODE_IMAGE=arche-workspace:latest`.
 
 ## Podman Socket
 
@@ -183,7 +187,7 @@ HTTP-01 challenge is used in remote mode. Make sure your domain resolves to the 
 | Traefik | `traefik:v3.6.7` | Reverse proxy, TLS termination, routing |
 | docker-socket-proxy | `tecnativa/docker-socket-proxy:0.3` | Secure container API access |
 | PostgreSQL | `postgres:16` | Database |
-| Web | GHCR image | Next.js app (BFF + spawner) |
+| Web | Configurable (`WEB_IMAGE`) | Next.js app (BFF + spawner) |
 
 ## Directory Structure (VPS)
 

--- a/infra/deploy/ansible/roles/app/tasks/main.yml
+++ b/infra/deploy/ansible/roles/app/tasks/main.yml
@@ -181,12 +181,13 @@
   ignore_errors: true
 
 # ---------------------------------------------------------------------------
-# Step 3: Pull new web image
+# Step 3: Pull new web image (unless built locally)
 # ---------------------------------------------------------------------------
 - name: Pull new web image
   ansible.builtin.command:
-    cmd: podman pull {{ image_prefix }}web:{{ web_version }}
+    cmd: podman pull {{ web_image }}
   changed_when: true
+  when: web_image != "arche-web:latest"
 
 # ---------------------------------------------------------------------------
 # Step 4: Ensure base services are running (postgres, traefik, socket-proxy)
@@ -325,7 +326,7 @@
       --label arche.role=web \
       --label arche.version={{ web_version }} \
       --restart unless-stopped \
-      {{ image_prefix }}web:{{ web_version }}
+      {{ web_image }}
   changed_when: true
 
 # 5d. Wait for the new container to pass health check

--- a/infra/deploy/ansible/vars/all.yml
+++ b/infra/deploy/ansible/vars/all.yml
@@ -14,6 +14,7 @@ podman_socket_path: "{{ lookup('env', 'PODMAN_SOCKET_PATH') | default('/run/podm
 # Container images
 image_prefix: "{{ lookup('env', 'IMAGE_PREFIX') | default('ghcr.io/peaberry-studio/arche/', true) }}"
 web_version: "{{ lookup('env', 'WEB_VERSION') | default('latest', true) }}"
+web_image: "{{ lookup('env', 'WEB_IMAGE') | default(image_prefix ~ 'web:' ~ web_version, true) }}"
 opencode_image: "{{ lookup('env', 'OPENCODE_IMAGE') | default('arche-workspace:latest', true) }}"
 
 # GHCR auth

--- a/infra/deploy/deploy.sh
+++ b/infra/deploy/deploy.sh
@@ -72,6 +72,37 @@ prepare_remote_workspace_image() {
     "cd /tmp/arche-workspace-image-src && podman build --build-arg OPENCODE_VERSION=1.1.45 -t arche-workspace:latest ."
 }
 
+prepare_remote_web_image() {
+  if [[ "$WEB_IMAGE" != "arche-web:latest" ]]; then
+    log "Skipping remote web image build (WEB_IMAGE=$WEB_IMAGE)"
+    return
+  fi
+
+  if $DRY_RUN; then
+    warn "DRY RUN — skipping remote web image build"
+    return
+  fi
+
+  local repo_root="$SCRIPT_DIR/../.."
+  repo_root="$(cd "$repo_root" && pwd)"
+  local web_src="$repo_root/apps/web"
+
+  if [[ ! -f "$web_src/Containerfile" ]]; then
+    err "Cannot find apps/web/Containerfile in $repo_root"
+    err "Run this script from within the arche repository."
+    exit 1
+  fi
+
+  log "Syncing web image sources to remote host..."
+  tar -C "$repo_root" -czf - apps/web | \
+    ssh -o BatchMode=yes -o ConnectTimeout=10 -i "$SSH_KEY" "${SSH_USER}@${DEPLOY_IP}" \
+      "rm -rf /tmp/arche-web-src && mkdir -p /tmp/arche-web-src && tar -xzf - -C /tmp/arche-web-src --strip-components=2"
+
+  log "Building web image on remote host: arche-web:latest"
+  ssh -o BatchMode=yes -o ConnectTimeout=10 -i "$SSH_KEY" "${SSH_USER}@${DEPLOY_IP}" \
+    "cd /tmp/arche-web-src && podman build -t arche-web:latest ."
+}
+
 usage() {
   cat <<'EOF'
 Arche One-Click Deployer
@@ -124,6 +155,7 @@ ENVIRONMENT VARIABLES (via .env or exported):
   ARCHE_SEED_TEST_EMAIL     Seed test user email (optional)
   ARCHE_SEED_TEST_SLUG      Seed test user slug (optional)
   ARCHE_USERS_PATH          Host path for persisted user data (optional)
+  WEB_IMAGE                 Web app image (set arche-web:latest to build on VPS)
   KB_CONTENT_HOST_PATH      Path to the KB content bare repo
   KB_CONFIG_HOST_PATH       Path to the KB config bare repo
 EOF
@@ -163,6 +195,8 @@ if [[ -f "$SCRIPT_DIR/.env" ]]; then
   set +a
   log ".env file loaded successfully"
 fi
+
+WEB_IMAGE="${WEB_IMAGE:-${IMAGE_PREFIX}web:${WEB_VERSION}}"
 
 # ---------------------------------------------------------------------------
 # Validation
@@ -399,6 +433,9 @@ deploy_remote() {
   # Build workspace image on remote host when using default OPENCODE_IMAGE
   prepare_remote_workspace_image
 
+  # Build web image on remote host when using local WEB_IMAGE
+  prepare_remote_web_image
+
   # Generate temporary inventory and extra-vars file
   INVENTORY=$(mktemp)
   EXTRA_VARS_FILE=$(mktemp)
@@ -410,7 +447,7 @@ ${DEPLOY_IP} ansible_user=${SSH_USER} ansible_ssh_private_key_file=${SSH_KEY}
 EOF
 
   # Export variables so python3 subprocess can read them
-  export DEPLOY_DOMAIN ACME_EMAIL IMAGE_PREFIX WEB_VERSION OPENCODE_IMAGE
+  export DEPLOY_DOMAIN ACME_EMAIL IMAGE_PREFIX WEB_VERSION WEB_IMAGE OPENCODE_IMAGE
 
   # Build extra vars as JSON (safe for secrets with special characters)
   python3 -c '
@@ -421,6 +458,7 @@ vars = {
     "deploy_mode": "remote",
     "image_prefix": os.environ["IMAGE_PREFIX"],
     "web_version": os.environ["WEB_VERSION"],
+    "web_image": os.environ["WEB_IMAGE"],
     "opencode_image": os.environ["OPENCODE_IMAGE"],
     "postgres_password": os.environ["POSTGRES_PASSWORD"],
     "arche_session_pepper": os.environ["ARCHE_SESSION_PEPPER"],


### PR DESCRIPTION
## Summary
- add a new optional WEB_IMAGE deploy variable that defaults to IMAGE_PREFIX + web:WEB_VERSION
- when WEB_IMAGE=arche-web:latest, sync apps/web sources and build the web image on the VPS before running Ansible
- update Ansible deployment to use web_image for pull/run and skip registry pull when using the local VPS-built web image
- document the new override in deploy docs and .env.example with VPS-build examples

## Why
- this mirrors the existing OPENCODE_IMAGE=arche-workspace:latest behavior
- it unblocks deployments when GHCR authentication or egress limits prevent pulling the web image