### PR TITLE
feat(providers): add OpenCode Zen provider support

### DIFF
--- a/apps/web/src/app/api/internal/providers/[provider]/[...path]/route.ts
+++ b/apps/web/src/app/api/internal/providers/[provider]/[...path]/route.ts
@@ -11,6 +11,7 @@ const PROVIDER_BASE_URL: Record<ProviderId, string> = {
   openai: 'https://api.openai.com/v1',
   anthropic: 'https://api.anthropic.com/v1',
   openrouter: 'https://openrouter.ai/api/v1',
+  opencode: 'https://opencode.ai/zen/v1',
 }
 
 const OPENAI_RESPONSES_MAX_FETCH_ATTEMPTS = 3
@@ -42,7 +43,7 @@ function isProviderId(value: string): value is ProviderId {
 }
 
 function extractGatewayToken(providerId: ProviderId, headers: Headers): string | null {
-  if (providerId === 'openai' || providerId === 'openrouter') {
+  if (providerId === 'openai' || providerId === 'openrouter' || providerId === 'opencode') {
     const header = headers.get('authorization')
     if (!header) return null
     const match = header.match(/^Bearer\s+(.+)$/i)
@@ -241,7 +242,7 @@ async function handleProxy(
   // downstream clients to attempt decoding a second time.
   headers.set('accept-encoding', 'identity')
 
-  if (provider === 'openai' || provider === 'openrouter') {
+  if (provider === 'openai' || provider === 'openrouter' || provider === 'opencode') {
     headers.set('authorization', `Bearer ${apiKey}`)
   } else {
     headers.set('x-api-key', apiKey)

--- a/apps/web/src/components/team/edit-user-dialog.tsx
+++ b/apps/web/src/components/team/edit-user-dialog.tsx
@@ -35,6 +35,8 @@ function providerLabel(providerId: ProviderId): string {
       return 'Anthropic'
     case 'openrouter':
       return 'OpenRouter'
+    case 'opencode':
+      return 'OpenCode Zen'
   }
 }
 

--- a/apps/web/src/components/workspace/workspace-footer.tsx
+++ b/apps/web/src/components/workspace/workspace-footer.tsx
@@ -138,6 +138,7 @@ export function WorkspaceFooter({
     if (providerId === "openai") return "OpenAI";
     if (providerId === "anthropic") return "Anthropic";
     if (providerId === "openrouter") return "OpenRouter";
+    if (providerId === "opencode") return "OpenCode Zen";
     return providerId;
   };
 

--- a/apps/web/src/lib/opencode/__tests__/providers.test.ts
+++ b/apps/web/src/lib/opencode/__tests__/providers.test.ts
@@ -31,7 +31,7 @@ describe('syncProviderAccessForInstance', () => {
   it('calls provider auth endpoints for each enabled provider', async () => {
     const mockFetch = vi.mocked(globalThis.fetch)
 
-    // openai enabled, anthropic enabled, openrouter not
+    // openai enabled, anthropic enabled, openrouter/opencode not
     mockGetCredential.mockImplementation(async ({ providerId }) => {
       if (providerId === 'openai') return { id: '1', version: 1 } as never
       if (providerId === 'anthropic') return { id: '2', version: 2 } as never
@@ -54,12 +54,13 @@ describe('syncProviderAccessForInstance', () => {
     expect(putCalls[0]![0]).toBe(`${fakeInstance.baseUrl}/auth/openai`)
     expect(putCalls[1]![0]).toBe(`${fakeInstance.baseUrl}/auth/anthropic`)
 
-    // Verify DELETE for disabled provider
+    // Verify DELETE for disabled providers
     const deleteCalls = mockFetch.mock.calls.filter(
       (call) => (call[1] as RequestInit)?.method === 'DELETE',
     )
-    expect(deleteCalls).toHaveLength(1)
+    expect(deleteCalls).toHaveLength(2)
     expect(deleteCalls[0]![0]).toBe(`${fakeInstance.baseUrl}/auth/openrouter`)
+    expect(deleteCalls[1]![0]).toBe(`${fakeInstance.baseUrl}/auth/opencode`)
 
     // Verify gateway tokens were issued for enabled providers
     expect(mockIssueToken).toHaveBeenCalledTimes(2)

--- a/apps/web/src/lib/providers/types.ts
+++ b/apps/web/src/lib/providers/types.ts
@@ -1,4 +1,4 @@
-export const PROVIDERS = ['openai', 'anthropic', 'openrouter'] as const
+export const PROVIDERS = ['openai', 'anthropic', 'openrouter', 'opencode'] as const
 export type ProviderId = (typeof PROVIDERS)[number]
 
 export type ProviderCredentialType = 'api'

--- a/apps/web/src/lib/spawner/docker.ts
+++ b/apps/web/src/lib/spawner/docker.ts
@@ -120,6 +120,11 @@ export async function createContainer(
           baseURL: "http://web:3000/api/internal/providers/openrouter",
         },
       },
+      opencode: {
+        options: {
+          baseURL: "http://web:3000/api/internal/providers/opencode",
+        },
+      },
     },
   };
 

--- a/apps/web/tests/opencode-providers.test.ts
+++ b/apps/web/tests/opencode-providers.test.ts
@@ -72,6 +72,7 @@ describe('syncProviderAccessForInstance', () => {
     // DELETE auth for other providers (best-effort)
     expect(urls).toContain('http://opencode-alice:4096/auth/anthropic')
     expect(urls).toContain('http://opencode-alice:4096/auth/openrouter')
+    expect(urls).toContain('http://opencode-alice:4096/auth/opencode')
     // Dispose refresh
     expect(urls).toContain('http://opencode-alice:4096/instance/dispose')
 

--- a/apps/web/tests/providers-gateway.test.ts
+++ b/apps/web/tests/providers-gateway.test.ts
@@ -410,4 +410,40 @@ describe('providers gateway', () => {
     expect(headers.get('authorization')).toBe('Bearer or-key')
     expect(headers.get('x-api-key')).toBe(null)
   })
+
+  it('proxies to OpenCode Zen with real api key', async () => {
+    mockVerifyGatewayToken.mockReturnValue({
+      userId: 'user-1',
+      workspaceSlug: 'ws',
+      providerId: 'opencode',
+      version: 1,
+      exp: Math.floor(Date.now() / 1000) + 1000,
+    })
+    mockGetActiveCredentialForUser.mockResolvedValue({
+      id: 'cred-oc',
+      type: 'api',
+      secret: 'encrypted',
+      version: 1,
+    })
+    mockDecryptProviderSecret.mockReturnValue({ apiKey: 'oc-key' })
+
+    ;(global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response('ok', { status: 200 })
+    )
+
+    await callProxy({
+      provider: 'opencode',
+      path: ['models'],
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer internal-token',
+      },
+    })
+
+    const [url, options] = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(url).toBe('https://opencode.ai/zen/v1/models?foo=bar')
+    const headers = options.headers as Headers
+    expect(headers.get('authorization')).toBe('Bearer oc-key')
+    expect(headers.get('x-api-key')).toBe(null)
+  })
 })

--- a/apps/web/tests/providers-routes.test.ts
+++ b/apps/web/tests/providers-routes.test.ts
@@ -125,6 +125,7 @@ describe('GET /api/u/[slug]/providers', () => {
       { providerId: 'openai', status: 'enabled', type: 'api', version: 2 },
       { providerId: 'anthropic', status: 'missing' },
       { providerId: 'openrouter', status: 'missing' },
+      { providerId: 'opencode', status: 'missing' },
     ])
   })
 })


### PR DESCRIPTION
## Summary
- add `opencode` to the managed provider list so Zen credentials can be stored, synced, and exposed in provider status APIs
- route OpenCode provider traffic through Arche's internal provider gateway, proxying to `https://opencode.ai/zen/v1` with bearer auth
- update workspace/team provider labels and extend provider gateway/sync route tests to cover OpenCode Zen

## Validation
- `pnpm test` (run before and after changes)
- `pnpm lint`