### PR TITLE
fix(workspace): keep connector gateway tokens stable

### DIFF
--- a/apps/web/src/lib/connectors/gateway-config.ts
+++ b/apps/web/src/lib/connectors/gateway-config.ts
@@ -15,12 +15,6 @@ export function getConnectorGatewayTokenSecret(): string {
   return 'dev-insecure-connector-gateway-secret'
 }
 
-export function getConnectorGatewayTokenTtlSeconds(): number {
-  const raw = process.env.ARCHE_CONNECTOR_GATEWAY_TOKEN_TTL_SECONDS
-  const parsed = raw ? Number(raw) : NaN
-  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 86400
-}
-
 export function getConnectorGatewayBaseUrl(): string {
   const configured = process.env.ARCHE_CONNECTOR_GATEWAY_BASE_URL || DEFAULT_CONNECTOR_GATEWAY_BASE_URL
   return configured.endsWith('/') ? configured.slice(0, -1) : configured

--- a/apps/web/src/lib/connectors/gateway-tokens.ts
+++ b/apps/web/src/lib/connectors/gateway-tokens.ts
@@ -1,15 +1,14 @@
 import crypto from 'node:crypto'
 
-import { getConnectorGatewayTokenSecret, getConnectorGatewayTokenTtlSeconds } from '@/lib/connectors/gateway-config'
+import { getConnectorGatewayTokenSecret } from '@/lib/connectors/gateway-config'
 
 export type ConnectorGatewayTokenPayload = {
   userId: string
   workspaceSlug: string
   connectorId: string
-  exp: number
 }
 
-type ConnectorGatewayTokenInput = Omit<ConnectorGatewayTokenPayload, 'exp'>
+type ConnectorGatewayTokenInput = ConnectorGatewayTokenPayload
 
 function encodePayload(payload: ConnectorGatewayTokenPayload): string {
   return Buffer.from(JSON.stringify(payload)).toString('base64url')
@@ -33,17 +32,12 @@ function isValidPayload(payload: ConnectorGatewayTokenPayload): boolean {
     typeof payload.workspaceSlug === 'string' &&
     payload.workspaceSlug.length > 0 &&
     typeof payload.connectorId === 'string' &&
-    payload.connectorId.length > 0 &&
-    typeof payload.exp === 'number' &&
-    Number.isFinite(payload.exp)
+    payload.connectorId.length > 0
   )
 }
 
 export function issueConnectorGatewayToken(input: ConnectorGatewayTokenInput): string {
-  const ttlSeconds = getConnectorGatewayTokenTtlSeconds()
-  const exp = Math.floor(Date.now() / 1000) + ttlSeconds
-  const payload: ConnectorGatewayTokenPayload = { ...input, exp }
-  const encoded = encodePayload(payload)
+  const encoded = encodePayload(input)
   const signature = signPayload(encoded, getConnectorGatewayTokenSecret())
   return `${encoded}.${signature}`
 }
@@ -71,10 +65,6 @@ export function verifyConnectorGatewayToken(token: string): ConnectorGatewayToke
   const payload = raw as ConnectorGatewayTokenPayload
   if (!isValidPayload(payload)) {
     throw new Error('invalid_token')
-  }
-
-  if (payload.exp <= Math.floor(Date.now() / 1000)) {
-    throw new Error('token_expired')
   }
 
   return payload

--- a/apps/web/tests/connectors-gateway-tokens.test.ts
+++ b/apps/web/tests/connectors-gateway-tokens.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ConnectorGatewayTokenPayload } from '@/lib/connectors/gateway-tokens'
+
+describe('connectors/gateway-tokens', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...originalEnv }
+    process.env.ARCHE_GATEWAY_TOKEN_SECRET = 'connector-token-secret'
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-01T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    process.env = originalEnv
+  })
+
+  it('issues token with base64url payload and signature', async () => {
+    const { issueConnectorGatewayToken, verifyConnectorGatewayToken } = await import('@/lib/connectors/gateway-tokens')
+    const payload: ConnectorGatewayTokenPayload = {
+      userId: 'user-1',
+      workspaceSlug: 'inaki',
+      connectorId: 'connector-1',
+    }
+
+    const token = issueConnectorGatewayToken({
+      userId: 'user-1',
+      workspaceSlug: 'inaki',
+      connectorId: 'connector-1',
+    })
+    const [payloadPart, sigPart] = token.split('.')
+
+    expect(payloadPart).toBe(Buffer.from(JSON.stringify(payload)).toString('base64url'))
+    expect(sigPart.length).toBeGreaterThan(0)
+    expect(verifyConnectorGatewayToken(token)).toEqual(payload)
+  })
+
+  it('rejects tokens with invalid signature', async () => {
+    const { issueConnectorGatewayToken, verifyConnectorGatewayToken } = await import('@/lib/connectors/gateway-tokens')
+    const token = issueConnectorGatewayToken({
+      userId: 'user-2',
+      workspaceSlug: 'inaki',
+      connectorId: 'connector-2',
+    })
+    const [payloadPart] = token.split('.')
+    const forged = `${payloadPart}.bad-signature`
+
+    expect(() => verifyConnectorGatewayToken(forged)).toThrow('invalid_token')
+  })
+
+  it('rejects tokens with invalid format', async () => {
+    const { verifyConnectorGatewayToken } = await import('@/lib/connectors/gateway-tokens')
+
+    expect(() => verifyConnectorGatewayToken('no-dot')).toThrow('invalid_token')
+  })
+
+  it('keeps tokens stable across time because runtime reload is restart-bound', async () => {
+    const { issueConnectorGatewayToken, verifyConnectorGatewayToken } = await import('@/lib/connectors/gateway-tokens')
+    const token = issueConnectorGatewayToken({
+      userId: 'user-3',
+      workspaceSlug: 'inaki',
+      connectorId: 'connector-3',
+    })
+
+    vi.setSystemTime(new Date('2025-01-07T00:00:00Z'))
+
+    expect(verifyConnectorGatewayToken(token)).toEqual(expect.objectContaining({
+      userId: 'user-3',
+      workspaceSlug: 'inaki',
+      connectorId: 'connector-3',
+    }))
+  })
+})


### PR DESCRIPTION
## Summary
- make connector gateway tokens stable instead of TTL-bound because they are embedded into long-lived workspace runtime config and cannot be rotated into a live workspace today
- remove the unused connector gateway TTL path and keep gateway authorization scoped by signature plus user, workspace, and connector identity checks
- add regression coverage for connector gateway token issuance and long-lived verification behavior

## Testing
- pnpm exec vitest run tests/connectors-gateway-tokens.test.ts tests/mcp-config.test.ts tests/connectors-test-route.test.ts src/lib/spawner/__tests__/runtime-artifacts.test.ts
- pnpm lint
- pnpm test (fails in existing unrelated suites: src/components/workspace/__tests__/markdown-editor.test.tsx and src/components/workspace/__tests__/obsidian-link-decorations.test.tsx because @tiptap/core cannot be resolved)