### PR TITLE
fix(infra): provision host before remote image builds

### DIFF
--- a/infra/deploy/ansible/playbooks/site.yml
+++ b/infra/deploy/ansible/playbooks/site.yml
@@ -35,12 +35,14 @@
     - role: podman
       when: needs_provision
     - role: app
+      when: not (bootstrap_only | default(false) | bool)
 
   post_tasks:
     - name: Verify running containers
       ansible.builtin.command: podman ps --filter "label=com.docker.compose.project=arche" --format "{{'{{'}}.Names{{'}}'}} - {{'{{'}}.Status{{'}}'}}"
       register: containers
       changed_when: false
+      when: not (bootstrap_only | default(false) | bool)
 
     - name: Display deployment status
       ansible.builtin.debug:
@@ -50,3 +52,4 @@
           - "{{ containers.stdout | default('No containers found') }}"
           - "App:   https://{{ domain }}"
           - "Dashboard: https://{{ domain }}/u/{{ arche_seed_admin_slug }}"
+      when: not (bootstrap_only | default(false) | bool)

--- a/infra/deploy/deploy.sh
+++ b/infra/deploy/deploy.sh
@@ -430,12 +430,6 @@ deploy_remote() {
     ensure_dns_record
   fi
 
-  # Build workspace image on remote host when using default OPENCODE_IMAGE
-  prepare_remote_workspace_image
-
-  # Build web image on remote host when using local WEB_IMAGE
-  prepare_remote_web_image
-
   # Generate temporary inventory and extra-vars file
   INVENTORY=$(mktemp)
   EXTRA_VARS_FILE=$(mktemp)
@@ -482,8 +476,41 @@ json.dump(vars, open(sys.argv[1], "w"))
   ANSIBLE_ARGS=(
     -i "$INVENTORY"
     --extra-vars "@${EXTRA_VARS_FILE}"
+    --extra-vars "bootstrap_only=false"
     "$SCRIPT_DIR/ansible/playbooks/site.yml"
   )
+
+  NEEDS_REMOTE_BUILD=false
+  if [[ "$OPENCODE_IMAGE" == "arche-workspace:latest" || "$WEB_IMAGE" == "arche-web:latest" ]]; then
+    NEEDS_REMOTE_BUILD=true
+  fi
+
+  if $NEEDS_REMOTE_BUILD; then
+    log "Ensuring remote host is provisioned before image build..."
+    BOOTSTRAP_ARGS=(
+      -i "$INVENTORY"
+      --extra-vars "@${EXTRA_VARS_FILE}"
+      --extra-vars "bootstrap_only=true"
+      "$SCRIPT_DIR/ansible/playbooks/site.yml"
+    )
+
+    if $VERBOSE; then
+      BOOTSTRAP_ARGS+=(-vvv)
+    fi
+
+    if $DRY_RUN; then
+      BOOTSTRAP_ARGS+=(--check)
+    fi
+
+    log "Running Ansible bootstrap playbook..."
+    ANSIBLE_CONFIG="$SCRIPT_DIR/ansible.cfg" ansible-playbook "${BOOTSTRAP_ARGS[@]}"
+  fi
+
+  # Build workspace image on remote host when using default OPENCODE_IMAGE
+  prepare_remote_workspace_image
+
+  # Build web image on remote host when using local WEB_IMAGE
+  prepare_remote_web_image
 
   if $VERBOSE; then
     ANSIBLE_ARGS+=(-vvv)


### PR DESCRIPTION
## Summary
- run a bootstrap Ansible pass before remote image builds when `OPENCODE_IMAGE=arche-workspace:latest` or `WEB_IMAGE=arche-web:latest`
- gate the app role and deployment post-tasks behind `bootstrap_only` so bootstrap can provision Podman/deploy user without attempting full app rollout
- keep the normal deployment pass intact after image build to apply full compose/web deployment

## Why
Fresh VPS deployments failed with `podman: command not found` because remote image builds were attempted before provisioning had installed Podman.