### PR TITLE
feat(web): support importing custom kickstart templates

### DIFF
--- a/apps/web/kickstart/templates/definition-parser.ts
+++ b/apps/web/kickstart/templates/definition-parser.ts
@@ -1,0 +1,210 @@
+import { getKickstartAgentById } from '@/kickstart/agents/catalog'
+import {
+  hasOnlyAllowedKeys,
+  isRecord,
+  parseNonEmptyString,
+  parseOrder,
+} from '@/kickstart/parse-utils'
+import type {
+  KickstartKbSkeletonEntry,
+  KickstartTemplateAgentOverride,
+  KickstartTemplateDefinition,
+} from '@/kickstart/types'
+
+export type ParsedTemplateDefinition = {
+  definition: KickstartTemplateDefinition
+  order: number
+}
+
+const TEMPLATE_DEFINITION_KEYS = new Set([
+  'id',
+  'label',
+  'description',
+  'kbSkeleton',
+  'agentsMdTemplate',
+  'recommendedAgentIds',
+  'agentOverrides',
+  'order',
+])
+
+const AGENT_OVERRIDE_KEYS = new Set(['model', 'prompt'])
+const KB_SKELETON_DIR_KEYS = new Set(['type', 'path'])
+const KB_SKELETON_FILE_KEYS = new Set(['type', 'path', 'content'])
+const CORE_AGENT_PROMPT_OVERRIDE_BLOCKLIST = new Set(['assistant', 'knowledge-curator'])
+
+function parseTemplateMarkdown(value: unknown, fieldName: string, fileName: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`Invalid ${fieldName} in kickstart template definition: ${fileName}`)
+  }
+
+  return value
+}
+
+function parseKbSkeleton(value: unknown, fileName: string): KickstartKbSkeletonEntry[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`Invalid kbSkeleton in kickstart template definition: ${fileName}`)
+  }
+
+  const entries: KickstartKbSkeletonEntry[] = []
+  const context = `kickstart template definition: ${fileName}`
+
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      throw new Error(`Invalid kbSkeleton entry in kickstart template definition: ${fileName}`)
+    }
+
+    if (entry.type === 'dir') {
+      if (!hasOnlyAllowedKeys(entry, KB_SKELETON_DIR_KEYS)) {
+        throw new Error(`Invalid kbSkeleton dir shape in kickstart template definition: ${fileName}`)
+      }
+
+      entries.push({
+        type: 'dir',
+        path: parseNonEmptyString(entry.path, 'kbSkeleton.path', context),
+      })
+      continue
+    }
+
+    if (entry.type === 'file') {
+      if (!hasOnlyAllowedKeys(entry, KB_SKELETON_FILE_KEYS)) {
+        throw new Error(`Invalid kbSkeleton file shape in kickstart template definition: ${fileName}`)
+      }
+
+      if (typeof entry.content !== 'string') {
+        throw new Error(`Invalid kbSkeleton content in kickstart template definition: ${fileName}`)
+      }
+
+      entries.push({
+        type: 'file',
+        path: parseNonEmptyString(entry.path, 'kbSkeleton.path', context),
+        content: entry.content,
+      })
+      continue
+    }
+
+    throw new Error(`Invalid kbSkeleton type in kickstart template definition: ${fileName}`)
+  }
+
+  return entries
+}
+
+function parseRecommendedAgentIds(value: unknown, fileName: string): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`Invalid recommendedAgentIds in kickstart template definition: ${fileName}`)
+  }
+
+  const recommendedAgentIds: string[] = []
+  const seenIds = new Set<string>()
+  const context = `kickstart template definition: ${fileName}`
+
+  for (const agentId of value) {
+    const parsedAgentId = parseNonEmptyString(agentId, 'recommendedAgentIds', context)
+
+    if (!getKickstartAgentById(parsedAgentId)) {
+      throw new Error(
+        `Unknown agent id in recommendedAgentIds (${parsedAgentId}) in kickstart template definition: ${fileName}`
+      )
+    }
+
+    if (seenIds.has(parsedAgentId)) {
+      continue
+    }
+
+    seenIds.add(parsedAgentId)
+    recommendedAgentIds.push(parsedAgentId)
+  }
+
+  return recommendedAgentIds
+}
+
+function parseAgentOverrides(
+  value: unknown,
+  fileName: string
+): Record<string, KickstartTemplateAgentOverride> {
+  if (!isRecord(value)) {
+    throw new Error(`Invalid agentOverrides in kickstart template definition: ${fileName}`)
+  }
+
+  const context = `kickstart template definition: ${fileName}`
+  const agentOverrides: Record<string, KickstartTemplateAgentOverride> = {}
+
+  for (const [agentId, override] of Object.entries(value)) {
+    const parsedAgentId = parseNonEmptyString(agentId, 'agentOverrides key', context)
+
+    if (!getKickstartAgentById(parsedAgentId)) {
+      throw new Error(
+        `Unknown agent id in agentOverrides (${parsedAgentId}) in kickstart template definition: ${fileName}`
+      )
+    }
+
+    if (!isRecord(override) || !hasOnlyAllowedKeys(override, AGENT_OVERRIDE_KEYS)) {
+      throw new Error(`Invalid agentOverrides entry shape in kickstart template definition: ${fileName}`)
+    }
+
+    const parsedOverride: KickstartTemplateAgentOverride = {}
+
+    if (override.model !== undefined) {
+      parsedOverride.model = parseNonEmptyString(override.model, 'agentOverrides.model', context)
+    }
+
+    if (override.prompt !== undefined) {
+      if (CORE_AGENT_PROMPT_OVERRIDE_BLOCKLIST.has(parsedAgentId)) {
+        throw new Error(
+          `Prompt overrides are not allowed for core agent ${parsedAgentId} in ${fileName}`
+        )
+      }
+
+      parsedOverride.prompt = parseTemplateMarkdown(override.prompt, 'agentOverrides.prompt', fileName)
+    }
+
+    if (!parsedOverride.model && !parsedOverride.prompt) {
+      throw new Error(`Invalid agentOverrides entry in kickstart template definition: ${fileName}`)
+    }
+
+    agentOverrides[parsedAgentId] = parsedOverride
+  }
+
+  return agentOverrides
+}
+
+export function parseKickstartTemplateDefinitionValue(
+  parsedValue: unknown,
+  fileName: string
+): ParsedTemplateDefinition {
+  if (!isRecord(parsedValue) || !hasOnlyAllowedKeys(parsedValue, TEMPLATE_DEFINITION_KEYS)) {
+    throw new Error(`Invalid object shape in kickstart template definition: ${fileName}`)
+  }
+
+  const recommendedAgentIds = parseRecommendedAgentIds(parsedValue.recommendedAgentIds, fileName)
+  const context = `kickstart template definition: ${fileName}`
+
+  const definition: KickstartTemplateDefinition = {
+    id: parseNonEmptyString(parsedValue.id, 'id', context),
+    label: parseNonEmptyString(parsedValue.label, 'label', context),
+    description: parseNonEmptyString(parsedValue.description, 'description', context),
+    kbSkeleton: parseKbSkeleton(parsedValue.kbSkeleton, fileName),
+    agentsMdTemplate: parseTemplateMarkdown(parsedValue.agentsMdTemplate, 'agentsMdTemplate', fileName),
+    recommendedAgentIds,
+    agentOverrides: parseAgentOverrides(parsedValue.agentOverrides, fileName),
+  }
+
+  return {
+    definition,
+    order: parseOrder(parsedValue.order, context),
+  }
+}
+
+export function parseKickstartTemplateDefinitionRaw(
+  raw: string,
+  fileName: string
+): ParsedTemplateDefinition {
+  let parsedValue: unknown
+
+  try {
+    parsedValue = JSON.parse(raw)
+  } catch {
+    throw new Error(`Invalid JSON in kickstart template definition: ${fileName}`)
+  }
+
+  return parseKickstartTemplateDefinitionValue(parsedValue, fileName)
+}

--- a/apps/web/kickstart/templates/index.ts
+++ b/apps/web/kickstart/templates/index.ts
@@ -1,219 +1,23 @@
 import { join } from 'node:path'
 
-import { getKickstartAgentById } from '@/kickstart/agents/catalog'
 import { loadDefinitions } from '@/kickstart/definition-loader'
-import {
-  hasOnlyAllowedKeys,
-  isRecord,
-  parseNonEmptyString,
-  parseOrder,
-} from '@/kickstart/parse-utils'
+import { parseKickstartTemplateDefinitionRaw } from '@/kickstart/templates/definition-parser'
 import type {
-  KickstartKbSkeletonEntry,
-  KickstartTemplateAgentOverride,
   KickstartTemplateDefinition,
   KickstartTemplateSummary,
 } from '@/kickstart/types'
-
-type ParsedTemplateDefinition = {
-  definition: KickstartTemplateDefinition
-  order: number
-}
-
-const TEMPLATE_DEFINITION_KEYS = new Set([
-  'id',
-  'label',
-  'description',
-  'kbSkeleton',
-  'agentsMdTemplate',
-  'recommendedAgentIds',
-  'agentOverrides',
-  'order',
-])
-
-const AGENT_OVERRIDE_KEYS = new Set(['model', 'prompt'])
-const KB_SKELETON_DIR_KEYS = new Set(['type', 'path'])
-const KB_SKELETON_FILE_KEYS = new Set(['type', 'path', 'content'])
-const CORE_AGENT_PROMPT_OVERRIDE_BLOCKLIST = new Set(['assistant', 'knowledge-curator'])
 
 const TEMPLATE_DEFINITION_DIR_CANDIDATES = [
   join(process.cwd(), 'kickstart/templates/definitions'),
   join(process.cwd(), 'apps/web/kickstart/templates/definitions'),
 ]
 
-function parseTemplateMarkdown(value: unknown, fieldName: string, fileName: string): string {
-  if (typeof value !== 'string' || !value.trim()) {
-    throw new Error(`Invalid ${fieldName} in kickstart template definition: ${fileName}`)
-  }
-
-  return value
-}
-
-function parseKbSkeleton(value: unknown, fileName: string): KickstartKbSkeletonEntry[] {
-  if (!Array.isArray(value) || value.length === 0) {
-    throw new Error(`Invalid kbSkeleton in kickstart template definition: ${fileName}`)
-  }
-
-  const entries: KickstartKbSkeletonEntry[] = []
-  const context = `kickstart template definition: ${fileName}`
-
-  for (const entry of value) {
-    if (!isRecord(entry)) {
-      throw new Error(`Invalid kbSkeleton entry in kickstart template definition: ${fileName}`)
-    }
-
-    if (entry.type === 'dir') {
-      if (!hasOnlyAllowedKeys(entry, KB_SKELETON_DIR_KEYS)) {
-        throw new Error(`Invalid kbSkeleton dir shape in kickstart template definition: ${fileName}`)
-      }
-
-      entries.push({
-        type: 'dir',
-        path: parseNonEmptyString(entry.path, 'kbSkeleton.path', context),
-      })
-      continue
-    }
-
-    if (entry.type === 'file') {
-      if (!hasOnlyAllowedKeys(entry, KB_SKELETON_FILE_KEYS)) {
-        throw new Error(`Invalid kbSkeleton file shape in kickstart template definition: ${fileName}`)
-      }
-
-      if (typeof entry.content !== 'string') {
-        throw new Error(`Invalid kbSkeleton content in kickstart template definition: ${fileName}`)
-      }
-
-      entries.push({
-        type: 'file',
-        path: parseNonEmptyString(entry.path, 'kbSkeleton.path', context),
-        content: entry.content,
-      })
-      continue
-    }
-
-    throw new Error(`Invalid kbSkeleton type in kickstart template definition: ${fileName}`)
-  }
-
-  return entries
-}
-
-function parseRecommendedAgentIds(value: unknown, fileName: string): string[] {
-  if (!Array.isArray(value) || value.length === 0) {
-    throw new Error(`Invalid recommendedAgentIds in kickstart template definition: ${fileName}`)
-  }
-
-  const recommendedAgentIds: string[] = []
-  const seenIds = new Set<string>()
-  const context = `kickstart template definition: ${fileName}`
-
-  for (const agentId of value) {
-    const parsedAgentId = parseNonEmptyString(agentId, 'recommendedAgentIds', context)
-
-    if (!getKickstartAgentById(parsedAgentId)) {
-      throw new Error(
-        `Unknown agent id in recommendedAgentIds (${parsedAgentId}) in kickstart template definition: ${fileName}`
-      )
-    }
-
-    if (seenIds.has(parsedAgentId)) {
-      continue
-    }
-
-    seenIds.add(parsedAgentId)
-    recommendedAgentIds.push(parsedAgentId)
-  }
-
-  return recommendedAgentIds
-}
-
-function parseAgentOverrides(
-  value: unknown,
-  fileName: string
-): Record<string, KickstartTemplateAgentOverride> {
-  if (!isRecord(value)) {
-    throw new Error(`Invalid agentOverrides in kickstart template definition: ${fileName}`)
-  }
-
-  const context = `kickstart template definition: ${fileName}`
-  const agentOverrides: Record<string, KickstartTemplateAgentOverride> = {}
-
-  for (const [agentId, override] of Object.entries(value)) {
-    const parsedAgentId = parseNonEmptyString(agentId, 'agentOverrides key', context)
-
-    if (!getKickstartAgentById(parsedAgentId)) {
-      throw new Error(
-        `Unknown agent id in agentOverrides (${parsedAgentId}) in kickstart template definition: ${fileName}`
-      )
-    }
-
-    if (!isRecord(override) || !hasOnlyAllowedKeys(override, AGENT_OVERRIDE_KEYS)) {
-      throw new Error(`Invalid agentOverrides entry shape in kickstart template definition: ${fileName}`)
-    }
-
-    const parsedOverride: KickstartTemplateAgentOverride = {}
-
-    if (override.model !== undefined) {
-      parsedOverride.model = parseNonEmptyString(override.model, 'agentOverrides.model', context)
-    }
-
-    if (override.prompt !== undefined) {
-      if (CORE_AGENT_PROMPT_OVERRIDE_BLOCKLIST.has(parsedAgentId)) {
-        throw new Error(
-          `Prompt overrides are not allowed for core agent ${parsedAgentId} in ${fileName}`
-        )
-      }
-
-      parsedOverride.prompt = parseTemplateMarkdown(override.prompt, 'agentOverrides.prompt', fileName)
-    }
-
-    if (!parsedOverride.model && !parsedOverride.prompt) {
-      throw new Error(`Invalid agentOverrides entry in kickstart template definition: ${fileName}`)
-    }
-
-    agentOverrides[parsedAgentId] = parsedOverride
-  }
-
-  return agentOverrides
-}
-
-function parseTemplateDefinition(raw: string, fileName: string): ParsedTemplateDefinition {
-  let parsedValue: unknown
-
-  try {
-    parsedValue = JSON.parse(raw)
-  } catch {
-    throw new Error(`Invalid JSON in kickstart template definition: ${fileName}`)
-  }
-
-  if (!isRecord(parsedValue) || !hasOnlyAllowedKeys(parsedValue, TEMPLATE_DEFINITION_KEYS)) {
-    throw new Error(`Invalid object shape in kickstart template definition: ${fileName}`)
-  }
-
-  const recommendedAgentIds = parseRecommendedAgentIds(parsedValue.recommendedAgentIds, fileName)
-  const context = `kickstart template definition: ${fileName}`
-
-  const definition: KickstartTemplateDefinition = {
-    id: parseNonEmptyString(parsedValue.id, 'id', context),
-    label: parseNonEmptyString(parsedValue.label, 'label', context),
-    description: parseNonEmptyString(parsedValue.description, 'description', context),
-    kbSkeleton: parseKbSkeleton(parsedValue.kbSkeleton, fileName),
-    agentsMdTemplate: parseTemplateMarkdown(parsedValue.agentsMdTemplate, 'agentsMdTemplate', fileName),
-    recommendedAgentIds,
-    agentOverrides: parseAgentOverrides(parsedValue.agentOverrides, fileName),
-  }
-
-  return {
-    definition,
-    order: parseOrder(parsedValue.order, context),
-  }
-}
-
 function loadKickstartTemplates(): KickstartTemplateDefinition[] {
   return loadDefinitions({
     directoryCandidates: TEMPLATE_DEFINITION_DIR_CANDIDATES,
     definitionKind: 'Kickstart template',
     idKind: 'template',
-    parse: parseTemplateDefinition,
+    parse: parseKickstartTemplateDefinitionRaw,
   })
 }
 

--- a/apps/web/kickstart/types.ts
+++ b/apps/web/kickstart/types.ts
@@ -65,12 +65,19 @@ export type KickstartAgentSelectionInput = {
   temperature?: number
 }
 
-export type KickstartApplyRequestPayload = {
-  companyName: string
-  companyDescription: string
-  templateId: string
-  agents: KickstartAgentSelectionInput[]
-}
+export type KickstartApplyRequestPayload =
+  | {
+      companyName: string
+      companyDescription: string
+      templateId: string
+      agents: KickstartAgentSelectionInput[]
+    }
+  | {
+      companyName: string
+      companyDescription: string
+      template: KickstartTemplateDefinition
+      agents: KickstartAgentSelectionInput[]
+    }
 
 export type KickstartNormalizedAgentSelection = {
   id: string

--- a/apps/web/kickstart/validation.ts
+++ b/apps/web/kickstart/validation.ts
@@ -4,16 +4,19 @@ import {
 } from '@/kickstart/agents/catalog'
 import { hasOnlyAllowedKeys, isRecord } from '@/kickstart/parse-utils'
 import { getRequiredAgentIdsForTemplate } from '@/kickstart/required-agent-ids'
+import { parseKickstartTemplateDefinitionValue } from '@/kickstart/templates/definition-parser'
 import { getKickstartTemplateById } from '@/kickstart/templates'
 import type {
   KickstartNormalizedAgentSelection,
   KickstartNormalizedApplyInput,
+  KickstartTemplateDefinition,
 } from '@/kickstart/types'
 
 const TOP_LEVEL_KEYS = new Set([
   'companyName',
   'companyDescription',
   'templateId',
+  'template',
   'agents',
 ])
 
@@ -191,6 +194,56 @@ function parseAgents(
   return { ok: true, value: selections }
 }
 
+function parseTemplate(payload: Record<string, unknown>): ValidationResult<KickstartTemplateDefinition> {
+  const hasTemplateId = payload.templateId !== undefined
+  const hasTemplate = payload.template !== undefined
+
+  if (!hasTemplateId && !hasTemplate) {
+    return {
+      ok: false,
+      message: 'either templateId or template is required',
+    }
+  }
+
+  if (hasTemplateId && hasTemplate) {
+    return {
+      ok: false,
+      message: 'templateId and template cannot be provided together',
+    }
+  }
+
+  if (hasTemplateId) {
+    const parsedTemplateId = parseRequiredString(payload.templateId, 'templateId', 80)
+    if (!parsedTemplateId.ok) {
+      return parsedTemplateId
+    }
+
+    const template = getKickstartTemplateById(parsedTemplateId.value)
+    if (!template) {
+      return {
+        ok: false,
+        message: `unknown template id: ${parsedTemplateId.value}`,
+      }
+    }
+
+    return { ok: true, value: template }
+  }
+
+  try {
+    const parsedTemplate = parseKickstartTemplateDefinitionValue(
+      payload.template,
+      'kickstart apply payload template'
+    )
+
+    return { ok: true, value: parsedTemplate.definition }
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : 'invalid template object',
+    }
+  }
+}
+
 export function parseKickstartApplyPayload(
   payload: unknown
 ): KickstartPayloadValidationResult {
@@ -228,21 +281,12 @@ export function parseKickstartApplyPayload(
     }
   }
 
-  const parsedTemplateId = parseRequiredString(payload.templateId, 'templateId', 80)
-  if (!parsedTemplateId.ok) {
-    return { ok: false, error: 'invalid_payload', message: parsedTemplateId.message }
+  const parsedTemplate = parseTemplate(payload)
+  if (!parsedTemplate.ok) {
+    return { ok: false, error: 'invalid_payload', message: parsedTemplate.message }
   }
 
-  const template = getKickstartTemplateById(parsedTemplateId.value)
-  if (!template) {
-    return {
-      ok: false,
-      error: 'invalid_payload',
-      message: `unknown template id: ${parsedTemplateId.value}`,
-    }
-  }
-
-  const parsedAgents = parseAgents(payload.agents, template.id)
+  const parsedAgents = parseAgents(payload.agents, parsedTemplate.value.id)
   if (!parsedAgents.ok) {
     return { ok: false, error: 'invalid_payload', message: parsedAgents.message }
   }
@@ -254,7 +298,7 @@ export function parseKickstartApplyPayload(
         companyName: parsedCompanyName.value,
         companyDescription: parsedCompanyDescription.value,
       },
-      template,
+      template: parsedTemplate.value,
       agents: parsedAgents.value,
     },
   }

--- a/apps/web/src/components/kickstart/kickstart-wizard.tsx
+++ b/apps/web/src/components/kickstart/kickstart-wizard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { type ChangeEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import {
   CheckCircle,
@@ -13,7 +13,10 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { getRequiredAgentIdsForTemplate } from '@/kickstart/required-agent-ids'
 import type {
+  KickstartApplyRequestPayload,
   KickstartStatus,
+  KickstartTemplateDefinition,
+  KickstartTemplateSummary,
   KickstartTemplatesResponse,
 } from '@/kickstart/types'
 import { cn } from '@/lib/utils'
@@ -34,6 +37,10 @@ type ModelOption = {
   label: string
 }
 
+type ImportTemplateResult =
+  | { ok: true; template: KickstartTemplateDefinition }
+  | { ok: false; error: string }
+
 const STEPS = [
   'Company details',
   'Template selection',
@@ -41,8 +48,186 @@ const STEPS = [
   'Review and apply',
 ]
 
+const IMPORT_TEMPLATE_ID = '__imported-template__'
+const CORE_AGENT_PROMPT_OVERRIDE_BLOCKLIST = new Set(['assistant', 'knowledge-curator'])
+
 function unique(values: string[]): string[] {
   return Array.from(new Set(values))
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function parseImportedTemplate(
+  value: unknown,
+  knownAgentIds: ReadonlySet<string>
+): ImportTemplateResult {
+  if (!isRecord(value)) {
+    return { ok: false, error: 'Template JSON must be an object.' }
+  }
+
+  const allowedKeys = new Set([
+    'id',
+    'label',
+    'description',
+    'kbSkeleton',
+    'agentsMdTemplate',
+    'recommendedAgentIds',
+    'agentOverrides',
+    'order',
+  ])
+
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      return { ok: false, error: `Unsupported template field: ${key}` }
+    }
+  }
+
+  const requiredStringFieldEntries: Array<[string, unknown]> = [
+    ['id', value.id],
+    ['label', value.label],
+    ['description', value.description],
+    ['agentsMdTemplate', value.agentsMdTemplate],
+  ]
+
+  for (const [field, fieldValue] of requiredStringFieldEntries) {
+    if (typeof fieldValue !== 'string' || fieldValue.trim().length === 0) {
+      return { ok: false, error: `${field} must be a non-empty string.` }
+    }
+  }
+
+  if (!Array.isArray(value.kbSkeleton) || value.kbSkeleton.length === 0) {
+    return { ok: false, error: 'kbSkeleton must be a non-empty array.' }
+  }
+
+  for (const entry of value.kbSkeleton) {
+    if (!isRecord(entry)) {
+      return { ok: false, error: 'kbSkeleton entries must be objects.' }
+    }
+
+    if (entry.type !== 'dir' && entry.type !== 'file') {
+      return { ok: false, error: 'kbSkeleton entry type must be "dir" or "file".' }
+    }
+
+    if (typeof entry.path !== 'string' || entry.path.trim().length === 0) {
+      return { ok: false, error: 'kbSkeleton entry path must be a non-empty string.' }
+    }
+
+    if (entry.type === 'file' && typeof entry.content !== 'string') {
+      return { ok: false, error: 'kbSkeleton file entry content must be a string.' }
+    }
+  }
+
+  if (!Array.isArray(value.recommendedAgentIds) || value.recommendedAgentIds.length === 0) {
+    return { ok: false, error: 'recommendedAgentIds must be a non-empty array.' }
+  }
+
+  const recommendedAgentIds: string[] = []
+  const seenRecommended = new Set<string>()
+  for (const agentIdValue of value.recommendedAgentIds) {
+    if (typeof agentIdValue !== 'string' || agentIdValue.trim().length === 0) {
+      return { ok: false, error: 'Each recommendedAgentId must be a non-empty string.' }
+    }
+
+    const agentId = agentIdValue.trim()
+    if (!knownAgentIds.has(agentId)) {
+      return { ok: false, error: `Unknown agent id in recommendedAgentIds: ${agentId}` }
+    }
+
+    if (!seenRecommended.has(agentId)) {
+      seenRecommended.add(agentId)
+      recommendedAgentIds.push(agentId)
+    }
+  }
+
+  if (!isRecord(value.agentOverrides)) {
+    return { ok: false, error: 'agentOverrides must be an object.' }
+  }
+
+  const agentOverrides: Record<string, { model?: string; prompt?: string }> = {}
+  for (const [agentId, overrideValue] of Object.entries(value.agentOverrides)) {
+    if (!knownAgentIds.has(agentId)) {
+      return { ok: false, error: `Unknown agent id in agentOverrides: ${agentId}` }
+    }
+
+    if (!isRecord(overrideValue)) {
+      return { ok: false, error: `agentOverrides.${agentId} must be an object.` }
+    }
+
+    const overrideKeys = Object.keys(overrideValue)
+    if (overrideKeys.some((key) => key !== 'model' && key !== 'prompt')) {
+      return {
+        ok: false,
+        error: `agentOverrides.${agentId} supports only "model" and "prompt".`,
+      }
+    }
+
+    const model = overrideValue.model
+    const prompt = overrideValue.prompt
+
+    if (model !== undefined && (typeof model !== 'string' || model.trim().length === 0)) {
+      return { ok: false, error: `agentOverrides.${agentId}.model must be a non-empty string.` }
+    }
+
+    if (prompt !== undefined && (typeof prompt !== 'string' || prompt.trim().length === 0)) {
+      return { ok: false, error: `agentOverrides.${agentId}.prompt must be a non-empty string.` }
+    }
+
+    if (prompt !== undefined && CORE_AGENT_PROMPT_OVERRIDE_BLOCKLIST.has(agentId)) {
+      return {
+        ok: false,
+        error: `Prompt overrides are not allowed for core agent: ${agentId}`,
+      }
+    }
+
+    if (model === undefined && prompt === undefined) {
+      return {
+        ok: false,
+        error: `agentOverrides.${agentId} must define at least one field.`,
+      }
+    }
+
+    agentOverrides[agentId] = {
+      ...(model !== undefined ? { model: model.trim() } : {}),
+      ...(prompt !== undefined ? { prompt } : {}),
+    }
+  }
+
+  const kbSkeleton = value.kbSkeleton.flatMap((entry) => {
+    if (!isRecord(entry)) {
+      return []
+    }
+
+    if (entry.type === 'dir') {
+      return [
+        {
+          type: 'dir' as const,
+          path: String(entry.path).trim(),
+        },
+      ]
+    }
+
+    return [
+      {
+        type: 'file' as const,
+        path: String(entry.path).trim(),
+        content: String(entry.content),
+      },
+    ]
+  })
+
+  const template: KickstartTemplateDefinition = {
+    id: value.id.trim(),
+    label: value.label.trim(),
+    description: value.description.trim(),
+    kbSkeleton,
+    agentsMdTemplate: value.agentsMdTemplate,
+    recommendedAgentIds,
+    agentOverrides,
+  }
+
+  return { ok: true, template }
 }
 
 export function KickstartWizard({ slug, initialStatus }: KickstartWizardProps) {
@@ -59,8 +244,11 @@ export function KickstartWizard({ slug, initialStatus }: KickstartWizardProps) {
   const [companyName, setCompanyName] = useState('')
   const [companyDescription, setCompanyDescription] = useState('')
   const [selectedTemplateId, setSelectedTemplateId] = useState('')
+  const [importedTemplate, setImportedTemplate] = useState<KickstartTemplateDefinition | null>(null)
+  const [importError, setImportError] = useState<string | null>(null)
   const [selectedAgentIds, setSelectedAgentIds] = useState<string[]>([])
   const [agentOverrides, setAgentOverrides] = useState<Record<string, AgentOverride>>({})
+  const importInputRef = useRef<HTMLInputElement | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -137,9 +325,23 @@ export function KickstartWizard({ slug, initialStatus }: KickstartWizardProps) {
   }, [slug])
 
   const selectedTemplate = useMemo(() => {
+    if (selectedTemplateId === IMPORT_TEMPLATE_ID) {
+      if (!importedTemplate) return null
+
+      const importedTemplateSummary: KickstartTemplateSummary = {
+        id: importedTemplate.id,
+        label: importedTemplate.label,
+        description: importedTemplate.description,
+        recommendedAgentIds: importedTemplate.recommendedAgentIds,
+        agentOverrides: importedTemplate.agentOverrides,
+      }
+
+      return importedTemplateSummary
+    }
+
     if (!catalog) return null
     return catalog.templates.find((template) => template.id === selectedTemplateId) ?? null
-  }, [catalog, selectedTemplateId])
+  }, [catalog, importedTemplate, selectedTemplateId])
 
   const agentById = useMemo(() => {
     return new Map((catalog?.agents ?? []).map((agent) => [agent.id, agent]))
@@ -232,6 +434,55 @@ export function KickstartWizard({ slug, initialStatus }: KickstartWizardProps) {
       ])
     )
     setApplyError(null)
+    setImportError(null)
+  }
+
+  function handleImportButtonClick() {
+    importInputRef.current?.click()
+  }
+
+  async function handleImportTemplate(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+
+    if (!file || !catalog) {
+      return
+    }
+
+    const knownAgentIds = new Set((catalog.agents ?? []).map((agent) => agent.id))
+
+    let rawContent = ''
+    try {
+      rawContent = await file.text()
+    } catch {
+      setImportError('Failed to read selected template file.')
+      return
+    }
+
+    let parsedJson: unknown
+    try {
+      parsedJson = JSON.parse(rawContent)
+    } catch {
+      setImportError('Invalid JSON file.')
+      return
+    }
+
+    const parsedTemplate = parseImportedTemplate(parsedJson, knownAgentIds)
+    if (!parsedTemplate.ok) {
+      setImportError(parsedTemplate.error)
+      return
+    }
+
+    setImportedTemplate(parsedTemplate.template)
+    setSelectedTemplateId(IMPORT_TEMPLATE_ID)
+    setSelectedAgentIds(
+      unique([
+        ...getRequiredAgentIdsForTemplate(parsedTemplate.template.id),
+        ...parsedTemplate.template.recommendedAgentIds,
+      ])
+    )
+    setApplyError(null)
+    setImportError(null)
   }
 
   function toggleAgent(agentId: string) {
@@ -261,25 +512,29 @@ export function KickstartWizard({ slug, initialStatus }: KickstartWizardProps) {
     setIsApplying(true)
 
     try {
+      const payload: KickstartApplyRequestPayload = {
+        companyName: companyName.trim(),
+        companyDescription: companyDescription.trim(),
+        agents: selectedAgentIds.map((agentId) => {
+          const resolved = resolveAgentValue(agentId)
+          return {
+            id: agentId,
+            model: resolved.model,
+            prompt: resolved.prompt,
+            temperature: resolved.temperature,
+          }
+        }),
+        ...(selectedTemplateId === IMPORT_TEMPLATE_ID && importedTemplate
+          ? { template: importedTemplate }
+          : { templateId: selectedTemplate.id }),
+      }
+
       const response = await fetch(`/api/u/${slug}/kickstart/apply`, {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
         },
-        body: JSON.stringify({
-          companyName: companyName.trim(),
-          companyDescription: companyDescription.trim(),
-          templateId: selectedTemplate.id,
-          agents: selectedAgentIds.map((agentId) => {
-            const resolved = resolveAgentValue(agentId)
-            return {
-              id: agentId,
-              model: resolved.model,
-              prompt: resolved.prompt,
-              temperature: resolved.temperature,
-            }
-          }),
-        }),
+        body: JSON.stringify(payload),
       })
 
       const data = (await response.json().catch(() => null)) as {
@@ -425,7 +680,48 @@ export function KickstartWizard({ slug, initialStatus }: KickstartWizardProps) {
                   </button>
                 )
               })}
+
+              <button
+                type="button"
+                onClick={handleImportButtonClick}
+                className={cn(
+                  'rounded-2xl border p-4 text-left transition-colors',
+                  selectedTemplateId === IMPORT_TEMPLATE_ID
+                    ? 'border-primary/55 bg-primary/10'
+                    : 'border-border/60 bg-background/40 hover:border-border'
+                )}
+              >
+                <p className="font-medium text-foreground">Import</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Upload a custom template JSON from your computer.
+                </p>
+                <p className="mt-3 text-xs text-muted-foreground">
+                  {importedTemplate
+                    ? `Loaded: ${importedTemplate.label}`
+                    : 'Template file must follow kickstart template definition schema.'}
+                </p>
+              </button>
             </div>
+
+            <input
+              ref={importInputRef}
+              type="file"
+              accept="application/json,.json"
+              className="hidden"
+              onChange={handleImportTemplate}
+            />
+
+            {importError && (
+              <div className="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                {importError}
+              </div>
+            )}
+
+            {selectedTemplateId === IMPORT_TEMPLATE_ID && importedTemplate && (
+              <div className="rounded-xl border border-border/60 bg-background/40 px-4 py-3 text-sm text-muted-foreground">
+                Imported template ID: <span className="font-medium text-foreground">{importedTemplate.id}</span>
+              </div>
+            )}
           </div>
         )}
 

--- a/apps/web/tests/kickstart-manifest.test.ts
+++ b/apps/web/tests/kickstart-manifest.test.ts
@@ -137,4 +137,48 @@ describe('kickstart artifact generation', () => {
     expect(output).toContain('Known Acme Labs')
     expect(output).toContain('{{ malicious }}')
   })
+
+  it('builds artifacts when payload uses an imported custom template', () => {
+    const parsed = parseKickstartApplyPayload({
+      companyName: 'Acme Labs',
+      companyDescription: 'Analytics tools for operations teams',
+      template: {
+        id: 'custom-template',
+        label: 'Custom Template',
+        description: 'Imported template',
+        kbSkeleton: [
+          { type: 'dir', path: 'Company' },
+          {
+            type: 'file',
+            path: 'Company/00 - Company Profile.md',
+            content: '# {{ companyName }}',
+          },
+        ],
+        agentsMdTemplate: '# Agents for {{ companyName }}',
+        recommendedAgentIds: ['assistant'],
+        agentOverrides: {
+          assistant: {
+            model: 'openai/gpt-5',
+          },
+        },
+      },
+      agents: [{ id: 'assistant' }],
+    })
+
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) {
+      return
+    }
+
+    const built = buildKickstartArtifacts(parsed.input)
+    expect(built.ok).toBe(true)
+    if (!built.ok) {
+      return
+    }
+
+    const profileFile = built.artifacts.kbFiles.find(
+      (file) => file.path === 'Company/00 - Company Profile.md'
+    )
+    expect(profileFile?.content).toContain('Acme Labs')
+  })
 })

--- a/apps/web/tests/kickstart-validation.test.ts
+++ b/apps/web/tests/kickstart-validation.test.ts
@@ -14,6 +14,32 @@ function buildValidPayload() {
   }
 }
 
+function buildValidCustomTemplate() {
+  return {
+    id: 'custom-template',
+    label: 'Custom Template',
+    description: 'Uploaded by user',
+    kbSkeleton: [
+      {
+        type: 'dir',
+        path: 'Company',
+      },
+      {
+        type: 'file',
+        path: 'Company/00 - Company Profile.md',
+        content: '# {{ companyName }}',
+      },
+    ],
+    agentsMdTemplate: '# Agents',
+    recommendedAgentIds: ['assistant'],
+    agentOverrides: {
+      assistant: {
+        model: 'openai/gpt-5',
+      },
+    },
+  }
+}
+
 describe('kickstart payload validation', () => {
   it.each([
     {
@@ -84,6 +110,46 @@ describe('kickstart payload validation', () => {
     expect(parsed.ok).toBe(valid)
     if (!valid && !parsed.ok) {
       expect(parsed.message).toContain(message)
+    }
+  })
+
+  it('accepts custom template object instead of templateId', () => {
+    const parsed = parseKickstartApplyPayload({
+      companyName: 'Acme Labs',
+      companyDescription: 'Analytics tools for operations teams',
+      template: buildValidCustomTemplate(),
+      agents: [{ id: 'assistant' }],
+    })
+
+    expect(parsed.ok).toBe(true)
+  })
+
+  it('rejects payload when templateId and template are both provided', () => {
+    const parsed = parseKickstartApplyPayload({
+      ...buildValidPayload(),
+      template: buildValidCustomTemplate(),
+    })
+
+    expect(parsed.ok).toBe(false)
+    if (!parsed.ok) {
+      expect(parsed.message).toContain('cannot be provided together')
+    }
+  })
+
+  it('rejects custom template object with unknown recommended agent', () => {
+    const parsed = parseKickstartApplyPayload({
+      companyName: 'Acme Labs',
+      companyDescription: 'Analytics tools for operations teams',
+      template: {
+        ...buildValidCustomTemplate(),
+        recommendedAgentIds: ['unknown-agent'],
+      },
+      agents: [{ id: 'assistant' }],
+    })
+
+    expect(parsed.ok).toBe(false)
+    if (!parsed.ok) {
+      expect(parsed.message).toContain('Unknown agent id in recommendedAgentIds')
     }
   })
 })


### PR DESCRIPTION
## Summary
- add an `Import` option to Kickstart template selection so admins can upload a local JSON template and use it as the selected baseline
- support custom template apply payloads by accepting either `templateId` (catalog template) or `template` (imported definition), with strict server-side validation using the same parser used for repository templates
- add tests for custom-template payload validation and artifact generation, and keep existing catalog-template behavior unchanged

## Verification
- pnpm test (apps/web)
- pnpm lint (apps/web)