### PR TITLE
fix(web): accept imported templates in kickstart readiness

### DIFF
--- a/apps/web/kickstart/repositories.ts
+++ b/apps/web/kickstart/repositories.ts
@@ -444,6 +444,25 @@ export async function contentRepoPathsExist(
   return bareRepoPathsExist(root, requiredPaths)
 }
 
+export async function contentRepoHasTrackedFiles(): Promise<boolean> {
+  const root = await resolveKickstartContentRepoRoot()
+  if (!root) return false
+
+  if (!(await hasBareRepoLayout(root))) {
+    return false
+  }
+
+  const tree = await runGit(['--git-dir', root, 'ls-tree', '-r', '--name-only', 'HEAD'])
+  if (!tree.ok) {
+    return false
+  }
+
+  return tree.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .some((line) => line.length > 0)
+}
+
 export async function contentRepoPathExists(
   repoPath: string,
   expectedType: 'file' | 'dir'

--- a/apps/web/kickstart/status.ts
+++ b/apps/web/kickstart/status.ts
@@ -7,14 +7,8 @@ import {
   validateCommonWorkspaceConfig,
 } from '@/lib/workspace-config'
 import { isKickstartApplyLocked } from '@/kickstart/lock'
-import { contentRepoPathsExist } from '@/kickstart/repositories'
+import { contentRepoHasTrackedFiles } from '@/kickstart/repositories'
 import type { KickstartStatus } from '@/kickstart/types'
-
-const REQUIRED_KB_PATHS: Array<{ path: string; type: 'file' | 'dir' }> = [
-  { path: 'Outputs', type: 'dir' },
-  { path: 'Company/00 - Company Profile.md', type: 'file' },
-  { path: 'Company/01 - Glossary.md', type: 'file' },
-]
 
 type GetKickstartStatusOptions = {
   ignoreLock?: boolean
@@ -37,7 +31,7 @@ async function isConfigReady(): Promise<boolean> {
 }
 
 async function isKbReady(): Promise<boolean> {
-  return contentRepoPathsExist(REQUIRED_KB_PATHS)
+  return contentRepoHasTrackedFiles()
 }
 
 export async function getKickstartStatus(

--- a/apps/web/tests/kickstart-status.test.ts
+++ b/apps/web/tests/kickstart-status.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockReadCommonWorkspaceConfig = vi.fn()
+const mockReadConfigRepoFile = vi.fn()
+vi.mock('@/lib/common-workspace-config-store', () => ({
+  readCommonWorkspaceConfig: (...args: unknown[]) => mockReadCommonWorkspaceConfig(...args),
+  readConfigRepoFile: (...args: unknown[]) => mockReadConfigRepoFile(...args),
+}))
+
+const mockParseCommonWorkspaceConfig = vi.fn()
+const mockValidateCommonWorkspaceConfig = vi.fn()
+vi.mock('@/lib/workspace-config', () => ({
+  parseCommonWorkspaceConfig: (...args: unknown[]) => mockParseCommonWorkspaceConfig(...args),
+  validateCommonWorkspaceConfig: (...args: unknown[]) => mockValidateCommonWorkspaceConfig(...args),
+}))
+
+const mockIsKickstartApplyLocked = vi.fn()
+vi.mock('@/kickstart/lock', () => ({
+  isKickstartApplyLocked: (...args: unknown[]) => mockIsKickstartApplyLocked(...args),
+}))
+
+const mockContentRepoHasTrackedFiles = vi.fn()
+vi.mock('@/kickstart/repositories', () => ({
+  contentRepoHasTrackedFiles: (...args: unknown[]) => mockContentRepoHasTrackedFiles(...args),
+}))
+
+describe('getKickstartStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockIsKickstartApplyLocked.mockResolvedValue(false)
+    mockReadCommonWorkspaceConfig.mockResolvedValue({ ok: true, content: '{"agent":{}}' })
+    mockParseCommonWorkspaceConfig.mockReturnValue({ ok: true, config: { agent: {} } })
+    mockValidateCommonWorkspaceConfig.mockReturnValue({ ok: true })
+    mockReadConfigRepoFile.mockResolvedValue({ ok: true, content: '# AGENTS' })
+    mockContentRepoHasTrackedFiles.mockResolvedValue(true)
+  })
+
+  it('returns setup_in_progress when setup lock is active', async () => {
+    mockIsKickstartApplyLocked.mockResolvedValue(true)
+
+    const { getKickstartStatus } = await import('@/kickstart/status')
+    const status = await getKickstartStatus()
+
+    expect(status).toBe('setup_in_progress')
+    expect(mockReadCommonWorkspaceConfig).not.toHaveBeenCalled()
+    expect(mockContentRepoHasTrackedFiles).not.toHaveBeenCalled()
+  })
+
+  it('returns ready when config is valid and KB has tracked files', async () => {
+    const { getKickstartStatus } = await import('@/kickstart/status')
+    const status = await getKickstartStatus()
+
+    expect(status).toBe('ready')
+  })
+
+  it('returns needs_setup when KB has no tracked files', async () => {
+    mockContentRepoHasTrackedFiles.mockResolvedValue(false)
+
+    const { getKickstartStatus } = await import('@/kickstart/status')
+    const status = await getKickstartStatus()
+
+    expect(status).toBe('needs_setup')
+  })
+
+  it('bypasses lock check when ignoreLock is true', async () => {
+    mockIsKickstartApplyLocked.mockResolvedValue(true)
+
+    const { getKickstartStatus } = await import('@/kickstart/status')
+    const status = await getKickstartStatus({ ignoreLock: true })
+
+    expect(status).toBe('ready')
+    expect(mockIsKickstartApplyLocked).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- fix kickstart readiness checks so imported templates are considered configured even when they do not include blank-template canonical KB file names
- replace static required-path validation with a generic `contentRepoHasTrackedFiles` check for the KB bare repo
- add unit tests for `getKickstartStatus` lock handling, ready/needs_setup transitions, and `ignoreLock` behavior

## Validation
- `pnpm test`
- `pnpm lint`