### PR TITLE
chore(ci): enforce image retention policy

### DIFF
--- a/.github/workflows/build-push-workspace.yml
+++ b/.github/workflows/build-push-workspace.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
     tags:
       - "v*.*.*"
-    paths:
-      - "infra/workspace-image/**"
-      - ".github/workflows/build-push-workspace.yml"
   repository_dispatch:
     types: [build-pr-image]
   workflow_dispatch:
@@ -53,7 +50,7 @@ jobs:
           elif [[ "${GITHUB_REF_TYPE}" == "tag" ]] && [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "RELEASE_TAG=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
             echo "MODE=release" >> "$GITHUB_OUTPUT"
-            echo "Building release workspace image with tags: ${GITHUB_REF_NAME}, ${SHA_TAG}"
+            echo "Building release workspace image with tag: ${GITHUB_REF_NAME}"
           else
             echo "MODE=main" >> "$GITHUB_OUTPUT"
             echo "Building main workspace image with tags: latest, ${SHA_TAG}"
@@ -68,7 +65,6 @@ jobs:
           elif [[ "${{ steps.tags.outputs.MODE }}" == "release" ]]; then
             podman build \
               -t $REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.RELEASE_TAG }} \
-              -t $REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.SHA_TAG }} \
               -f infra/workspace-image/Containerfile infra/workspace-image
           else
             podman build \
@@ -84,7 +80,6 @@ jobs:
             echo "Pushed PR workspace image: $REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.PR_TAG }}"
           elif [[ "${{ steps.tags.outputs.MODE }}" == "release" ]]; then
             podman push $REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.RELEASE_TAG }}
-            podman push $REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.SHA_TAG }}
           else
             podman push $REGISTRY/$IMAGE_NAME:latest
             podman push $REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.SHA_TAG }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
     tags:
       - "v*.*.*"
-    paths:
-      - "apps/web/**"
-      - ".github/workflows/build-push.yml"
   repository_dispatch:
     types: [build-pr-image]
   workflow_dispatch:
@@ -53,7 +50,7 @@ jobs:
           elif [[ "${GITHUB_REF_TYPE}" == "tag" ]] && [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "RELEASE_TAG=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
             echo "MODE=release" >> "$GITHUB_OUTPUT"
-            echo "Building release image with tags: ${GITHUB_REF_NAME}, ${SHA_TAG}"
+            echo "Building release image with tag: ${GITHUB_REF_NAME}"
           else
             echo "MODE=main" >> "$GITHUB_OUTPUT"
             echo "Building main branch image with tags: latest, ${SHA_TAG}"
@@ -68,7 +65,6 @@ jobs:
           elif [[ "${{ steps.tags.outputs.MODE }}" == "release" ]]; then
             podman build --build-arg GIT_SHA="${{ steps.tags.outputs.SHA_TAG }}" \
               -t $REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.RELEASE_TAG }} \
-              -t $REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.SHA_TAG }} \
               -f apps/web/Containerfile apps/web
           else
             podman build --build-arg GIT_SHA="${{ steps.tags.outputs.SHA_TAG }}" \
@@ -84,7 +80,6 @@ jobs:
             echo "Pushed PR image: $REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.PR_TAG }}"
           elif [[ "${{ steps.tags.outputs.MODE }}" == "release" ]]; then
             podman push $REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.RELEASE_TAG }}
-            podman push $REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.SHA_TAG }}
           else
             podman push $REGISTRY/$IMAGE_NAME:latest
             podman push $REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.SHA_TAG }}

--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -6,79 +6,172 @@ on:
       - Build & Push Web Image
       - Build & Push Workspace Image
     types: [completed]
-  workflow_dispatch:
-    inputs:
-      keep_pr_versions:
-        description: "Newest PR-tagged versions to keep per package"
-        required: false
-        default: "30"
-        type: string
+  schedule:
+    - cron: "17 * * * *"
+
+concurrency:
+  group: ghcr-retention
+  cancel-in-progress: false
 
 jobs:
-  prune-pr-images:
+  reconcile-images:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+      pull-requests: read
 
     steps:
-      - name: Prune old PR-tagged package versions
+      - name: Reconcile GHCR package versions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
-          KEEP_PR_VERSIONS: ${{ github.event.inputs.keep_pr_versions || '30' }}
         run: |
           set -euo pipefail
 
-          if ! [[ "${KEEP_PR_VERSIONS}" =~ ^[0-9]+$ ]]; then
-            echo "Invalid KEEP_PR_VERSIONS='${KEEP_PR_VERSIONS}', expected integer" >&2
-            exit 1
-          fi
+          tmp_dir="$(mktemp -d)"
+          trap 'rm -rf "$tmp_dir"' EXIT
 
-          prune_package() {
+          open_prs_file="$tmp_dir/open_prs.txt"
+          gh pr list \
+            --repo "${OWNER}/${REPO}" \
+            --state open \
+            --limit 1000 \
+            --json number \
+            --jq '.[].number' | sort -n > "$open_prs_file"
+
+          open_pr_count="$(wc -l < "$open_prs_file" | tr -d ' ')"
+          echo "Open PRs: ${open_pr_count}"
+
+          reconcile_package() {
             local package_name="$1"
             local encoded_package="${package_name//\//%2F}"
-            local tmp_file
-            tmp_file="$(mktemp)"
+            local safe_name="${package_name//\//_}"
+            local raw_versions="$tmp_dir/${safe_name}.jsonl"
+            local versions_json="$tmp_dir/${safe_name}.json"
+            local keep_ids_file="$tmp_dir/${safe_name}.keep"
+            local delete_ids_file="$tmp_dir/${safe_name}.delete"
+            local open_prs_json
 
-            echo "Checking ${package_name}"
+            echo "::group::Reconcile ${package_name}"
+
             if ! gh api --paginate \
               "/orgs/${OWNER}/packages/container/${encoded_package}/versions?per_page=100" \
-              --jq '.[] | {id, updated_at, tags: (.metadata.container.tags // [])}' > "${tmp_file}"; then
-              echo "Package not found or not accessible: ${package_name}"
-              rm -f "${tmp_file}"
-              return
+              --jq '.[] | {id, updated_at, tags: (.metadata.container.tags // [])}' > "$raw_versions"; then
+              echo "Package not found or inaccessible: ${package_name}"
+              echo "::endgroup::"
+              return 0
             fi
 
-            local delete_ids
-            delete_ids="$(
-              jq -s -r --argjson keep "${KEEP_PR_VERSIONS}" '
-                [ .[]
-                  | select((.tags | map(test("^pr-")) | any))
-                  | {id, updated_at}
-                ]
-                | sort_by(.updated_at)
-                | reverse
-                | .[$keep:]
-                | .[].id
-              ' "${tmp_file}"
-            )"
-
-            rm -f "${tmp_file}"
-
-            if [[ -z "${delete_ids}" ]]; then
-              echo "No old PR-tagged versions to delete for ${package_name}"
-              return
+            if [[ ! -s "$raw_versions" ]]; then
+              echo "No package versions found for ${package_name}"
+              echo "::endgroup::"
+              return 0
             fi
+
+            jq -s '.' "$raw_versions" > "$versions_json"
+            : > "$keep_ids_file"
+
+            open_prs_json="$(jq -Rs 'split("\n") | map(select(length > 0) | tonumber)' "$open_prs_file")"
+
+            # Keep all release-tagged versions forever.
+            jq -r '
+              .[]
+              | select(any(.tags[]?; test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")))
+              | .id
+            ' "$versions_json" >> "$keep_ids_file"
+
+            # Keep the current main image (the one tagged latest, usually also tagged with current sha).
+            jq -r '
+              [ .[] | select(any(.tags[]?; . == "latest")) ]
+              | sort_by(.updated_at)
+              | reverse
+              | .[:1]
+              | .[].id
+            ' "$versions_json" >> "$keep_ids_file"
+
+            # Keep exactly one previous main image: newest sha-only version that is not latest/release/pr.
+            jq -r '
+              def is_sha: test("^[0-9a-f]{7,40}$");
+              def is_release: test("^v[0-9]+\\.[0-9]+\\.[0-9]+$");
+              def is_pr: test("^pr-[0-9]+$");
+
+              [ .[]
+                | select(
+                    (.tags | length) > 0
+                    and (any(.tags[]?; . == "latest") | not)
+                    and (any(.tags[]?; is_release) | not)
+                    and (any(.tags[]?; is_pr) | not)
+                    and (all(.tags[]?; is_sha))
+                  )
+              ]
+              | sort_by(.updated_at)
+              | reverse
+              | .[:1]
+              | .[].id
+            ' "$versions_json" >> "$keep_ids_file"
+
+            # Keep only one PR image per OPEN PR: the newest version carrying pr-<number>.
+            jq -r --argjson open_prs "$open_prs_json" '
+              def pr_num: capture("^pr-(?<n>[0-9]+)$").n | tonumber;
+
+              [ .[]
+                | .pr_tags = [ .tags[]? | select(test("^pr-[0-9]+$")) ]
+                | select((.pr_tags | length) > 0)
+                | .open_pr_numbers = [ .pr_tags[] | pr_num | select($open_prs | index(.) != null) ]
+                | select((.open_pr_numbers | length) > 0)
+              ] as $pr_versions
+              |
+              [ $pr_versions[] as $v
+                | $v.open_pr_numbers[]
+                | { pr: ., id: $v.id, updated_at: $v.updated_at }
+              ]
+              | sort_by(.pr, .updated_at)
+              | group_by(.pr)
+              | map(sort_by(.updated_at) | reverse | .[0].id)
+              | .[]
+            ' "$versions_json" >> "$keep_ids_file"
+
+            sort -u "$keep_ids_file" -o "$keep_ids_file"
+
+            echo "Kept versions for ${package_name}:"
+            jq -r --rawfile keep_ids_raw "$keep_ids_file" '
+              ($keep_ids_raw | split("\n") | map(select(length > 0) | tonumber)) as $keep_ids
+              | .[]
+              | select($keep_ids | index(.id))
+              | "KEEP   id=\(.id) updated_at=\(.updated_at) tags=\((.tags | if length == 0 then \"<untagged>\" else join(\",\") end))"
+            ' "$versions_json" || true
+
+            jq -r --rawfile keep_ids_raw "$keep_ids_file" '
+              ($keep_ids_raw | split("\n") | map(select(length > 0) | tonumber)) as $keep_ids
+              | .[]
+              | select(($keep_ids | index(.id)) | not)
+              | .id
+            ' "$versions_json" > "$delete_ids_file"
+
+            if [[ ! -s "$delete_ids_file" ]]; then
+              echo "No deletions needed for ${package_name}"
+              echo "::endgroup::"
+              return 0
+            fi
+
+            echo "Deleting versions for ${package_name}:"
+            jq -r --rawfile keep_ids_raw "$keep_ids_file" '
+              ($keep_ids_raw | split("\n") | map(select(length > 0) | tonumber)) as $keep_ids
+              | .[]
+              | select(($keep_ids | index(.id)) | not)
+              | "DELETE id=\(.id) updated_at=\(.updated_at) tags=\((.tags | if length == 0 then \"<untagged>\" else join(\",\") end))"
+            ' "$versions_json"
 
             while IFS= read -r version_id; do
-              [[ -z "${version_id}" ]] && continue
-              echo "Deleting ${package_name} version id=${version_id}"
+              [[ -z "$version_id" ]] && continue
               gh api --method DELETE "/orgs/${OWNER}/packages/container/${encoded_package}/versions/${version_id}"
-            done <<< "${delete_ids}"
+            done < "$delete_ids_file"
+
+            echo "::endgroup::"
           }
 
-          prune_package "${REPO}/web"
-          prune_package "${REPO}/workspace"
+          reconcile_package "${REPO}/web"
+          reconcile_package "${REPO}/workspace"


### PR DESCRIPTION
## Summary
- always build both web and workspace images on pushes to `main` and release tags
- stop publishing SHA tags for release builds (keep only the official version tag)
- replace the GHCR retention workflow with a reconciliation policy that keeps current+previous main images, keeps releases, keeps one PR image per open PR, and deletes orphaned/untagged versions
- run retention on build workflow completion and hourly cron to cover all cases

## Notes
- manual PR builds via `/build` (repository dispatch) trigger both image workflows
- retention runs after those workflows complete via `workflow_run`

## Validation
- YAML parse checks for all modified workflows
- `git diff --check`