### PR TITLE
feat(workspace): add expert mention autocomplete

### DIFF
--- a/apps/web/src/components/workspace/__tests__/chat-panel-textarea.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/chat-panel-textarea.test.tsx
@@ -363,7 +363,36 @@ describe("ChatPanel textarea", () => {
     expect(screen.queryByRole("button", { name: /ads scripts/i })).toBeNull();
   });
 
-  it("renders expert mention suggestions in a fixed popover above the caret", async () => {
+  it("closes expert mention suggestions when the composer loses focus", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ attachments: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderChatPanel(undefined, {
+      agents: [
+        { id: "assistant", displayName: "Assistant", isPrimary: true },
+        { id: "ads-scripts", displayName: "Ads Scripts", isPrimary: false },
+      ],
+    });
+
+    const textarea = getTextarea();
+    fireEvent.change(textarea, { target: { value: "Ask @ads" } });
+    textarea.setSelectionRange("Ask @ads".length, "Ask @ads".length);
+    fireEvent.select(textarea);
+
+    expect(await screen.findByRole("button", { name: /ads scripts/i })).toBeTruthy();
+
+    textarea.focus();
+    fireEvent.blur(textarea);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /ads scripts/i })).toBeNull();
+    });
+  });
+
+  it("renders expert mention suggestions in a fixed popover anchored to the caret", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ attachments: [] }),
@@ -391,8 +420,11 @@ describe("ChatPanel textarea", () => {
       throw new Error("Expected popover container");
     }
 
+    await waitFor(() => {
+      expect(popover.style.visibility).toBe("visible");
+    });
+
     expect(popover.style.position).toBe("fixed");
-    expect(popover.style.transform).toBe("translateY(calc(-100% - 8px))");
   });
 
   it("inserts a pending expert mention at the current cursor position", async () => {

--- a/apps/web/src/components/workspace/__tests__/chat-panel-textarea.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/chat-panel-textarea.test.tsx
@@ -363,6 +363,38 @@ describe("ChatPanel textarea", () => {
     expect(screen.queryByRole("button", { name: /ads scripts/i })).toBeNull();
   });
 
+  it("renders expert mention suggestions in a fixed popover above the caret", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ attachments: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderChatPanel(undefined, {
+      agents: [
+        { id: "assistant", displayName: "Assistant", isPrimary: true },
+        { id: "ads-scripts", displayName: "Ads Scripts", isPrimary: false },
+      ],
+    });
+
+    const textarea = getTextarea();
+    fireEvent.change(textarea, { target: { value: "Ask @ads" } });
+    textarea.setSelectionRange("Ask @ads".length, "Ask @ads".length);
+    fireEvent.select(textarea);
+
+    const suggestion = await screen.findByRole("button", { name: /ads scripts/i });
+    const popover = suggestion.closest('[role="presentation"]');
+
+    expect(popover).toBeTruthy();
+
+    if (!(popover instanceof HTMLDivElement)) {
+      throw new Error("Expected popover container");
+    }
+
+    expect(popover.style.position).toBe("fixed");
+    expect(popover.style.transform).toBe("translateY(calc(-100% - 8px))");
+  });
+
   it("inserts a pending expert mention at the current cursor position", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/apps/web/src/components/workspace/__tests__/chat-panel-textarea.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/chat-panel-textarea.test.tsx
@@ -330,6 +330,94 @@ describe("ChatPanel textarea", () => {
     });
   });
 
+  it("accepts an expert mention suggestion with Enter and inserts the agent id", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ attachments: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const onSendMessage = vi.fn().mockResolvedValue(true);
+    renderChatPanel(onSendMessage, {
+      agents: [
+        { id: "assistant", displayName: "Assistant", isPrimary: true },
+        { id: "ads-scripts", displayName: "Ads Scripts", isPrimary: false },
+        { id: "seo", displayName: "SEO", isPrimary: false },
+      ],
+    });
+
+    const textarea = getTextarea();
+    fireEvent.change(textarea, { target: { value: "Ask @ads" } });
+    textarea.setSelectionRange("Ask @ads".length, "Ask @ads".length);
+    fireEvent.select(textarea);
+
+    expect(await screen.findByRole("button", { name: /ads scripts/i })).toBeTruthy();
+
+    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(textarea.value).toBe("Ask @ads-scripts ");
+    });
+
+    expect(onSendMessage).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: /ads scripts/i })).toBeNull();
+  });
+
+  it("inserts a pending expert mention at the current cursor position", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ attachments: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const onPendingInsertConsumed = vi.fn();
+    const onSendMessage = vi.fn().mockResolvedValue(true);
+
+    const { rerender } = render(
+      <WorkspaceThemeProvider storageScope="alice">
+        <ChatPanel
+          slug="alice"
+          sessions={[{ id: "s1", title: "Chat", status: "idle", updatedAt: "now", agent: "OpenCode" }]}
+          messages={[]}
+          activeSessionId="s1"
+          openFilePaths={[]}
+          onCloseSession={vi.fn()}
+          onOpenFile={vi.fn()}
+          onSendMessage={onSendMessage}
+          onPendingInsertConsumed={onPendingInsertConsumed}
+        />
+      </WorkspaceThemeProvider>
+    );
+
+    const textarea = getTextarea();
+    fireEvent.change(textarea, { target: { value: "Plan: campaign" } });
+    textarea.setSelectionRange("Plan: ".length, "Plan: ".length);
+    fireEvent.select(textarea);
+
+    rerender(
+      <WorkspaceThemeProvider storageScope="alice">
+        <ChatPanel
+          slug="alice"
+          sessions={[{ id: "s1", title: "Chat", status: "idle", updatedAt: "now", agent: "OpenCode" }]}
+          messages={[]}
+          activeSessionId="s1"
+          openFilePaths={[]}
+          onCloseSession={vi.fn()}
+          onOpenFile={vi.fn()}
+          onSendMessage={onSendMessage}
+          pendingInsert="@ads-scripts "
+          onPendingInsertConsumed={onPendingInsertConsumed}
+        />
+      </WorkspaceThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(textarea.value).toBe("Plan: @ads-scripts campaign");
+    });
+
+    expect(onPendingInsertConsumed).toHaveBeenCalledTimes(1);
+  });
+
   it("disables send while a pasted image upload is in progress", async () => {
     const attachmentStore: MockAttachment[] = [];
     const uploadedAttachment: MockAttachment = {

--- a/apps/web/src/components/workspace/__tests__/workspace-shell.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/workspace-shell.test.tsx
@@ -32,10 +32,18 @@ vi.mock("@/contexts/workspace-theme-context", () => ({
 
 vi.mock("@/hooks/use-workspace", () => ({
   useWorkspace: () => ({
-    sessions: [],
+    sessions: [
+      {
+        id: "root-session",
+        title: "Root session",
+        status: "idle",
+        updatedAt: "now",
+        updatedAtRaw: Date.now(),
+      },
+    ],
     messages: [],
     diffs: [],
-    activeSessionId: null,
+    activeSessionId: "root-session",
     unseenCompletedSessions: new Set<string>(),
     isConnected: true,
     connection: { status: "connected", error: null },
@@ -48,7 +56,10 @@ vi.mock("@/hooks/use-workspace", () => ({
     deleteSession: vi.fn(),
     renameSession: vi.fn(),
     selectSession: vi.fn(),
-    agentCatalog: [],
+    agentCatalog: [
+      { id: "assistant", displayName: "Assistant", isPrimary: true },
+      { id: "ads-scripts", displayName: "Ads Scripts", isPrimary: false },
+    ],
     fileTree: [],
     isStartingNewSession: false,
     sendMessage: vi.fn(),
@@ -66,9 +77,10 @@ vi.mock("@/hooks/use-workspace", () => ({
 }));
 
 vi.mock("@/components/workspace/chat-panel", () => ({
-  ChatPanel: ({ onShowContext }: { onShowContext?: () => void }) => (
+  ChatPanel: ({ onShowContext, pendingInsert }: { onShowContext?: () => void; pendingInsert?: string | null }) => (
     <div>
       <span>Chat Panel</span>
+      <span>{pendingInsert ?? "No pending insert"}</span>
       <button type="button" onClick={() => onShowContext?.()}>
         Show Context
       </button>
@@ -89,10 +101,18 @@ vi.mock("@/components/workspace/inspector-panel", () => ({
 }));
 
 vi.mock("@/components/workspace/left-panel", () => ({
-  LeftPanel: ({ leftCollapsed, onToggleLeft }: { leftCollapsed: boolean; onToggleLeft: () => void }) => (
-    <button type="button" data-collapsed={String(leftCollapsed)} onClick={onToggleLeft}>
-      Left Panel
-    </button>
+  LeftPanel: ({ leftCollapsed, onToggleLeft, onSelectAgent }: { leftCollapsed: boolean; onToggleLeft: () => void; onSelectAgent: (agent: { id: string; displayName: string; isPrimary: boolean }) => void }) => (
+    <div>
+      <button type="button" data-collapsed={String(leftCollapsed)} onClick={onToggleLeft}>
+        Left Panel
+      </button>
+      <button
+        type="button"
+        onClick={() => onSelectAgent({ id: "ads-scripts", displayName: "Ads Scripts", isPrimary: false })}
+      >
+        Insert Ads Scripts
+      </button>
+    </div>
   ),
 }));
 
@@ -189,6 +209,20 @@ describe("WorkspaceShell", () => {
 
     await waitFor(() => {
       expect(createSessionMock).toHaveBeenCalledWith();
+    });
+  });
+
+  it("inserts the expert id when selecting an expert from the left panel", async () => {
+    render(<WorkspaceShell slug="alice" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Insert Ads Scripts" })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Insert Ads Scripts" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("@ads-scripts ")).toBeTruthy();
     });
   });
 

--- a/apps/web/src/components/workspace/__tests__/workspace-shell.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/workspace-shell.test.tsx
@@ -147,6 +147,20 @@ function setViewportWidth(width: number) {
   window.dispatchEvent(new Event("resize"));
 }
 
+function findSizedPanelContainer(element: HTMLElement | null): HTMLElement | null {
+  let current = element;
+
+  while (current) {
+    if (current.style.width) {
+      return current;
+    }
+
+    current = current.parentElement;
+  }
+
+  return null;
+}
+
 describe("WorkspaceShell", () => {
   beforeEach(() => {
     stubBrowserStorage();
@@ -222,7 +236,9 @@ describe("WorkspaceShell", () => {
     fireEvent.click(screen.getByRole("button", { name: "Insert Ads Scripts" }));
 
     await waitFor(() => {
-      expect(screen.getByText("@ads-scripts ")).toBeTruthy();
+      expect(
+        screen.getByText((_, element) => element?.textContent === "@ads-scripts ")
+      ).toBeTruthy();
     });
   });
 
@@ -288,9 +304,9 @@ describe("WorkspaceShell", () => {
       expect(screen.getByRole("button", { name: "Inspector Panel" }).dataset.collapsed).toBe("false");
     });
 
-    const leftPanelWidth = Number.parseFloat(leftPanelButton.parentElement?.style.width ?? "0");
+    const leftPanelWidth = Number.parseFloat(findSizedPanelContainer(leftPanelButton)?.style.width ?? "0");
     const rightPanelWidth = Number.parseFloat(
-      screen.getByRole("button", { name: "Inspector Panel" }).parentElement?.style.width ?? "0"
+      findSizedPanelContainer(screen.getByRole("button", { name: "Inspector Panel" }))?.style.width ?? "0"
     );
 
     const expectedRightWidth = (1440 - leftPanelWidth - 24) / 2;
@@ -347,7 +363,7 @@ describe("WorkspaceShell", () => {
     expect(screen.getByRole("button", { name: "Inspector Panel" }).dataset.collapsed).toBe("true");
 
     const leftPanelButton = screen.getByRole("button", { name: "Left Panel" });
-    const leftPanelWrapper = leftPanelButton.parentElement;
+    const leftPanelWrapper = findSizedPanelContainer(leftPanelButton);
 
     expect(leftPanelWrapper?.style.width).toBe("264px");
   });

--- a/apps/web/src/components/workspace/chat-panel.tsx
+++ b/apps/web/src/components/workspace/chat-panel.tsx
@@ -1,16 +1,14 @@
 "use client";
 
 import {
-  useRef,
-  useState,
+  useCallback,
   useEffect,
   useMemo,
-  useCallback,
+  useRef,
+  useState,
   type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
-  type SyntheticEvent,
 } from "react";
-import { createPortal } from "react-dom";
 import {
   CaretDown,
   CheckCircle,
@@ -27,6 +25,7 @@ import {
   X,
 } from "@phosphor-icons/react";
 
+import { AgentMentionAutocomplete } from "@/components/workspace/chat-panel/agent-mention-autocomplete";
 import { ChatPanelMessages } from "@/components/workspace/chat-panel/messages";
 import { ChatPanelSessionHeader } from "@/components/workspace/chat-panel/session-header";
 import type { ContextMode, SessionTabInfo } from "@/components/workspace/chat-panel/types";
@@ -48,6 +47,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useWorkspaceTheme } from "@/contexts/workspace-theme-context";
+import { useAgentMentionAutocomplete } from "@/hooks/use-agent-mention-autocomplete";
 import type { AgentCatalogItem } from "@/hooks/use-workspace";
 import type { AvailableModel } from "@/lib/opencode/types";
 import {
@@ -103,186 +103,7 @@ type ConnectorSummary = {
   name: string;
 };
 
-type TextSelectionRange = {
-  start: number;
-  end: number;
-};
-
-type AgentMentionAutocompleteState = {
-  from: number;
-  to: number;
-  left: number;
-  top: number;
-  selectedIndex: number;
-  suggestions: AgentCatalogItem[];
-};
-
 const MAX_CONTEXT_PATHS_PER_MESSAGE = 20;
-const MAX_AGENT_MENTION_SUGGESTIONS = 8;
-const AGENT_MENTION_AUTOCOMPLETE_WIDTH_PX = 320;
-const AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_GAP_PX = 8;
-const AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX = 12;
-
-const TEXTAREA_CARET_STYLE_PROPERTIES = [
-  "box-sizing",
-  "width",
-  "height",
-  "overflow-x",
-  "overflow-y",
-  "border-top-width",
-  "border-right-width",
-  "border-bottom-width",
-  "border-left-width",
-  "padding-top",
-  "padding-right",
-  "padding-bottom",
-  "padding-left",
-  "font-style",
-  "font-variant",
-  "font-weight",
-  "font-stretch",
-  "font-size",
-  "font-size-adjust",
-  "line-height",
-  "font-family",
-  "letter-spacing",
-  "text-align",
-  "text-indent",
-  "text-transform",
-  "text-decoration",
-  "text-rendering",
-  "text-overflow",
-  "text-wrap-mode",
-  "text-wrap-style",
-  "tab-size",
-  "white-space",
-  "word-break",
-  "word-spacing",
-  "scrollbar-gutter",
-] as const;
-
-function normalizeAgentSearchValue(value: string): string {
-  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "");
-}
-
-function buildAgentMentionSuggestions(
-  agents: AgentCatalogItem[],
-  query: string
-): AgentCatalogItem[] {
-  const rawQuery = query.trim().toLowerCase();
-  const normalizedQuery = normalizeAgentSearchValue(query);
-
-  const scored = agents
-    .map((agent) => {
-      const id = agent.id.toLowerCase();
-      const displayName = agent.displayName.toLowerCase();
-      const normalizedId = normalizeAgentSearchValue(agent.id);
-      const normalizedDisplayName = normalizeAgentSearchValue(agent.displayName);
-
-      let score = 0;
-      if (rawQuery.length > 0) {
-        if (id.startsWith(rawQuery)) score = 0;
-        else if (displayName.startsWith(rawQuery)) score = 1;
-        else if (normalizedId.startsWith(normalizedQuery)) score = 2;
-        else if (normalizedDisplayName.startsWith(normalizedQuery)) score = 3;
-        else if (id.includes(rawQuery)) score = 4;
-        else if (displayName.includes(rawQuery)) score = 5;
-        else if (normalizedId.includes(normalizedQuery)) score = 6;
-        else if (normalizedDisplayName.includes(normalizedQuery)) score = 7;
-        else return null;
-      }
-
-      return { agent, score };
-    })
-    .filter((entry): entry is { agent: AgentCatalogItem; score: number } => entry !== null)
-    .sort((left, right) => {
-      if (left.score !== right.score) {
-        return left.score - right.score;
-      }
-      return left.agent.displayName.localeCompare(right.agent.displayName);
-    });
-
-  return scored.slice(0, MAX_AGENT_MENTION_SUGGESTIONS).map((entry) => entry.agent);
-}
-
-function findAgentMentionMatch(
-  value: string,
-  caretPosition: number
-): { from: number; to: number; query: string } | null {
-  const clampedCaret = Math.max(0, Math.min(caretPosition, value.length));
-  const beforeCaret = value.slice(0, clampedCaret);
-  const atIndex = beforeCaret.lastIndexOf("@");
-
-  if (atIndex === -1) return null;
-  if (atIndex > 0 && !/\s/.test(beforeCaret[atIndex - 1] ?? "")) {
-    return null;
-  }
-
-  const beforeQuery = beforeCaret.slice(atIndex + 1);
-  if (/\s|@/.test(beforeQuery)) {
-    return null;
-  }
-
-  const afterCaret = value.slice(clampedCaret).match(/^[^\s@]*/)?.[0] ?? "";
-  const query = `${beforeQuery}${afterCaret}`;
-
-  return {
-    from: atIndex,
-    to: clampedCaret + afterCaret.length,
-    query,
-  };
-}
-
-function getTextareaLineHeight(style: CSSStyleDeclaration): number {
-  const parsed = Number.parseFloat(style.lineHeight);
-  if (Number.isFinite(parsed)) return parsed;
-
-  const fontSize = Number.parseFloat(style.fontSize);
-  if (Number.isFinite(fontSize)) return fontSize * 1.4;
-
-  return 20;
-}
-
-function getTextareaCaretPosition(
-  textarea: HTMLTextAreaElement,
-  position: number
-): { left: number; top: number } {
-  const div = document.createElement("div");
-  const style = window.getComputedStyle(textarea);
-
-  div.setAttribute("data-agent-mention-caret", "true");
-  div.style.position = "absolute";
-  div.style.visibility = "hidden";
-  div.style.pointerEvents = "none";
-  div.style.whiteSpace = "pre-wrap";
-  div.style.wordBreak = "break-word";
-  div.style.overflow = "hidden";
-  div.style.top = "0";
-  div.style.left = "-9999px";
-  div.style.width = `${textarea.clientWidth}px`;
-
-  for (const property of TEXTAREA_CARET_STYLE_PROPERTIES) {
-    div.style.setProperty(property, style.getPropertyValue(property));
-  }
-
-  div.textContent = textarea.value.slice(0, position);
-  if (div.textContent.endsWith("\n")) {
-    div.textContent += "\u200b";
-  }
-
-  const span = document.createElement("span");
-  span.textContent = textarea.value.slice(position) || "\u200b";
-  div.appendChild(span);
-  document.body.appendChild(div);
-
-  const coordinates = {
-    left: span.offsetLeft - textarea.scrollLeft,
-    top: span.offsetTop - textarea.scrollTop + getTextareaLineHeight(style),
-  };
-
-  document.body.removeChild(div);
-  return coordinates;
-}
 
 function downloadMarkdownFile(filename: string, content: string) {
   const blob = new Blob([content], { type: "text/markdown;charset=utf-8" });
@@ -353,11 +174,7 @@ export function ChatPanel({
   const titleInputRef = useRef<HTMLInputElement>(null);
   const preventSessionMenuAutoFocusRef = useRef(false);
   const ignoreNextTitleBlurRef = useRef(false);
-  const selectionRangeRef = useRef<TextSelectionRange>({ start: 0, end: 0 });
-  const pendingSelectionRangeRef = useRef<TextSelectionRange | null>(null);
   const [inputValue, setInputValue] = useState("");
-  const [agentMentionAutocomplete, setAgentMentionAutocomplete] =
-    useState<AgentMentionAutocompleteState | null>(null);
   const [modelSearch, setModelSearch] = useState("");
   const [isModelMenuOpen, setIsModelMenuOpen] = useState(false);
   const [attachments, setAttachments] = useState<WorkspaceAttachment[]>([]);
@@ -414,118 +231,23 @@ export function ChatPanel({
     activeSession && editingSessionId === activeSession.id
   );
   const canFocusComposer = !isReadOnly && !isStartingNewSession && Boolean(onSendMessage);
-  const mentionableAgents = useMemo(
-    () => agents.filter((agent) => !agent.isPrimary),
-    [agents]
-  );
-
-  const syncTextareaSelection = useCallback((textarea?: HTMLTextAreaElement | null) => {
-    const target = textarea ?? textareaRef.current;
-    if (!target) return;
-
-    selectionRangeRef.current = {
-      start: target.selectionStart ?? target.value.length,
-      end: target.selectionEnd ?? target.value.length,
-    };
-  }, []);
-
-  const updateAgentMentionAutocomplete = useCallback(
-    (value: string, selection: TextSelectionRange) => {
-      if (isReadOnly || mentionableAgents.length === 0 || selection.start !== selection.end) {
-        setAgentMentionAutocomplete(null);
-        return;
-      }
-
-      const match = findAgentMentionMatch(value, selection.end);
-      if (!match) {
-        setAgentMentionAutocomplete(null);
-        return;
-      }
-
-      const suggestions = buildAgentMentionSuggestions(mentionableAgents, match.query);
-      if (suggestions.length === 0) {
-        setAgentMentionAutocomplete(null);
-        return;
-      }
-
-      const textarea = textareaRef.current;
-      if (!textarea) {
-        setAgentMentionAutocomplete(null);
-        return;
-      }
-
-      const textareaRect = textarea.getBoundingClientRect();
-      const caret = getTextareaCaretPosition(textarea, match.to);
-      const maxLeft = Math.max(
-        window.innerWidth -
-          AGENT_MENTION_AUTOCOMPLETE_WIDTH_PX -
-          AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX,
-        AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX
-      );
-
-      setAgentMentionAutocomplete((previous) => ({
-        from: match.from,
-        to: match.to,
-        suggestions,
-        left: Math.min(
-          Math.max(
-            textareaRect.left + caret.left,
-            AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX
-          ),
-          maxLeft
-        ),
-        top: textareaRect.top + caret.top,
-        selectedIndex:
-          previous &&
-          previous.from === match.from &&
-          previous.to === match.to &&
-          previous.selectedIndex < suggestions.length
-            ? previous.selectedIndex
-            : 0,
-      }));
-    },
-    [isReadOnly, mentionableAgents]
-  );
-
-  const restoreComposerSelection = useCallback((selection: TextSelectionRange) => {
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-
-    textarea.focus();
-    textarea.setSelectionRange(selection.start, selection.end);
-    selectionRangeRef.current = selection;
-    updateAgentMentionAutocomplete(textarea.value, selection);
-  }, [updateAgentMentionAutocomplete]);
-
-  const insertComposerText = useCallback(
-    (text: string, range?: { from: number; to: number }) => {
-      setInputValue((previous) => {
-        const fallbackSelection = selectionRangeRef.current;
-        const rawStart = range?.from ?? fallbackSelection.start;
-        const rawEnd = range?.to ?? fallbackSelection.end;
-        const start = Math.max(0, Math.min(rawStart, previous.length));
-        const end = Math.max(start, Math.min(rawEnd, previous.length));
-        const nextValue = `${previous.slice(0, start)}${text}${previous.slice(end)}`;
-        const nextSelection = {
-          start: start + text.length,
-          end: start + text.length,
-        };
-
-        pendingSelectionRangeRef.current = nextSelection;
-        selectionRangeRef.current = nextSelection;
-        return nextValue;
-      });
-    },
-    []
-  );
-
-  const applyAgentMentionSuggestion = useCallback(
-    (agent: AgentCatalogItem, range?: { from: number; to: number }) => {
-      insertComposerText(`@${agent.id} `, range);
-      setAgentMentionAutocomplete(null);
-    },
-    [insertComposerText]
-  );
+  const {
+    agentMentionAutocomplete,
+    clearAgentMentionAutocomplete,
+    handleInputChange,
+    handleMentionKeyDown,
+    handleTextareaBlur,
+    handleTextareaKeyUp,
+    handleTextareaSelectionChange,
+    insertComposerText,
+    onAgentMentionSelect,
+  } = useAgentMentionAutocomplete({
+    agents,
+    inputValue,
+    isReadOnly,
+    setInputValue,
+    textareaRef,
+  });
 
   const cancelSessionRename = useCallback(() => {
     if (isSavingTitle) return;
@@ -647,24 +369,6 @@ export function ChatPanel({
       cancelAnimationFrame(frameId);
     };
   }, [isModelMenuOpen]);
-
-  useEffect(() => {
-    const pendingSelection = pendingSelectionRangeRef.current;
-    if (!pendingSelection) return;
-
-    const frameId = requestAnimationFrame(() => {
-      restoreComposerSelection(pendingSelection);
-      pendingSelectionRangeRef.current = null;
-    });
-
-    return () => {
-      cancelAnimationFrame(frameId);
-    };
-  }, [inputValue, restoreComposerSelection]);
-
-  useEffect(() => {
-    updateAgentMentionAutocomplete(inputValue, selectionRangeRef.current);
-  }, [inputValue, updateAgentMentionAutocomplete]);
 
   const effectiveContextPaths = useMemo(() => {
     if (contextMode === "off") return [];
@@ -1111,10 +815,12 @@ export function ChatPanel({
       return;
     }
 
+    clearAgentMentionAutocomplete();
     setInputValue("");
     textareaRef.current?.focus();
     setSelectedAttachmentPaths([]);
   }, [
+    clearAgentMentionAutocomplete,
     contextPathsToSend,
     inputValue,
     isReadOnly,
@@ -1128,58 +834,13 @@ export function ChatPanel({
   ]);
 
   const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (agentMentionAutocomplete && agentMentionAutocomplete.suggestions.length > 0) {
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        setAgentMentionAutocomplete((previous) => {
-          if (!previous) return null;
-          return {
-            ...previous,
-            selectedIndex: (previous.selectedIndex + 1) % previous.suggestions.length,
-          };
-        });
-        return;
-      }
-
-      if (event.key === "ArrowUp") {
-        event.preventDefault();
-        setAgentMentionAutocomplete((previous) => {
-          if (!previous) return null;
-          return {
-            ...previous,
-            selectedIndex:
-              (previous.selectedIndex - 1 + previous.suggestions.length) %
-              previous.suggestions.length,
-          };
-        });
-        return;
-      }
-
-      if (event.key === "Enter" || event.key === "Tab") {
-        event.preventDefault();
-        const selected =
-          agentMentionAutocomplete.suggestions[agentMentionAutocomplete.selectedIndex];
-        if (selected) {
-          applyAgentMentionSuggestion(selected, {
-            from: agentMentionAutocomplete.from,
-            to: agentMentionAutocomplete.to,
-          });
-        }
-        return;
-      }
-
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setAgentMentionAutocomplete(null);
-        return;
-      }
-    }
+    if (handleMentionKeyDown(event)) return;
 
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
       handleSend();
     }
-  }, [agentMentionAutocomplete, applyAgentMentionSuggestion, handleSend]);
+  }, [handleMentionKeyDown, handleSend]);
 
   useEffect(() => {
     const textarea = textareaRef.current;
@@ -1193,39 +854,6 @@ export function ChatPanel({
     textarea.style.height = "auto";
     textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`;
   }, [inputValue]);
-
-  const handleInputChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    syncTextareaSelection(event.currentTarget);
-    setInputValue(event.target.value);
-  }, [syncTextareaSelection]);
-
-  const handleTextareaSelectionChange = useCallback(
-    (event: SyntheticEvent<HTMLTextAreaElement>) => {
-      syncTextareaSelection(event.currentTarget);
-      updateAgentMentionAutocomplete(
-        event.currentTarget.value,
-        selectionRangeRef.current
-      );
-    },
-    [syncTextareaSelection, updateAgentMentionAutocomplete]
-  );
-
-  const handleTextareaKeyUp = useCallback(
-    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
-      if (
-        event.key === "ArrowDown" ||
-        event.key === "ArrowUp" ||
-        event.key === "Enter" ||
-        event.key === "Escape" ||
-        event.key === "Tab"
-      ) {
-        return;
-      }
-
-      handleTextareaSelectionChange(event);
-    },
-    [handleTextareaSelectionChange]
-  );
 
   // Get the current status from the last pending message (if any).
   // Only show transient statuses (thinking, tool calls) while actively streaming.
@@ -1664,6 +1292,7 @@ export function ChatPanel({
           <textarea
             ref={textareaRef}
             value={inputValue}
+            onBlur={handleTextareaBlur}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             onClick={handleTextareaSelectionChange}
@@ -1675,55 +1304,10 @@ export function ChatPanel({
             disabled={isStartingNewSession || !onSendMessage}
             rows={1}
           />
-          {agentMentionAutocomplete && typeof document !== "undefined"
-            ? createPortal(
-                <div
-                  className="pointer-events-none z-50"
-                  role="presentation"
-                  style={{
-                    position: "fixed",
-                    left: agentMentionAutocomplete.left,
-                    top: agentMentionAutocomplete.top,
-                    transform: `translateY(calc(-100% - ${AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_GAP_PX}px))`,
-                  }}
-                >
-                  <div
-                    className="pointer-events-auto rounded-md border border-white/10 bg-background/95 p-1 shadow-lg backdrop-blur-sm"
-                    style={{
-                      width: `min(${AGENT_MENTION_AUTOCOMPLETE_WIDTH_PX}px, calc(100vw - ${AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX * 2}px))`,
-                    }}
-                  >
-                    {agentMentionAutocomplete.suggestions.map((agent, index) => (
-                      <button
-                        key={agent.id}
-                        type="button"
-                        className={cn(
-                          "flex w-full items-center justify-between gap-3 rounded-sm px-2 py-1.5 text-left text-xs",
-                          index === agentMentionAutocomplete.selectedIndex
-                            ? "bg-primary/15 text-primary"
-                            : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
-                        )}
-                        onMouseDown={(event) => {
-                          event.preventDefault();
-                          applyAgentMentionSuggestion(agent, {
-                            from: agentMentionAutocomplete.from,
-                            to: agentMentionAutocomplete.to,
-                          });
-                        }}
-                      >
-                        <span className="min-w-0 flex-1 truncate font-medium">
-                          {agent.displayName}
-                        </span>
-                        <span className="shrink-0 text-[10px] text-muted-foreground">
-                          @{agent.id}
-                        </span>
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-                document.body
-              )
-            : null}
+          <AgentMentionAutocomplete
+            autocomplete={agentMentionAutocomplete}
+            onSelect={onAgentMentionSelect}
+          />
           <Button
             size="icon"
             className={cn(

--- a/apps/web/src/components/workspace/chat-panel.tsx
+++ b/apps/web/src/components/workspace/chat-panel.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
+  type SyntheticEvent,
 } from "react";
 import {
   CaretDown,
@@ -46,6 +47,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useWorkspaceTheme } from "@/contexts/workspace-theme-context";
+import type { AgentCatalogItem } from "@/hooks/use-workspace";
 import type { AvailableModel } from "@/lib/opencode/types";
 import {
   buildWorkspaceSessionMarkdown,
@@ -62,6 +64,7 @@ import type {
 
 type ChatPanelProps = {
   slug: string;
+  agents?: AgentCatalogItem[];
   attachmentsEnabled?: boolean;
   sessions: ChatSession[];
   messages: ChatMessage[];
@@ -99,7 +102,184 @@ type ConnectorSummary = {
   name: string;
 };
 
+type TextSelectionRange = {
+  start: number;
+  end: number;
+};
+
+type AgentMentionAutocompleteState = {
+  from: number;
+  to: number;
+  left: number;
+  top: number;
+  selectedIndex: number;
+  suggestions: AgentCatalogItem[];
+};
+
 const MAX_CONTEXT_PATHS_PER_MESSAGE = 20;
+const MAX_AGENT_MENTION_SUGGESTIONS = 8;
+const AGENT_MENTION_AUTOCOMPLETE_WIDTH_PX = 320;
+
+const TEXTAREA_CARET_STYLE_PROPERTIES = [
+  "box-sizing",
+  "width",
+  "height",
+  "overflow-x",
+  "overflow-y",
+  "border-top-width",
+  "border-right-width",
+  "border-bottom-width",
+  "border-left-width",
+  "padding-top",
+  "padding-right",
+  "padding-bottom",
+  "padding-left",
+  "font-style",
+  "font-variant",
+  "font-weight",
+  "font-stretch",
+  "font-size",
+  "font-size-adjust",
+  "line-height",
+  "font-family",
+  "letter-spacing",
+  "text-align",
+  "text-indent",
+  "text-transform",
+  "text-decoration",
+  "text-rendering",
+  "text-overflow",
+  "text-wrap-mode",
+  "text-wrap-style",
+  "tab-size",
+  "white-space",
+  "word-break",
+  "word-spacing",
+  "scrollbar-gutter",
+] as const;
+
+function normalizeAgentSearchValue(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+function buildAgentMentionSuggestions(
+  agents: AgentCatalogItem[],
+  query: string
+): AgentCatalogItem[] {
+  const rawQuery = query.trim().toLowerCase();
+  const normalizedQuery = normalizeAgentSearchValue(query);
+
+  const scored = agents
+    .map((agent) => {
+      const id = agent.id.toLowerCase();
+      const displayName = agent.displayName.toLowerCase();
+      const normalizedId = normalizeAgentSearchValue(agent.id);
+      const normalizedDisplayName = normalizeAgentSearchValue(agent.displayName);
+
+      let score = 0;
+      if (rawQuery.length > 0) {
+        if (id.startsWith(rawQuery)) score = 0;
+        else if (displayName.startsWith(rawQuery)) score = 1;
+        else if (normalizedId.startsWith(normalizedQuery)) score = 2;
+        else if (normalizedDisplayName.startsWith(normalizedQuery)) score = 3;
+        else if (id.includes(rawQuery)) score = 4;
+        else if (displayName.includes(rawQuery)) score = 5;
+        else if (normalizedId.includes(normalizedQuery)) score = 6;
+        else if (normalizedDisplayName.includes(normalizedQuery)) score = 7;
+        else return null;
+      }
+
+      return { agent, score };
+    })
+    .filter((entry): entry is { agent: AgentCatalogItem; score: number } => entry !== null)
+    .sort((left, right) => {
+      if (left.score !== right.score) {
+        return left.score - right.score;
+      }
+      return left.agent.displayName.localeCompare(right.agent.displayName);
+    });
+
+  return scored.slice(0, MAX_AGENT_MENTION_SUGGESTIONS).map((entry) => entry.agent);
+}
+
+function findAgentMentionMatch(
+  value: string,
+  caretPosition: number
+): { from: number; to: number; query: string } | null {
+  const clampedCaret = Math.max(0, Math.min(caretPosition, value.length));
+  const beforeCaret = value.slice(0, clampedCaret);
+  const atIndex = beforeCaret.lastIndexOf("@");
+
+  if (atIndex === -1) return null;
+  if (atIndex > 0 && !/\s/.test(beforeCaret[atIndex - 1] ?? "")) {
+    return null;
+  }
+
+  const beforeQuery = beforeCaret.slice(atIndex + 1);
+  if (/\s|@/.test(beforeQuery)) {
+    return null;
+  }
+
+  const afterCaret = value.slice(clampedCaret).match(/^[^\s@]*/)?.[0] ?? "";
+  const query = `${beforeQuery}${afterCaret}`;
+
+  return {
+    from: atIndex,
+    to: clampedCaret + afterCaret.length,
+    query,
+  };
+}
+
+function getTextareaLineHeight(style: CSSStyleDeclaration): number {
+  const parsed = Number.parseFloat(style.lineHeight);
+  if (Number.isFinite(parsed)) return parsed;
+
+  const fontSize = Number.parseFloat(style.fontSize);
+  if (Number.isFinite(fontSize)) return fontSize * 1.4;
+
+  return 20;
+}
+
+function getTextareaCaretPosition(
+  textarea: HTMLTextAreaElement,
+  position: number
+): { left: number; top: number } {
+  const div = document.createElement("div");
+  const style = window.getComputedStyle(textarea);
+
+  div.setAttribute("data-agent-mention-caret", "true");
+  div.style.position = "absolute";
+  div.style.visibility = "hidden";
+  div.style.pointerEvents = "none";
+  div.style.whiteSpace = "pre-wrap";
+  div.style.wordBreak = "break-word";
+  div.style.overflow = "hidden";
+  div.style.top = "0";
+  div.style.left = "-9999px";
+  div.style.width = `${textarea.clientWidth}px`;
+
+  for (const property of TEXTAREA_CARET_STYLE_PROPERTIES) {
+    div.style.setProperty(property, style.getPropertyValue(property));
+  }
+
+  div.textContent = textarea.value.slice(0, position);
+  if (div.textContent.endsWith("\n")) {
+    div.textContent += "\u200b";
+  }
+
+  const span = document.createElement("span");
+  span.textContent = textarea.value.slice(position) || "\u200b";
+  div.appendChild(span);
+  document.body.appendChild(div);
+
+  const coordinates = {
+    left: span.offsetLeft - textarea.scrollLeft,
+    top: span.offsetTop - textarea.scrollTop + getTextareaLineHeight(style),
+  };
+
+  document.body.removeChild(div);
+  return coordinates;
+}
 
 function downloadMarkdownFile(filename: string, content: string) {
   const blob = new Blob([content], { type: "text/markdown;charset=utf-8" });
@@ -116,6 +296,7 @@ function downloadMarkdownFile(filename: string, content: string) {
 
 export function ChatPanel({
   slug,
+  agents = [],
   attachmentsEnabled = true,
   sessions,
   messages,
@@ -150,6 +331,7 @@ export function ChatPanel({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const isStuckToBottomRef = useRef(true);
+  const composerRef = useRef<HTMLDivElement>(null);
   const chatContentStyle = useMemo(
     () => ({
       '--workspace-chat-font-family': chatFontFamily === 'serif'
@@ -169,7 +351,11 @@ export function ChatPanel({
   const titleInputRef = useRef<HTMLInputElement>(null);
   const preventSessionMenuAutoFocusRef = useRef(false);
   const ignoreNextTitleBlurRef = useRef(false);
+  const selectionRangeRef = useRef<TextSelectionRange>({ start: 0, end: 0 });
+  const pendingSelectionRangeRef = useRef<TextSelectionRange | null>(null);
   const [inputValue, setInputValue] = useState("");
+  const [agentMentionAutocomplete, setAgentMentionAutocomplete] =
+    useState<AgentMentionAutocompleteState | null>(null);
   const [modelSearch, setModelSearch] = useState("");
   const [isModelMenuOpen, setIsModelMenuOpen] = useState(false);
   const [attachments, setAttachments] = useState<WorkspaceAttachment[]>([]);
@@ -226,6 +412,115 @@ export function ChatPanel({
     activeSession && editingSessionId === activeSession.id
   );
   const canFocusComposer = !isReadOnly && !isStartingNewSession && Boolean(onSendMessage);
+  const mentionableAgents = useMemo(
+    () => agents.filter((agent) => !agent.isPrimary),
+    [agents]
+  );
+
+  const syncTextareaSelection = useCallback((textarea?: HTMLTextAreaElement | null) => {
+    const target = textarea ?? textareaRef.current;
+    if (!target) return;
+
+    selectionRangeRef.current = {
+      start: target.selectionStart ?? target.value.length,
+      end: target.selectionEnd ?? target.value.length,
+    };
+  }, []);
+
+  const updateAgentMentionAutocomplete = useCallback(
+    (value: string, selection: TextSelectionRange) => {
+      if (isReadOnly || mentionableAgents.length === 0 || selection.start !== selection.end) {
+        setAgentMentionAutocomplete(null);
+        return;
+      }
+
+      const match = findAgentMentionMatch(value, selection.end);
+      if (!match) {
+        setAgentMentionAutocomplete(null);
+        return;
+      }
+
+      const suggestions = buildAgentMentionSuggestions(mentionableAgents, match.query);
+      if (suggestions.length === 0) {
+        setAgentMentionAutocomplete(null);
+        return;
+      }
+
+      const textarea = textareaRef.current;
+      const composer = composerRef.current;
+      if (!textarea || !composer) {
+        setAgentMentionAutocomplete(null);
+        return;
+      }
+
+      const textareaRect = textarea.getBoundingClientRect();
+      const composerRect = composer.getBoundingClientRect();
+      const caret = getTextareaCaretPosition(textarea, match.to);
+      const maxLeft = Math.max(
+        composer.clientWidth - AGENT_MENTION_AUTOCOMPLETE_WIDTH_PX,
+        0
+      );
+
+      setAgentMentionAutocomplete((previous) => ({
+        from: match.from,
+        to: match.to,
+        suggestions,
+        left: Math.min(
+          Math.max(textareaRect.left - composerRect.left + caret.left, 0),
+          maxLeft
+        ),
+        top: textareaRect.top - composerRect.top + caret.top + 8,
+        selectedIndex:
+          previous &&
+          previous.from === match.from &&
+          previous.to === match.to &&
+          previous.selectedIndex < suggestions.length
+            ? previous.selectedIndex
+            : 0,
+      }));
+    },
+    [isReadOnly, mentionableAgents]
+  );
+
+  const restoreComposerSelection = useCallback((selection: TextSelectionRange) => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    textarea.focus();
+    textarea.setSelectionRange(selection.start, selection.end);
+    selectionRangeRef.current = selection;
+    updateAgentMentionAutocomplete(textarea.value, selection);
+  }, [updateAgentMentionAutocomplete]);
+
+  const insertComposerText = useCallback(
+    (text: string, range?: { from: number; to: number }) => {
+      setInputValue((previous) => {
+        const fallbackSelection = selectionRangeRef.current;
+        const rawStart = range?.from ?? fallbackSelection.start;
+        const rawEnd = range?.to ?? fallbackSelection.end;
+        const start = Math.max(0, Math.min(rawStart, previous.length));
+        const end = Math.max(start, Math.min(rawEnd, previous.length));
+        const nextValue = `${previous.slice(0, start)}${text}${previous.slice(end)}`;
+        const nextSelection = {
+          start: start + text.length,
+          end: start + text.length,
+        };
+
+        pendingSelectionRangeRef.current = nextSelection;
+        selectionRangeRef.current = nextSelection;
+        return nextValue;
+      });
+    },
+    []
+  );
+
+  const applyAgentMentionSuggestion = useCallback(
+    (agent: AgentCatalogItem, range?: { from: number; to: number }) => {
+      insertComposerText(`@${agent.id} `, range);
+      setAgentMentionAutocomplete(null);
+    },
+    [insertComposerText]
+  );
 
   const cancelSessionRename = useCallback(() => {
     if (isSavingTitle) return;
@@ -347,6 +642,24 @@ export function ChatPanel({
       cancelAnimationFrame(frameId);
     };
   }, [isModelMenuOpen]);
+
+  useEffect(() => {
+    const pendingSelection = pendingSelectionRangeRef.current;
+    if (!pendingSelection) return;
+
+    const frameId = requestAnimationFrame(() => {
+      restoreComposerSelection(pendingSelection);
+      pendingSelectionRangeRef.current = null;
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
+  }, [inputValue, restoreComposerSelection]);
+
+  useEffect(() => {
+    updateAgentMentionAutocomplete(inputValue, selectionRangeRef.current);
+  }, [inputValue, updateAgentMentionAutocomplete]);
 
   const effectiveContextPaths = useMemo(() => {
     if (contextMode === "off") return [];
@@ -710,14 +1023,13 @@ export function ChatPanel({
   useEffect(() => {
     if (!pendingInsert) return;
     const frameId = requestAnimationFrame(() => {
-      setInputValue((prev) => prev + pendingInsert);
-      textareaRef.current?.focus();
+      insertComposerText(pendingInsert);
       onPendingInsertConsumed?.();
     });
     return () => {
       cancelAnimationFrame(frameId);
     };
-  }, [pendingInsert, onPendingInsertConsumed]);
+  }, [insertComposerText, onPendingInsertConsumed, pendingInsert]);
 
   // --- Smart auto-scroll: only scroll when the user is "stuck" to the bottom ---
   const SCROLL_BOTTOM_THRESHOLD = 60;
@@ -810,12 +1122,59 @@ export function ChatPanel({
     isUploadingAttachment,
   ]);
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (agentMentionAutocomplete && agentMentionAutocomplete.suggestions.length > 0) {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setAgentMentionAutocomplete((previous) => {
+          if (!previous) return null;
+          return {
+            ...previous,
+            selectedIndex: (previous.selectedIndex + 1) % previous.suggestions.length,
+          };
+        });
+        return;
+      }
+
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setAgentMentionAutocomplete((previous) => {
+          if (!previous) return null;
+          return {
+            ...previous,
+            selectedIndex:
+              (previous.selectedIndex - 1 + previous.suggestions.length) %
+              previous.suggestions.length,
+          };
+        });
+        return;
+      }
+
+      if (event.key === "Enter" || event.key === "Tab") {
+        event.preventDefault();
+        const selected =
+          agentMentionAutocomplete.suggestions[agentMentionAutocomplete.selectedIndex];
+        if (selected) {
+          applyAgentMentionSuggestion(selected, {
+            from: agentMentionAutocomplete.from,
+            to: agentMentionAutocomplete.to,
+          });
+        }
+        return;
+      }
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setAgentMentionAutocomplete(null);
+        return;
+      }
+    }
+
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
       handleSend();
     }
-  }, [handleSend]);
+  }, [agentMentionAutocomplete, applyAgentMentionSuggestion, handleSend]);
 
   useEffect(() => {
     const textarea = textareaRef.current;
@@ -830,9 +1189,38 @@ export function ChatPanel({
     textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`;
   }, [inputValue]);
 
-  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setInputValue(e.target.value);
-  }, []);
+  const handleInputChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    syncTextareaSelection(event.currentTarget);
+    setInputValue(event.target.value);
+  }, [syncTextareaSelection]);
+
+  const handleTextareaSelectionChange = useCallback(
+    (event: SyntheticEvent<HTMLTextAreaElement>) => {
+      syncTextareaSelection(event.currentTarget);
+      updateAgentMentionAutocomplete(
+        event.currentTarget.value,
+        selectionRangeRef.current
+      );
+    },
+    [syncTextareaSelection, updateAgentMentionAutocomplete]
+  );
+
+  const handleTextareaKeyUp = useCallback(
+    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+      if (
+        event.key === "ArrowDown" ||
+        event.key === "ArrowUp" ||
+        event.key === "Enter" ||
+        event.key === "Escape" ||
+        event.key === "Tab"
+      ) {
+        return;
+      }
+
+      handleTextareaSelectionChange(event);
+    },
+    [handleTextareaSelectionChange]
+  );
 
   // Get the current status from the last pending message (if any).
   // Only show transient statuses (thinking, tool calls) while actively streaming.
@@ -1152,7 +1540,7 @@ export function ChatPanel({
           </p>
         )}
         
-        <div className="flex items-end gap-1.5 rounded-xl border border-white/10 bg-foreground/5 px-2 py-2">
+        <div ref={composerRef} className="relative flex items-end gap-1.5 rounded-xl border border-white/10 bg-foreground/5 px-2 py-2">
           {attachmentsEnabled && (
             <>
               <input
@@ -1273,12 +1661,54 @@ export function ChatPanel({
             value={inputValue}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
+            onClick={handleTextareaSelectionChange}
             onPaste={handleTextareaPaste}
+            onSelect={handleTextareaSelectionChange}
+            onKeyUp={handleTextareaKeyUp}
             className="max-h-[200px] flex-1 resize-none bg-transparent px-1.5 py-1.5 text-sm leading-5 text-foreground outline-none placeholder:text-muted-foreground/60"
             placeholder="Type a message..."
             disabled={isStartingNewSession || !onSendMessage}
             rows={1}
           />
+          {agentMentionAutocomplete ? (
+            <div
+              className="pointer-events-none absolute z-20"
+              role="presentation"
+              style={{
+                left: agentMentionAutocomplete.left,
+                top: agentMentionAutocomplete.top,
+              }}
+            >
+              <div className="pointer-events-auto min-w-[240px] max-w-[320px] rounded-md border border-white/10 bg-background/95 p-1 shadow-lg backdrop-blur-sm">
+                {agentMentionAutocomplete.suggestions.map((agent, index) => (
+                  <button
+                    key={agent.id}
+                    type="button"
+                    className={cn(
+                      "flex w-full items-center justify-between gap-3 rounded-sm px-2 py-1.5 text-left text-xs",
+                      index === agentMentionAutocomplete.selectedIndex
+                        ? "bg-primary/15 text-primary"
+                        : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
+                    )}
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      applyAgentMentionSuggestion(agent, {
+                        from: agentMentionAutocomplete.from,
+                        to: agentMentionAutocomplete.to,
+                      });
+                    }}
+                  >
+                    <span className="min-w-0 flex-1 truncate font-medium">
+                      {agent.displayName}
+                    </span>
+                    <span className="shrink-0 text-[10px] text-muted-foreground">
+                      @{agent.id}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
           <Button
             size="icon"
             className={cn(

--- a/apps/web/src/components/workspace/chat-panel.tsx
+++ b/apps/web/src/components/workspace/chat-panel.tsx
@@ -10,6 +10,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type SyntheticEvent,
 } from "react";
+import { createPortal } from "react-dom";
 import {
   CaretDown,
   CheckCircle,
@@ -119,6 +120,8 @@ type AgentMentionAutocompleteState = {
 const MAX_CONTEXT_PATHS_PER_MESSAGE = 20;
 const MAX_AGENT_MENTION_SUGGESTIONS = 8;
 const AGENT_MENTION_AUTOCOMPLETE_WIDTH_PX = 320;
+const AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_GAP_PX = 8;
+const AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX = 12;
 
 const TEXTAREA_CARET_STYLE_PROPERTIES = [
   "box-sizing",
@@ -331,7 +334,6 @@ export function ChatPanel({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const isStuckToBottomRef = useRef(true);
-  const composerRef = useRef<HTMLDivElement>(null);
   const chatContentStyle = useMemo(
     () => ({
       '--workspace-chat-font-family': chatFontFamily === 'serif'
@@ -447,18 +449,18 @@ export function ChatPanel({
       }
 
       const textarea = textareaRef.current;
-      const composer = composerRef.current;
-      if (!textarea || !composer) {
+      if (!textarea) {
         setAgentMentionAutocomplete(null);
         return;
       }
 
       const textareaRect = textarea.getBoundingClientRect();
-      const composerRect = composer.getBoundingClientRect();
       const caret = getTextareaCaretPosition(textarea, match.to);
       const maxLeft = Math.max(
-        composer.clientWidth - AGENT_MENTION_AUTOCOMPLETE_WIDTH_PX,
-        0
+        window.innerWidth -
+          AGENT_MENTION_AUTOCOMPLETE_WIDTH_PX -
+          AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX,
+        AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX
       );
 
       setAgentMentionAutocomplete((previous) => ({
@@ -466,10 +468,13 @@ export function ChatPanel({
         to: match.to,
         suggestions,
         left: Math.min(
-          Math.max(textareaRect.left - composerRect.left + caret.left, 0),
+          Math.max(
+            textareaRect.left + caret.left,
+            AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX
+          ),
           maxLeft
         ),
-        top: textareaRect.top - composerRect.top + caret.top + 8,
+        top: textareaRect.top + caret.top,
         selectedIndex:
           previous &&
           previous.from === match.from &&
@@ -1540,7 +1545,7 @@ export function ChatPanel({
           </p>
         )}
         
-        <div ref={composerRef} className="relative flex items-end gap-1.5 rounded-xl border border-white/10 bg-foreground/5 px-2 py-2">
+        <div className="relative flex items-end gap-1.5 rounded-xl border border-white/10 bg-foreground/5 px-2 py-2">
           {attachmentsEnabled && (
             <>
               <input
@@ -1670,45 +1675,55 @@ export function ChatPanel({
             disabled={isStartingNewSession || !onSendMessage}
             rows={1}
           />
-          {agentMentionAutocomplete ? (
-            <div
-              className="pointer-events-none absolute z-20"
-              role="presentation"
-              style={{
-                left: agentMentionAutocomplete.left,
-                top: agentMentionAutocomplete.top,
-              }}
-            >
-              <div className="pointer-events-auto min-w-[240px] max-w-[320px] rounded-md border border-white/10 bg-background/95 p-1 shadow-lg backdrop-blur-sm">
-                {agentMentionAutocomplete.suggestions.map((agent, index) => (
-                  <button
-                    key={agent.id}
-                    type="button"
-                    className={cn(
-                      "flex w-full items-center justify-between gap-3 rounded-sm px-2 py-1.5 text-left text-xs",
-                      index === agentMentionAutocomplete.selectedIndex
-                        ? "bg-primary/15 text-primary"
-                        : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
-                    )}
-                    onMouseDown={(event) => {
-                      event.preventDefault();
-                      applyAgentMentionSuggestion(agent, {
-                        from: agentMentionAutocomplete.from,
-                        to: agentMentionAutocomplete.to,
-                      });
+          {agentMentionAutocomplete && typeof document !== "undefined"
+            ? createPortal(
+                <div
+                  className="pointer-events-none z-50"
+                  role="presentation"
+                  style={{
+                    position: "fixed",
+                    left: agentMentionAutocomplete.left,
+                    top: agentMentionAutocomplete.top,
+                    transform: `translateY(calc(-100% - ${AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_GAP_PX}px))`,
+                  }}
+                >
+                  <div
+                    className="pointer-events-auto rounded-md border border-white/10 bg-background/95 p-1 shadow-lg backdrop-blur-sm"
+                    style={{
+                      width: `min(${AGENT_MENTION_AUTOCOMPLETE_WIDTH_PX}px, calc(100vw - ${AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX * 2}px))`,
                     }}
                   >
-                    <span className="min-w-0 flex-1 truncate font-medium">
-                      {agent.displayName}
-                    </span>
-                    <span className="shrink-0 text-[10px] text-muted-foreground">
-                      @{agent.id}
-                    </span>
-                  </button>
-                ))}
-              </div>
-            </div>
-          ) : null}
+                    {agentMentionAutocomplete.suggestions.map((agent, index) => (
+                      <button
+                        key={agent.id}
+                        type="button"
+                        className={cn(
+                          "flex w-full items-center justify-between gap-3 rounded-sm px-2 py-1.5 text-left text-xs",
+                          index === agentMentionAutocomplete.selectedIndex
+                            ? "bg-primary/15 text-primary"
+                            : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
+                        )}
+                        onMouseDown={(event) => {
+                          event.preventDefault();
+                          applyAgentMentionSuggestion(agent, {
+                            from: agentMentionAutocomplete.from,
+                            to: agentMentionAutocomplete.to,
+                          });
+                        }}
+                      >
+                        <span className="min-w-0 flex-1 truncate font-medium">
+                          {agent.displayName}
+                        </span>
+                        <span className="shrink-0 text-[10px] text-muted-foreground">
+                          @{agent.id}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>,
+                document.body
+              )
+            : null}
           <Button
             size="icon"
             className={cn(

--- a/apps/web/src/components/workspace/chat-panel/__tests__/agent-mention-autocomplete.test.ts
+++ b/apps/web/src/components/workspace/chat-panel/__tests__/agent-mention-autocomplete.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { getAgentMentionAutocompletePosition } from "@/lib/workspace-agent-mentions";
+
+describe("getAgentMentionAutocompletePosition", () => {
+  it("renders below the caret when there is not enough room above", () => {
+    expect(
+      getAgentMentionAutocompletePosition({
+        anchorLeft: 24,
+        anchorTop: 18,
+        popoverWidth: 220,
+        popoverHeight: 160,
+        viewportWidth: 800,
+        viewportHeight: 600,
+      })
+    ).toEqual({
+      left: 24,
+      top: 26,
+      placement: "bottom",
+    });
+  });
+
+  it("renders above the caret when there is not enough room below", () => {
+    expect(
+      getAgentMentionAutocompletePosition({
+        anchorLeft: 24,
+        anchorTop: 560,
+        popoverWidth: 220,
+        popoverHeight: 160,
+        viewportWidth: 800,
+        viewportHeight: 600,
+      })
+    ).toEqual({
+      left: 24,
+      top: 392,
+      placement: "top",
+    });
+  });
+
+  it("clamps the popover inside the viewport when space is tight", () => {
+    expect(
+      getAgentMentionAutocompletePosition({
+        anchorLeft: 500,
+        anchorTop: 15,
+        popoverWidth: 200,
+        popoverHeight: 140,
+        viewportWidth: 640,
+        viewportHeight: 170,
+      })
+    ).toEqual({
+      left: 428,
+      top: 18,
+      placement: "bottom",
+    });
+  });
+});

--- a/apps/web/src/components/workspace/chat-panel/agent-mention-autocomplete.tsx
+++ b/apps/web/src/components/workspace/chat-panel/agent-mention-autocomplete.tsx
@@ -1,0 +1,139 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import type { AgentCatalogItem } from "@/hooks/use-workspace";
+import {
+  AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX,
+  AGENT_MENTION_AUTOCOMPLETE_WIDTH_PX,
+  getAgentMentionAutocompletePosition,
+  getEstimatedAgentMentionAutocompleteHeight,
+  type AgentMentionAutocompletePosition,
+  type AgentMentionAutocompleteState,
+} from "@/lib/workspace-agent-mentions";
+import { cn } from "@/lib/utils";
+
+type AgentMentionAutocompleteProps = {
+  autocomplete: AgentMentionAutocompleteState | null;
+  onSelect: (agent: AgentCatalogItem, range: { from: number; to: number }) => void;
+};
+
+export function AgentMentionAutocomplete({
+  autocomplete,
+  onSelect,
+}: AgentMentionAutocompleteProps) {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState<
+    | (AgentMentionAutocompletePosition & {
+        anchorLeft: number;
+        anchorTop: number;
+        from: number;
+        suggestionCount: number;
+        to: number;
+        viewportHeight: number;
+        viewportWidth: number;
+      })
+    | null
+  >(null);
+
+  useLayoutEffect(() => {
+    if (!autocomplete || typeof window === "undefined") return;
+
+    const popover = popoverRef.current;
+    if (!popover) return;
+
+    const rect = popover.getBoundingClientRect();
+    const nextPosition = getAgentMentionAutocompletePosition({
+      anchorLeft: autocomplete.left,
+      anchorTop: autocomplete.top,
+      popoverWidth: rect.width,
+      popoverHeight: rect.height,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    });
+
+    setPosition({
+      ...nextPosition,
+      anchorLeft: autocomplete.left,
+      anchorTop: autocomplete.top,
+      from: autocomplete.from,
+      suggestionCount: autocomplete.suggestions.length,
+      to: autocomplete.to,
+      viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth,
+    });
+  }, [autocomplete]);
+
+  if (!autocomplete || typeof document === "undefined") return null;
+
+  const fallbackPosition = getAgentMentionAutocompletePosition({
+    anchorLeft: autocomplete.left,
+    anchorTop: autocomplete.top,
+    popoverWidth: Math.min(
+      AGENT_MENTION_AUTOCOMPLETE_WIDTH_PX,
+      window.innerWidth - AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX * 2
+    ),
+    popoverHeight: Math.min(
+      getEstimatedAgentMentionAutocompleteHeight(autocomplete.suggestions.length),
+      window.innerHeight - AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX * 2
+    ),
+    viewportWidth: window.innerWidth,
+    viewportHeight: window.innerHeight,
+  });
+
+  const isPositionCurrent =
+    position !== null &&
+    position.anchorLeft === autocomplete.left &&
+    position.anchorTop === autocomplete.top &&
+    position.from === autocomplete.from &&
+    position.suggestionCount === autocomplete.suggestions.length &&
+    position.to === autocomplete.to &&
+    position.viewportHeight === window.innerHeight &&
+    position.viewportWidth === window.innerWidth;
+  const resolvedPosition = isPositionCurrent ? position : fallbackPosition;
+
+  return createPortal(
+    <div
+      className="pointer-events-none z-50"
+      role="presentation"
+      style={{
+        position: "fixed",
+        left: resolvedPosition.left,
+        top: resolvedPosition.top,
+        visibility: isPositionCurrent ? "visible" : "hidden",
+      }}
+    >
+      <div
+        ref={popoverRef}
+        className="pointer-events-auto overflow-y-auto rounded-md border border-white/10 bg-background/95 p-1 shadow-lg backdrop-blur-sm"
+        style={{
+          width: `min(${AGENT_MENTION_AUTOCOMPLETE_WIDTH_PX}px, calc(100vw - ${AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX * 2}px))`,
+          maxHeight: `calc(100vh - ${AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX * 2}px)`,
+        }}
+      >
+        {autocomplete.suggestions.map((agent, index) => (
+          <button
+            key={agent.id}
+            type="button"
+            className={cn(
+              "flex w-full items-center justify-between gap-3 rounded-sm px-2 py-1.5 text-left text-xs",
+              index === autocomplete.selectedIndex
+                ? "bg-primary/15 text-primary"
+                : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
+            )}
+            onMouseDown={(event) => {
+              event.preventDefault();
+              onSelect(agent, {
+                from: autocomplete.from,
+                to: autocomplete.to,
+              });
+            }}
+          >
+            <span className="min-w-0 flex-1 truncate font-medium">{agent.displayName}</span>
+            <span className="shrink-0 text-[10px] text-muted-foreground">@{agent.id}</span>
+          </button>
+        ))}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/apps/web/src/components/workspace/workspace-shell.tsx
+++ b/apps/web/src/components/workspace/workspace-shell.tsx
@@ -7,7 +7,7 @@ import { ChatCircle, Circle, Compass, File } from "@phosphor-icons/react";
 import { ensureInstanceRunningAction } from "@/actions/spawner";
 import type { SyncKbResult } from "@/app/api/instances/[slug]/sync-kb/route";
 import { useWorkspaceTheme } from "@/contexts/workspace-theme-context";
-import { useWorkspace } from "@/hooks/use-workspace";
+import { useWorkspace, type AgentCatalogItem } from "@/hooks/use-workspace";
 import type { WorkspaceFileNode, WorkspaceSession } from "@/lib/opencode/types";
 import {
   isProtectedWorkspacePath,
@@ -1078,12 +1078,12 @@ export function WorkspaceShell({
     value: string;
   } | null>(null);
 
-  const handleSelectAgent = useCallback((agent: { displayName: string }) => {
+  const handleSelectAgent = useCallback((agent: AgentCatalogItem) => {
     if (!workspace.activeSessionId) return;
 
     setPendingInsert({
       sessionId: workspace.activeSessionId,
-      value: "@" + agent.displayName + " ",
+      value: `@${agent.id} `,
     });
   }, [workspace.activeSessionId]);
 
@@ -1334,6 +1334,7 @@ export function WorkspaceShell({
     <ChatPanel
       key={workspace.activeSessionId ?? "no-session"}
       slug={slug}
+      agents={workspace.agentCatalog}
       attachmentsEnabled={workspaceAgentEnabled}
       sessions={uiSessions}
       messages={uiMessages}

--- a/apps/web/src/hooks/use-agent-mention-autocomplete.ts
+++ b/apps/web/src/hooks/use-agent-mention-autocomplete.ts
@@ -1,0 +1,292 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type Dispatch,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type RefObject,
+  type SetStateAction,
+  type SyntheticEvent,
+} from "react";
+
+import type { AgentCatalogItem } from "@/hooks/use-workspace";
+import {
+  buildAgentMentionSuggestions,
+  findAgentMentionMatch,
+  getTextareaCaretPosition,
+  type AgentMentionAutocompleteState,
+} from "@/lib/workspace-agent-mentions";
+
+type TextSelectionRange = {
+  start: number;
+  end: number;
+};
+
+type UseAgentMentionAutocompleteOptions = {
+  agents: AgentCatalogItem[];
+  inputValue: string;
+  isReadOnly: boolean;
+  setInputValue: Dispatch<SetStateAction<string>>;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+};
+
+type UseAgentMentionAutocompleteResult = {
+  agentMentionAutocomplete: AgentMentionAutocompleteState | null;
+  clearAgentMentionAutocomplete: () => void;
+  handleInputChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
+  handleMentionKeyDown: (event: ReactKeyboardEvent<HTMLTextAreaElement>) => boolean;
+  handleTextareaBlur: () => void;
+  handleTextareaKeyUp: (event: ReactKeyboardEvent<HTMLTextAreaElement>) => void;
+  handleTextareaSelectionChange: (event: SyntheticEvent<HTMLTextAreaElement>) => void;
+  insertComposerText: (text: string, range?: { from: number; to: number }) => void;
+  onAgentMentionSelect: (agent: AgentCatalogItem, range: { from: number; to: number }) => void;
+};
+
+export function useAgentMentionAutocomplete({
+  agents,
+  inputValue,
+  isReadOnly,
+  setInputValue,
+  textareaRef,
+}: UseAgentMentionAutocompleteOptions): UseAgentMentionAutocompleteResult {
+  const [agentMentionAutocomplete, setAgentMentionAutocomplete] =
+    useState<AgentMentionAutocompleteState | null>(null);
+  const selectionRangeRef = useRef<TextSelectionRange>({ start: 0, end: 0 });
+  const pendingSelectionRangeRef = useRef<TextSelectionRange | null>(null);
+
+  const mentionableAgents = useMemo(
+    () => agents.filter((agent) => !agent.isPrimary),
+    [agents]
+  );
+
+  const syncTextareaSelection = useCallback(
+    (textarea?: HTMLTextAreaElement | null) => {
+      const target = textarea ?? textareaRef.current;
+      if (!target) return;
+
+      selectionRangeRef.current = {
+        start: target.selectionStart ?? target.value.length,
+        end: target.selectionEnd ?? target.value.length,
+      };
+    },
+    [textareaRef]
+  );
+
+  const updateAgentMentionAutocomplete = useCallback(
+    (value: string, selection: TextSelectionRange) => {
+      if (isReadOnly || mentionableAgents.length === 0 || selection.start !== selection.end) {
+        setAgentMentionAutocomplete(null);
+        return;
+      }
+
+      const match = findAgentMentionMatch(value, selection.end);
+      if (!match) {
+        setAgentMentionAutocomplete(null);
+        return;
+      }
+
+      const suggestions = buildAgentMentionSuggestions(mentionableAgents, match.query);
+      if (suggestions.length === 0) {
+        setAgentMentionAutocomplete(null);
+        return;
+      }
+
+      const textarea = textareaRef.current;
+      if (!textarea) {
+        setAgentMentionAutocomplete(null);
+        return;
+      }
+
+      const textareaRect = textarea.getBoundingClientRect();
+      const caret = getTextareaCaretPosition(textarea, match.to);
+
+      setAgentMentionAutocomplete((previous) => ({
+        from: match.from,
+        to: match.to,
+        suggestions,
+        left: textareaRect.left + caret.left,
+        top: textareaRect.top + caret.top,
+        selectedIndex:
+          previous &&
+          previous.from === match.from &&
+          previous.to === match.to &&
+          previous.selectedIndex < suggestions.length
+            ? previous.selectedIndex
+            : 0,
+      }));
+    },
+    [isReadOnly, mentionableAgents, textareaRef]
+  );
+
+  const restoreComposerSelection = useCallback(
+    (selection: TextSelectionRange) => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+
+      textarea.focus();
+      textarea.setSelectionRange(selection.start, selection.end);
+      selectionRangeRef.current = selection;
+      updateAgentMentionAutocomplete(textarea.value, selection);
+    },
+    [textareaRef, updateAgentMentionAutocomplete]
+  );
+
+  const insertComposerText = useCallback(
+    (text: string, range?: { from: number; to: number }) => {
+      setInputValue((previous) => {
+        const fallbackSelection = selectionRangeRef.current;
+        const rawStart = range?.from ?? fallbackSelection.start;
+        const rawEnd = range?.to ?? fallbackSelection.end;
+        const start = Math.max(0, Math.min(rawStart, previous.length));
+        const end = Math.max(start, Math.min(rawEnd, previous.length));
+        const nextValue = `${previous.slice(0, start)}${text}${previous.slice(end)}`;
+        const nextSelection = {
+          start: start + text.length,
+          end: start + text.length,
+        };
+
+        pendingSelectionRangeRef.current = nextSelection;
+        selectionRangeRef.current = nextSelection;
+        return nextValue;
+      });
+    },
+    [setInputValue]
+  );
+
+  const onAgentMentionSelect = useCallback(
+    (agent: AgentCatalogItem, range: { from: number; to: number }) => {
+      insertComposerText(`@${agent.id} `, range);
+      setAgentMentionAutocomplete(null);
+    },
+    [insertComposerText]
+  );
+
+  useEffect(() => {
+    const pendingSelection = pendingSelectionRangeRef.current;
+    if (!pendingSelection) return;
+
+    const frameId = requestAnimationFrame(() => {
+      restoreComposerSelection(pendingSelection);
+      pendingSelectionRangeRef.current = null;
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
+  }, [inputValue, restoreComposerSelection]);
+
+  const clearAgentMentionAutocomplete = useCallback(() => {
+    setAgentMentionAutocomplete(null);
+  }, []);
+
+  const handleInputChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      syncTextareaSelection(event.currentTarget);
+      setInputValue(event.target.value);
+      updateAgentMentionAutocomplete(event.target.value, selectionRangeRef.current);
+    },
+    [setInputValue, syncTextareaSelection, updateAgentMentionAutocomplete]
+  );
+
+  const handleTextareaSelectionChange = useCallback(
+    (event: SyntheticEvent<HTMLTextAreaElement>) => {
+      syncTextareaSelection(event.currentTarget);
+      updateAgentMentionAutocomplete(event.currentTarget.value, selectionRangeRef.current);
+    },
+    [syncTextareaSelection, updateAgentMentionAutocomplete]
+  );
+
+  const handleTextareaKeyUp = useCallback(
+    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+      if (
+        event.key === "ArrowDown" ||
+        event.key === "ArrowUp" ||
+        event.key === "Enter" ||
+        event.key === "Escape" ||
+        event.key === "Tab"
+      ) {
+        return;
+      }
+
+      handleTextareaSelectionChange(event);
+    },
+    [handleTextareaSelectionChange]
+  );
+
+  const handleMentionKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+      if (!agentMentionAutocomplete || agentMentionAutocomplete.suggestions.length === 0) {
+        return false;
+      }
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setAgentMentionAutocomplete((previous) => {
+          if (!previous) return null;
+
+          return {
+            ...previous,
+            selectedIndex: (previous.selectedIndex + 1) % previous.suggestions.length,
+          };
+        });
+        return true;
+      }
+
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setAgentMentionAutocomplete((previous) => {
+          if (!previous) return null;
+
+          return {
+            ...previous,
+            selectedIndex:
+              (previous.selectedIndex - 1 + previous.suggestions.length) %
+              previous.suggestions.length,
+          };
+        });
+        return true;
+      }
+
+      if (event.key === "Enter" || event.key === "Tab") {
+        event.preventDefault();
+        const selected =
+          agentMentionAutocomplete.suggestions[agentMentionAutocomplete.selectedIndex];
+        if (selected) {
+          onAgentMentionSelect(selected, {
+            from: agentMentionAutocomplete.from,
+            to: agentMentionAutocomplete.to,
+          });
+        }
+        return true;
+      }
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setAgentMentionAutocomplete(null);
+        return true;
+      }
+
+      return false;
+    },
+    [agentMentionAutocomplete, onAgentMentionSelect]
+  );
+
+  const handleTextareaBlur = useCallback(() => {
+    clearAgentMentionAutocomplete();
+  }, [clearAgentMentionAutocomplete]);
+
+  return {
+    agentMentionAutocomplete,
+    clearAgentMentionAutocomplete,
+    handleInputChange,
+    handleMentionKeyDown,
+    handleTextareaBlur,
+    handleTextareaKeyUp,
+    handleTextareaSelectionChange,
+    insertComposerText,
+    onAgentMentionSelect,
+  };
+}

--- a/apps/web/src/lib/workspace-agent-mentions.ts
+++ b/apps/web/src/lib/workspace-agent-mentions.ts
@@ -1,0 +1,256 @@
+import type { AgentCatalogItem } from "@/hooks/use-workspace";
+
+export type AgentMentionAutocompletePlacement = "top" | "bottom";
+
+export type AgentMentionAutocompletePosition = {
+  left: number;
+  top: number;
+  placement: AgentMentionAutocompletePlacement;
+};
+
+export type AgentMentionAutocompleteState = {
+  from: number;
+  to: number;
+  left: number;
+  top: number;
+  selectedIndex: number;
+  suggestions: AgentCatalogItem[];
+};
+
+type AgentMentionAutocompletePositionParams = {
+  anchorLeft: number;
+  anchorTop: number;
+  popoverWidth: number;
+  popoverHeight: number;
+  viewportWidth: number;
+  viewportHeight: number;
+};
+
+const MAX_AGENT_MENTION_SUGGESTIONS = 8;
+const AGENT_MENTION_AUTOCOMPLETE_ITEM_HEIGHT_PX = 30;
+const AGENT_MENTION_AUTOCOMPLETE_CHROME_HEIGHT_PX = 10;
+
+export const AGENT_MENTION_AUTOCOMPLETE_WIDTH_PX = 320;
+export const AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_GAP_PX = 8;
+export const AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX = 12;
+
+const TEXTAREA_CARET_STYLE_PROPERTIES = [
+  "box-sizing",
+  "width",
+  "height",
+  "overflow-x",
+  "overflow-y",
+  "border-top-width",
+  "border-right-width",
+  "border-bottom-width",
+  "border-left-width",
+  "padding-top",
+  "padding-right",
+  "padding-bottom",
+  "padding-left",
+  "font-style",
+  "font-variant",
+  "font-weight",
+  "font-stretch",
+  "font-size",
+  "font-size-adjust",
+  "line-height",
+  "font-family",
+  "letter-spacing",
+  "text-align",
+  "text-indent",
+  "text-transform",
+  "text-decoration",
+  "text-rendering",
+  "text-overflow",
+  "text-wrap-mode",
+  "text-wrap-style",
+  "tab-size",
+  "white-space",
+  "word-break",
+  "word-spacing",
+  "scrollbar-gutter",
+] as const;
+
+function clamp(value: number, min: number, max: number): number {
+  if (max <= min) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+function normalizeAgentSearchValue(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+function getTextareaLineHeight(style: CSSStyleDeclaration): number {
+  const parsed = Number.parseFloat(style.lineHeight);
+  if (Number.isFinite(parsed)) return parsed;
+
+  const fontSize = Number.parseFloat(style.fontSize);
+  if (Number.isFinite(fontSize)) return fontSize * 1.4;
+
+  return 20;
+}
+
+export function getEstimatedAgentMentionAutocompleteHeight(suggestionCount: number): number {
+  return (
+    AGENT_MENTION_AUTOCOMPLETE_CHROME_HEIGHT_PX +
+    suggestionCount * AGENT_MENTION_AUTOCOMPLETE_ITEM_HEIGHT_PX
+  );
+}
+
+export function buildAgentMentionSuggestions(
+  agents: AgentCatalogItem[],
+  query: string
+): AgentCatalogItem[] {
+  const rawQuery = query.trim().toLowerCase();
+  const normalizedQuery = normalizeAgentSearchValue(query);
+
+  const scored = agents
+    .map((agent) => {
+      const id = agent.id.toLowerCase();
+      const displayName = agent.displayName.toLowerCase();
+      const normalizedId = normalizeAgentSearchValue(agent.id);
+      const normalizedDisplayName = normalizeAgentSearchValue(agent.displayName);
+
+      let score = 0;
+      if (rawQuery.length > 0) {
+        if (id.startsWith(rawQuery)) score = 0;
+        else if (displayName.startsWith(rawQuery)) score = 1;
+        else if (normalizedId.startsWith(normalizedQuery)) score = 2;
+        else if (normalizedDisplayName.startsWith(normalizedQuery)) score = 3;
+        else if (id.includes(rawQuery)) score = 4;
+        else if (displayName.includes(rawQuery)) score = 5;
+        else if (normalizedId.includes(normalizedQuery)) score = 6;
+        else if (normalizedDisplayName.includes(normalizedQuery)) score = 7;
+        else return null;
+      }
+
+      return { agent, score };
+    })
+    .filter((entry): entry is { agent: AgentCatalogItem; score: number } => entry !== null)
+    .sort((left, right) => {
+      if (left.score !== right.score) {
+        return left.score - right.score;
+      }
+
+      return left.agent.displayName.localeCompare(right.agent.displayName);
+    });
+
+  return scored.slice(0, MAX_AGENT_MENTION_SUGGESTIONS).map((entry) => entry.agent);
+}
+
+export function findAgentMentionMatch(
+  value: string,
+  caretPosition: number
+): { from: number; to: number; query: string } | null {
+  const clampedCaret = Math.max(0, Math.min(caretPosition, value.length));
+  const beforeCaret = value.slice(0, clampedCaret);
+  const atIndex = beforeCaret.lastIndexOf("@");
+
+  if (atIndex === -1) return null;
+  if (atIndex > 0 && !/\s/.test(beforeCaret[atIndex - 1] ?? "")) {
+    return null;
+  }
+
+  const beforeQuery = beforeCaret.slice(atIndex + 1);
+  if (/\s|@/.test(beforeQuery)) {
+    return null;
+  }
+
+  const afterCaret = value.slice(clampedCaret).match(/^[^\s@]*/)?.[0] ?? "";
+  const query = `${beforeQuery}${afterCaret}`;
+
+  return {
+    from: atIndex,
+    to: clampedCaret + afterCaret.length,
+    query,
+  };
+}
+
+export function getTextareaCaretPosition(
+  textarea: HTMLTextAreaElement,
+  position: number
+): { left: number; top: number } {
+  const div = document.createElement("div");
+  const style = window.getComputedStyle(textarea);
+
+  div.setAttribute("data-agent-mention-caret", "true");
+  div.style.position = "absolute";
+  div.style.visibility = "hidden";
+  div.style.pointerEvents = "none";
+  div.style.whiteSpace = "pre-wrap";
+  div.style.wordBreak = "break-word";
+  div.style.overflow = "hidden";
+  div.style.top = "0";
+  div.style.left = "-9999px";
+  div.style.width = `${textarea.clientWidth}px`;
+
+  for (const property of TEXTAREA_CARET_STYLE_PROPERTIES) {
+    div.style.setProperty(property, style.getPropertyValue(property));
+  }
+
+  div.textContent = textarea.value.slice(0, position);
+  if (div.textContent.endsWith("\n")) {
+    div.textContent += "\u200b";
+  }
+
+  const span = document.createElement("span");
+  span.textContent = textarea.value.slice(position) || "\u200b";
+  div.appendChild(span);
+  document.body.appendChild(div);
+
+  const coordinates = {
+    left: span.offsetLeft - textarea.scrollLeft,
+    top: span.offsetTop - textarea.scrollTop + getTextareaLineHeight(style),
+  };
+
+  document.body.removeChild(div);
+  return coordinates;
+}
+
+export function getAgentMentionAutocompletePosition({
+  anchorLeft,
+  anchorTop,
+  popoverWidth,
+  popoverHeight,
+  viewportWidth,
+  viewportHeight,
+}: AgentMentionAutocompletePositionParams): AgentMentionAutocompletePosition {
+  const left = clamp(
+    anchorLeft,
+    AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX,
+    viewportWidth - popoverWidth - AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX
+  );
+
+  const availableAbove =
+    anchorTop -
+    AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_GAP_PX -
+    AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX;
+  const availableBelow =
+    viewportHeight -
+    anchorTop -
+    AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_GAP_PX -
+    AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX;
+
+  const placement: AgentMentionAutocompletePlacement =
+    availableBelow >= popoverHeight
+      ? "bottom"
+      : availableAbove >= popoverHeight
+        ? "top"
+        : availableBelow >= availableAbove
+          ? "bottom"
+          : "top";
+
+  const rawTop =
+    placement === "bottom"
+      ? anchorTop + AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_GAP_PX
+      : anchorTop - popoverHeight - AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_GAP_PX;
+
+  const top = clamp(
+    rawTop,
+    AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX,
+    viewportHeight - popoverHeight - AGENT_MENTION_AUTOCOMPLETE_VIEWPORT_PADDING_PX
+  );
+
+  return { left, top, placement };
+}


### PR DESCRIPTION
## Summary
- add `@expert` autocomplete in the workspace composer with keyboard and mouse selection
- insert canonical subagent ids like `@ads-scripts` from the experts panel at the current cursor position
- cover the expert mention flows with composer and workspace shell tests

## Validation
- `pnpm lint`
- `pnpm test`
- `podman build -f Containerfile -t arche-web:test .` (from `apps/web/`)