### PR TITLE
fix(ci): repair jq filters in GHCR retention workflow

### DIFF
--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -140,14 +140,14 @@ jobs:
             jq -r --rawfile keep_ids_raw "$keep_ids_file" '
               ($keep_ids_raw | split("\n") | map(select(length > 0) | tonumber)) as $keep_ids
               | .[]
-              | select($keep_ids | index(.id))
-              | "KEEP   id=\(.id) updated_at=\(.updated_at) tags=\((.tags | if length == 0 then \"<untagged>\" else join(\",\") end))"
+              | select(.id as $id | $keep_ids | index($id))
+              | "KEEP   id=\(.id) updated_at=\(.updated_at) tags=\((.tags | if length == 0 then "<untagged>" else join(",") end))"
             ' "$versions_json" || true
 
             jq -r --rawfile keep_ids_raw "$keep_ids_file" '
               ($keep_ids_raw | split("\n") | map(select(length > 0) | tonumber)) as $keep_ids
               | .[]
-              | select(($keep_ids | index(.id)) | not)
+              | select((.id as $id | $keep_ids | index($id)) | not)
               | .id
             ' "$versions_json" > "$delete_ids_file"
 
@@ -161,8 +161,8 @@ jobs:
             jq -r --rawfile keep_ids_raw "$keep_ids_file" '
               ($keep_ids_raw | split("\n") | map(select(length > 0) | tonumber)) as $keep_ids
               | .[]
-              | select(($keep_ids | index(.id)) | not)
-              | "DELETE id=\(.id) updated_at=\(.updated_at) tags=\((.tags | if length == 0 then \"<untagged>\" else join(\",\") end))"
+              | select((.id as $id | $keep_ids | index($id)) | not)
+              | "DELETE id=\(.id) updated_at=\(.updated_at) tags=\((.tags | if length == 0 then "<untagged>" else join(",") end))"
             ' "$versions_json"
 
             while IFS= read -r version_id; do


### PR DESCRIPTION
## Summary
Fix the GHCR retention workflow failure caused by broken jq filters introduced in the new retention reconciliation logic.

## Root cause
- Invalid jq string interpolation quoting in the KEEP/DELETE log formatters.
- Wrong jq scope in `index(.id)`, where `.id` was evaluated against the keep-id array instead of the current version object.

## Changes
- Fix jq interpolation strings used in KEEP/DELETE logging output.
- Capture the current version id with `.id as $id` before checking membership in `$keep_ids`.

## Validation
- `pnpm test` (from `apps/web`) ✅
- `pnpm lint` (from `apps/web`) ✅
