### PR TITLE
fix(infra): stabilize web gateway alias and validate encryption key

### DIFF
--- a/infra/deploy/ansible/roles/app/tasks/main.yml
+++ b/infra/deploy/ansible/roles/app/tasks/main.yml
@@ -329,12 +329,19 @@
       {{ web_image }}
   changed_when: true
 
+- name: Ensure new web container has stable web alias on arche-internal
+  ansible.builtin.shell:
+    cmd: >
+      podman network disconnect arche-internal {{ new_web_container }} >/dev/null 2>&1 || true;
+      podman network connect --alias web arche-internal {{ new_web_container }}
+  changed_when: true
+
 # 5d. Wait for the new container to pass health check
 - name: Wait for new web container to pass health check
   ansible.builtin.shell:
     cmd: >
       podman exec {{ new_web_container }}
-      node -e "fetch('http://localhost:3000/api/health').then(r=>{if(!r.ok)throw 1}).catch(()=>process.exit(1))"
+      node -e "Promise.all([fetch('http://localhost:3000/api/health'),fetch('http://web:3000/api/health')]).then(([local,alias])=>{if(!local.ok||!alias.ok)throw 1}).catch(()=>process.exit(1))"
   register: health_check
   retries: 36
   delay: 5

--- a/infra/deploy/deploy.sh
+++ b/infra/deploy/deploy.sh
@@ -203,6 +203,34 @@ WEB_IMAGE="${WEB_IMAGE:-${IMAGE_PREFIX}web:${WEB_VERSION}}"
 # ---------------------------------------------------------------------------
 ERRORS=()
 
+validate_encryption_key() {
+  local key="${ARCHE_ENCRYPTION_KEY:-}"
+  local decoded_length
+
+  if [[ -z "$key" ]]; then
+    return
+  fi
+
+  decoded_length="$(python3 - <<'PY'
+import base64
+import os
+
+key = os.environ.get("ARCHE_ENCRYPTION_KEY", "")
+
+try:
+  decoded = base64.b64decode(key, validate=True)
+except Exception:
+  print(-1)
+else:
+  print(len(decoded))
+PY
+)"
+
+  if [[ "$decoded_length" != "32" ]]; then
+    ERRORS+=("ARCHE_ENCRYPTION_KEY must decode from base64 to exactly 32 bytes (example: openssl rand -base64 32)")
+  fi
+}
+
 validate_remote() {
   log "Starting validate_remote..."
   [[ -z "$DEPLOY_IP" ]]    && ERRORS+=("--ip is required")
@@ -237,6 +265,8 @@ validate_remote() {
   [[ -z "${ARCHE_SEED_ADMIN_PASSWORD:-}" ]] && ERRORS+=("ARCHE_SEED_ADMIN_PASSWORD is required")
   [[ -z "${ARCHE_SEED_ADMIN_SLUG:-}" ]]     && ERRORS+=("ARCHE_SEED_ADMIN_SLUG is required")
 
+  validate_encryption_key
+
   log "validate_remote complete, errors: ${#ERRORS[@]}"
 }
 
@@ -255,6 +285,8 @@ validate_local() {
   export ARCHE_SEED_ADMIN_SLUG="${ARCHE_SEED_ADMIN_SLUG:-admin}"
   export ARCHE_SEED_TEST_EMAIL="${ARCHE_SEED_TEST_EMAIL:-peter@example.com}"
   export ARCHE_SEED_TEST_SLUG="${ARCHE_SEED_TEST_SLUG:-peter}"
+
+  validate_encryption_key
 }
 
 log "About to determine mode, current MODE=$MODE"


### PR DESCRIPTION
## Summary
- reconnect each newly deployed web container to `arche-internal` with the stable alias `web`, so workspace containers can always resolve the internal provider gateway host.
- harden blue/green readiness checks by requiring both `http://localhost:3000/api/health` and `http://web:3000/api/health` to succeed before the old container is removed.
- add a deploy-time validation in `infra/deploy/deploy.sh` to fail fast when `ARCHE_ENCRYPTION_KEY` is not valid base64 for exactly 32 bytes.