### PR TITLE
fix(web): restore Zen free model access

### DIFF
--- a/apps/web/src/actions/__tests__/opencode-models.test.ts
+++ b/apps/web/src/actions/__tests__/opencode-models.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  SESSION_COOKIE_NAME: 'arche_session',
+  getSessionFromToken: vi.fn(),
+}))
+
+vi.mock('@/lib/opencode/client', () => ({
+  createInstanceClient: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('@/lib/providers/store', () => ({
+  getActiveCredentialForUser: vi.fn(),
+}))
+
+import { cookies } from 'next/headers'
+import { getSessionFromToken } from '@/lib/auth'
+import { createInstanceClient } from '@/lib/opencode/client'
+import { getActiveCredentialForUser } from '@/lib/providers/store'
+import { listModelsAction } from '../opencode'
+
+const mockCookies = vi.mocked(cookies)
+const mockGetSessionFromToken = vi.mocked(getSessionFromToken)
+const mockCreateInstanceClient = vi.mocked(createInstanceClient)
+const mockGetActiveCredentialForUser = vi.mocked(getActiveCredentialForUser)
+
+const providersResponse = {
+  data: {
+    providers: [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        models: {
+          'gpt-5.2': { name: 'GPT-5.2' },
+        },
+      },
+      {
+        id: 'opencode',
+        name: 'OpenCode Zen',
+        models: {
+          'scene-free': { name: 'Scene Free' },
+        },
+      },
+    ],
+    default: {
+      openai: 'gpt-5.2',
+      opencode: 'scene-free',
+    },
+  },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockCookies.mockResolvedValue({
+    get: vi.fn(() => ({ name: 'arche_session', value: 'token-123' })),
+  } as never)
+
+  mockGetSessionFromToken.mockResolvedValue({
+    user: {
+      id: 'user-1',
+      slug: 'alice',
+      role: 'USER',
+    },
+  } as never)
+
+  mockCreateInstanceClient.mockResolvedValue({
+    config: {
+      providers: vi.fn().mockResolvedValue(providersResponse),
+    },
+  } as never)
+})
+
+describe('listModelsAction', () => {
+  it('keeps OpenCode Zen models visible without stored credentials', async () => {
+    mockGetActiveCredentialForUser.mockResolvedValue(null)
+
+    const result = await listModelsAction('alice')
+
+    expect(result.ok).toBe(true)
+    expect(result.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ providerId: 'opencode', modelId: 'scene-free' }),
+      ]),
+    )
+    expect(result.models).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ providerId: 'openai', modelId: 'gpt-5.2' }),
+      ]),
+    )
+  })
+
+  it('keeps paid providers gated behind active credentials', async () => {
+    mockGetActiveCredentialForUser.mockImplementation(async ({ providerId }) => {
+      if (providerId === 'openai') {
+        return {
+          id: 'cred-openai',
+          type: 'api',
+          secret: 'encrypted',
+          version: 1,
+        }
+      }
+
+      return null
+    })
+
+    const result = await listModelsAction('alice')
+
+    expect(result.ok).toBe(true)
+    expect(result.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ providerId: 'openai', modelId: 'gpt-5.2' }),
+        expect.objectContaining({ providerId: 'opencode', modelId: 'scene-free' }),
+      ]),
+    )
+  })
+})

--- a/apps/web/src/actions/opencode.ts
+++ b/apps/web/src/actions/opencode.ts
@@ -23,6 +23,12 @@ import type {
 } from "@/lib/opencode/types";
 import { extractTextContent, transformParts } from "@/lib/opencode/transform";
 
+const CREDENTIAL_REQUIRED_PROVIDER_IDS = new Set<ProviderId>([
+  "openai",
+  "anthropic",
+  "openrouter",
+]);
+
 function normalizeMessageRole(
   role: unknown
 ): "user" | "assistant" | "system" | null {
@@ -874,10 +880,13 @@ export async function listModelsAction(slug: string): Promise<{
     const models: AvailableModel[] = [];
 
     for (const provider of providers ?? []) {
-      // Only expose paid providers when the workspace owner has an active key.
+      const providerId = provider.id as ProviderId;
+
+      // OpenCode Zen can be available via native workspace auth even without
+      // an Arche-managed API credential.
       if (
-        PROVIDERS.includes(provider.id as ProviderId) &&
-        !enabledProviderIds.has(provider.id as ProviderId)
+        CREDENTIAL_REQUIRED_PROVIDER_IDS.has(providerId) &&
+        !enabledProviderIds.has(providerId)
       ) {
         continue;
       }

--- a/apps/web/src/app/api/internal/providers/[provider]/[...path]/route.ts
+++ b/apps/web/src/app/api/internal/providers/[provider]/[...path]/route.ts
@@ -193,42 +193,58 @@ async function handleProxy(
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
   }
 
-  let payload: ReturnType<typeof verifyGatewayToken>
+  let payload: ReturnType<typeof verifyGatewayToken> | null = null
+  let apiKey: string | null = null
+
   try {
     payload = verifyGatewayToken(token)
   } catch {
-    return NextResponse.json({ error: 'invalid_token' }, { status: 401 })
+    if (provider !== 'opencode') {
+      return NextResponse.json({ error: 'invalid_token' }, { status: 401 })
+    }
+
+    // When no Arche-managed credential is configured, OpenCode Zen may be
+    // authenticated natively in the workspace. In that case, forward the
+    // workspace token as-is.
+    apiKey = token
   }
 
-  if (payload.providerId !== provider) {
-    return NextResponse.json({ error: 'provider_mismatch' }, { status: 403 })
+  if (payload) {
+    if (payload.providerId !== provider) {
+      return NextResponse.json({ error: 'provider_mismatch' }, { status: 403 })
+    }
+
+    const credential = await getActiveCredentialForUser({
+      userId: payload.userId,
+      providerId: provider,
+    })
+
+    if (!credential) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+    }
+
+    if (credential.type !== 'api') {
+      return NextResponse.json({ error: 'unsupported_credential' }, { status: 501 })
+    }
+
+    let secret: ReturnType<typeof decryptProviderSecret>
+    try {
+      secret = decryptProviderSecret(credential.secret)
+    } catch {
+      return NextResponse.json({ error: 'invalid_credentials' }, { status: 500 })
+    }
+
+    if (!('apiKey' in secret) || typeof secret.apiKey !== 'string' || !secret.apiKey.trim()) {
+      return NextResponse.json({ error: 'unsupported_credential' }, { status: 501 })
+    }
+
+    apiKey = secret.apiKey.trim()
   }
 
-  const credential = await getActiveCredentialForUser({
-    userId: payload.userId,
-    providerId: provider,
-  })
-
-  if (!credential) {
+  if (!apiKey) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
   }
 
-  if (credential.type !== 'api') {
-    return NextResponse.json({ error: 'unsupported_credential' }, { status: 501 })
-  }
-
-  let secret: ReturnType<typeof decryptProviderSecret>
-  try {
-    secret = decryptProviderSecret(credential.secret)
-  } catch {
-    return NextResponse.json({ error: 'invalid_credentials' }, { status: 500 })
-  }
-
-  if (!('apiKey' in secret) || typeof secret.apiKey !== 'string' || !secret.apiKey.trim()) {
-    return NextResponse.json({ error: 'unsupported_credential' }, { status: 501 })
-  }
-
-  const apiKey = secret.apiKey.trim()
   const upstreamUrl = buildUpstreamUrl(PROVIDER_BASE_URL[provider], pathSegments, new URL(request.url))
 
   const headers = new Headers(request.headers)

--- a/apps/web/src/lib/opencode/__tests__/providers.test.ts
+++ b/apps/web/src/lib/opencode/__tests__/providers.test.ts
@@ -54,13 +54,12 @@ describe('syncProviderAccessForInstance', () => {
     expect(putCalls[0]![0]).toBe(`${fakeInstance.baseUrl}/auth/openai`)
     expect(putCalls[1]![0]).toBe(`${fakeInstance.baseUrl}/auth/anthropic`)
 
-    // Verify DELETE for disabled providers
+    // Verify DELETE for disabled managed providers
     const deleteCalls = mockFetch.mock.calls.filter(
       (call) => (call[1] as RequestInit)?.method === 'DELETE',
     )
-    expect(deleteCalls).toHaveLength(2)
+    expect(deleteCalls).toHaveLength(1)
     expect(deleteCalls[0]![0]).toBe(`${fakeInstance.baseUrl}/auth/openrouter`)
-    expect(deleteCalls[1]![0]).toBe(`${fakeInstance.baseUrl}/auth/opencode`)
 
     // Verify gateway tokens were issued for enabled providers
     expect(mockIssueToken).toHaveBeenCalledTimes(2)

--- a/apps/web/src/lib/opencode/providers.ts
+++ b/apps/web/src/lib/opencode/providers.ts
@@ -36,6 +36,11 @@ export async function syncProviderAccessForInstance(
       const url = `${instance.baseUrl}/auth/${providerId}`
 
       if (!enabled) {
+        if (providerId === 'opencode') {
+          // Preserve native Zen authentication when no Arche-managed credential exists.
+          continue
+        }
+
         await fetch(url, {
           method: 'DELETE',
           headers: {

--- a/apps/web/tests/opencode-providers.test.ts
+++ b/apps/web/tests/opencode-providers.test.ts
@@ -69,10 +69,10 @@ describe('syncProviderAccessForInstance', () => {
 
     // PUT auth for enabled provider
     expect(urls).toContain('http://opencode-alice:4096/auth/openai')
-    // DELETE auth for other providers (best-effort)
+    // DELETE auth for managed providers without credentials (best-effort)
     expect(urls).toContain('http://opencode-alice:4096/auth/anthropic')
     expect(urls).toContain('http://opencode-alice:4096/auth/openrouter')
-    expect(urls).toContain('http://opencode-alice:4096/auth/opencode')
+    expect(urls).not.toContain('http://opencode-alice:4096/auth/opencode')
     // Dispose refresh
     expect(urls).toContain('http://opencode-alice:4096/instance/dispose')
 

--- a/apps/web/tests/providers-gateway.test.ts
+++ b/apps/web/tests/providers-gateway.test.ts
@@ -446,4 +446,29 @@ describe('providers gateway', () => {
     expect(headers.get('authorization')).toBe('Bearer oc-key')
     expect(headers.get('x-api-key')).toBe(null)
   })
+
+  it('passes through OpenCode Zen workspace tokens when not gateway-managed', async () => {
+    mockVerifyGatewayToken.mockImplementation(() => {
+      throw new Error('invalid_token')
+    })
+
+    ;(global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response('ok', { status: 200 })
+    )
+
+    await callProxy({
+      provider: 'opencode',
+      path: ['models'],
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer zen-user-token',
+      },
+    })
+
+    const [url, options] = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(url).toBe('https://opencode.ai/zen/v1/models?foo=bar')
+    const headers = options.headers as Headers
+    expect(headers.get('authorization')).toBe('Bearer zen-user-token')
+    expect(mockGetActiveCredentialForUser).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary
- keep OpenCode Zen models visible in the workspace model list even when there is no Arche-managed provider credential.
- preserve native Zen authentication by skipping `/auth/opencode` deletion during provider sync when no managed opencode credential exists.
- allow the internal providers gateway to pass through workspace Zen bearer tokens for `opencode` when gateway token verification is not applicable, while keeping strict credential gating for OpenAI/Anthropic/OpenRouter.

## Validation
- pnpm test
- pnpm lint