### PR TITLE
feat(workspace): add shared skills support

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,6 +47,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dockerode": "^4.0.9",
+    "fflate": "^0.8.2",
     "lucide-react": "^0.563.0",
     "next": "16.1.6",
     "otpauth": "^9.4.1",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       dockerode:
         specifier: ^4.0.9
         version: 4.0.9
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.3)
@@ -2706,6 +2709,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -7215,6 +7221,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
     dependencies:

--- a/apps/web/src/app/api/u/[slug]/agents/[name]/route.ts
+++ b/apps/web/src/app/api/u/[slug]/agents/[name]/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server'
 
 import {
+  buildAgentPermissionConfigFromCapabilities,
   buildAgentToolsConfigFromCapabilities,
   type AgentCapabilities,
   validateAgentCapabilityConnectorIds,
+  validateAgentCapabilitySkillIds,
   validateAgentCapabilityTools,
 } from '@/lib/agent-capabilities'
 import { auditEvent } from '@/lib/auth'
@@ -11,6 +13,7 @@ import { readCommonWorkspaceConfig, writeCommonWorkspaceConfig } from '@/lib/com
 import type { ConnectorType } from '@/lib/connectors/types'
 import { validateConnectorType } from '@/lib/connectors/validators'
 import { withAuth } from '@/lib/runtime/with-auth'
+import { listSkills } from '@/lib/skills/skill-store'
 import { connectorService, userService } from '@/lib/services'
 import {
   type CommonWorkspaceConfig,
@@ -43,6 +46,7 @@ type UpdateAgentRequest = {
   isPrimary?: boolean
   expectedHash?: string
   capabilities?: {
+    skillIds?: unknown
     tools?: unknown
     mcpConnectorIds?: unknown
   }
@@ -98,13 +102,15 @@ async function loadEnabledConnectorsForSlug(slug: string): Promise<EnabledConnec
 
 function parseCapabilities(
   value: unknown,
-  enabledConnectors: EnabledConnector[]
+  enabledConnectors: EnabledConnector[],
+  availableSkillIds: Set<string>,
 ): { ok: true; capabilities: AgentCapabilities } | { ok: false; error: string } {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return { ok: false, error: 'invalid_capabilities' }
   }
 
   const capabilities = value as {
+    skillIds?: unknown
     tools?: unknown
     mcpConnectorIds?: unknown
   }
@@ -127,9 +133,20 @@ function parseCapabilities(
     return { ok: false, error: 'unknown_mcp_connector' }
   }
 
+  const skillResult = validateAgentCapabilitySkillIds(capabilities.skillIds)
+  if (!skillResult.ok) {
+    return { ok: false, error: skillResult.error }
+  }
+
+  const unknownSkillId = skillResult.skillIds.find((skillId) => !availableSkillIds.has(skillId))
+  if (unknownSkillId) {
+    return { ok: false, error: 'unknown_skill' }
+  }
+
   return {
     ok: true,
     capabilities: {
+      skillIds: skillResult.skillIds,
       tools: toolsResult.tools,
       mcpConnectorIds: connectorResult.connectorIds,
     },
@@ -256,7 +273,17 @@ export const PATCH = withAuth<AgentDetailResponse | { error: string; message?: s
 
     if ('capabilities' in body) {
       const enabledConnectors = await loadEnabledConnectorsForSlug(slug)
-      const capabilitiesResult = parseCapabilities(body.capabilities, enabledConnectors)
+      const skillsResult = await listSkills()
+      if (!skillsResult.ok) {
+        const status = skillsResult.error === 'kb_unavailable' ? 503 : 500
+        return NextResponse.json({ error: skillsResult.error }, { status })
+      }
+
+      const capabilitiesResult = parseCapabilities(
+        body.capabilities,
+        enabledConnectors,
+        new Set(skillsResult.data.map((skill) => skill.name))
+      )
       if (!capabilitiesResult.ok) {
         return NextResponse.json({ error: capabilitiesResult.error }, { status: 400 })
       }
@@ -265,6 +292,16 @@ export const PATCH = withAuth<AgentDetailResponse | { error: string; message?: s
         capabilitiesResult.capabilities,
         enabledConnectors
       )
+
+      const permission = buildAgentPermissionConfigFromCapabilities(
+        capabilitiesResult.capabilities,
+        updated.permission,
+      )
+      if (permission) {
+        updated.permission = permission
+      } else {
+        delete updated.permission
+      }
     }
 
     let nextConfig: CommonWorkspaceConfig = {

--- a/apps/web/src/app/api/u/[slug]/agents/route.ts
+++ b/apps/web/src/app/api/u/[slug]/agents/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server'
 
 import {
+  buildAgentPermissionConfigFromCapabilities,
   buildAgentToolsConfigFromCapabilities,
   type AgentCapabilities,
   validateAgentCapabilityConnectorIds,
+  validateAgentCapabilitySkillIds,
   validateAgentCapabilityTools,
 } from '@/lib/agent-capabilities'
 import { auditEvent } from '@/lib/auth'
@@ -11,6 +13,7 @@ import { readCommonWorkspaceConfig, writeCommonWorkspaceConfig } from '@/lib/com
 import type { ConnectorType } from '@/lib/connectors/types'
 import { validateConnectorType } from '@/lib/connectors/validators'
 import { withAuth } from '@/lib/runtime/with-auth'
+import { listSkills } from '@/lib/skills/skill-store'
 import { connectorService, userService } from '@/lib/services'
 import {
   type CommonAgentConfig,
@@ -49,6 +52,7 @@ type CreateAgentRequest = {
   isPrimary?: boolean
   expectedHash?: string
   capabilities?: {
+    skillIds?: unknown
     tools?: unknown
     mcpConnectorIds?: unknown
   }
@@ -106,13 +110,15 @@ async function loadEnabledConnectorsForSlug(slug: string): Promise<EnabledConnec
 
 function parseCapabilities(
   value: unknown,
-  enabledConnectors: EnabledConnector[]
+  enabledConnectors: EnabledConnector[],
+  availableSkillIds: Set<string>,
 ): { ok: true; capabilities: AgentCapabilities } | { ok: false; error: string } {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return { ok: false, error: 'invalid_capabilities' }
   }
 
   const capabilities = value as {
+    skillIds?: unknown
     tools?: unknown
     mcpConnectorIds?: unknown
   }
@@ -135,9 +141,20 @@ function parseCapabilities(
     return { ok: false, error: 'unknown_mcp_connector' }
   }
 
+  const skillResult = validateAgentCapabilitySkillIds(capabilities.skillIds)
+  if (!skillResult.ok) {
+    return { ok: false, error: skillResult.error }
+  }
+
+  const unknownSkillId = skillResult.skillIds.find((skillId) => !availableSkillIds.has(skillId))
+  if (unknownSkillId) {
+    return { ok: false, error: 'unknown_skill' }
+  }
+
   return {
     ok: true,
     capabilities: {
+      skillIds: skillResult.skillIds,
       tools: toolsResult.tools,
       mcpConnectorIds: connectorResult.connectorIds,
     },
@@ -252,7 +269,17 @@ export const POST = withAuth<{ agent: AgentListItem; hash?: string } | { error: 
         : undefined
 
     const enabledConnectors = await loadEnabledConnectorsForSlug(slug)
-    const capabilitiesResult = parseCapabilities(body.capabilities, enabledConnectors)
+    const skillsResult = await listSkills()
+    if (!skillsResult.ok) {
+      const status = skillsResult.error === 'kb_unavailable' ? 503 : 500
+      return NextResponse.json({ error: skillsResult.error }, { status })
+    }
+
+    const capabilitiesResult = parseCapabilities(
+      body.capabilities,
+      enabledConnectors,
+      new Set(skillsResult.data.map((skill) => skill.name))
+    )
     if (!capabilitiesResult.ok) {
       return NextResponse.json({ error: capabilitiesResult.error }, { status: 400 })
     }
@@ -264,6 +291,7 @@ export const POST = withAuth<{ agent: AgentListItem; hash?: string } | { error: 
       model,
       temperature,
       prompt,
+      permission: buildAgentPermissionConfigFromCapabilities(capabilitiesResult.capabilities, undefined),
       tools: buildAgentToolsConfigFromCapabilities(capabilitiesResult.capabilities, enabledConnectors),
     }
 

--- a/apps/web/src/app/api/u/[slug]/skills/[name]/export/route.ts
+++ b/apps/web/src/app/api/u/[slug]/skills/[name]/export/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+
+import { auditEvent } from '@/lib/auth'
+import { readSkillBundle } from '@/lib/skills/skill-store'
+import { createSkillArchive } from '@/lib/skills/skill-zip'
+import { withAuth } from '@/lib/runtime/with-auth'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+type SkillExportRouteParams = { name: string; slug: string }
+
+export const GET = withAuth<{ error: string }, SkillExportRouteParams>(
+  { csrf: false },
+  async (_request, { user, slug, params: { name } }) => {
+    const result = await readSkillBundle(name)
+    if (!result.ok) {
+      const status = result.error === 'not_found'
+        ? 404
+        : result.error === 'kb_unavailable'
+          ? 503
+          : 500
+      return NextResponse.json({ error: result.error }, { status })
+    }
+
+    const archive = createSkillArchive(result.data)
+
+    await auditEvent({
+      actorUserId: user.id,
+      action: 'skill.exported',
+      metadata: { slug, skillName: name },
+    })
+
+    return new Response(Buffer.from(archive), {
+      status: 200,
+      headers: {
+        'Cache-Control': 'no-store',
+        'Content-Disposition': `attachment; filename="${name}.zip"; filename*=UTF-8''${encodeURIComponent(`${name}.zip`)}`,
+        'Content-Type': 'application/zip',
+      },
+    })
+  }
+)

--- a/apps/web/src/app/api/u/[slug]/skills/[name]/route.ts
+++ b/apps/web/src/app/api/u/[slug]/skills/[name]/route.ts
@@ -1,0 +1,187 @@
+import { NextResponse } from 'next/server'
+
+import { auditEvent } from '@/lib/auth'
+import {
+  deleteSkill,
+  readSkill,
+  saveSkillDocument,
+} from '@/lib/skills/skill-store'
+import { withAuth } from '@/lib/runtime/with-auth'
+
+type SkillDetailResponse = {
+  hash?: string | null
+  skill: {
+    assignedAgentIds: string[]
+    body: string
+    description: string
+    hasResources: boolean
+    name: string
+    resourcePaths: string[]
+  }
+}
+
+type UpdateSkillRequest = {
+  assignedAgentIds?: unknown
+  body?: unknown
+  description?: unknown
+  expectedHash?: unknown
+}
+
+function parseAssignedAgentIds(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null
+  }
+
+  const agentIds: string[] = []
+  for (const entry of value) {
+    if (typeof entry !== 'string' || !entry.trim()) {
+      return null
+    }
+
+    agentIds.push(entry.trim())
+  }
+
+  return Array.from(new Set(agentIds)).sort((left, right) => left.localeCompare(right))
+}
+
+type SkillRouteParams = { name: string; slug: string }
+
+export const GET = withAuth<SkillDetailResponse | { error: string }, SkillRouteParams>(
+  { csrf: false },
+  async (_request, { params: { name } }) => {
+    const result = await readSkill(name)
+    if (!result.ok) {
+      const status = result.error === 'not_found'
+        ? 404
+        : result.error === 'kb_unavailable'
+          ? 503
+          : 500
+      return NextResponse.json({ error: result.error }, { status })
+    }
+
+    return NextResponse.json({ skill: result.data, hash: result.hash })
+  }
+)
+
+export const PATCH = withAuth<SkillDetailResponse | { error: string }, SkillRouteParams>(
+  { csrf: true },
+  async (request, { user, slug, params: { name } }) => {
+    if (user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+    }
+
+    let body: UpdateSkillRequest
+    try {
+      body = await request.json()
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+      }
+
+      throw error
+    }
+
+    const existing = await readSkill(name)
+    if (!existing.ok) {
+      const status = existing.error === 'not_found'
+        ? 404
+        : existing.error === 'kb_unavailable'
+          ? 503
+          : 500
+      return NextResponse.json({ error: existing.error }, { status })
+    }
+
+    const description = 'description' in body
+      ? typeof body.description === 'string'
+        ? body.description.trim()
+        : ''
+      : existing.data.description
+    if (!description || description.length > 1024) {
+      return NextResponse.json({ error: 'invalid_description' }, { status: 400 })
+    }
+
+    const skillBody = 'body' in body
+      ? typeof body.body === 'string'
+        ? body.body
+        : null
+      : existing.data.body
+    if (skillBody == null) {
+      return NextResponse.json({ error: 'invalid_body' }, { status: 400 })
+    }
+
+    const assignedAgentIds = 'assignedAgentIds' in body
+      ? parseAssignedAgentIds(body.assignedAgentIds)
+      : existing.data.assignedAgentIds
+    if (!assignedAgentIds) {
+      return NextResponse.json({ error: 'invalid_assigned_agents' }, { status: 400 })
+    }
+
+    const result = await saveSkillDocument({
+      mode: 'update',
+      name,
+      description,
+      body: skillBody,
+      assignedAgentIds,
+      expectedHash: typeof body.expectedHash === 'string' ? body.expectedHash : undefined,
+    })
+    if (!result.ok) {
+      const status =
+        result.error === 'not_found' ? 404
+        : result.error === 'conflict' ? 409
+        : result.error === 'unknown_agent' ? 400
+        : result.error === 'kb_unavailable' ? 503
+        : 500
+      return NextResponse.json({ error: result.error }, { status })
+    }
+
+    const updated = await readSkill(name)
+    if (!updated.ok) {
+      return NextResponse.json({ error: 'read_failed' }, { status: 500 })
+    }
+
+    await auditEvent({
+      actorUserId: user.id,
+      action: 'skill.updated',
+      metadata: { slug, skillName: name },
+    })
+
+    return NextResponse.json({ skill: updated.data, hash: result.hash })
+  }
+)
+
+export const DELETE = withAuth<{ hash?: string } | { error: string }, SkillRouteParams>(
+  { csrf: true },
+  async (request, { user, slug, params: { name } }) => {
+    if (user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+    }
+
+    let body: { expectedHash?: unknown } | null = null
+    try {
+      body = await request.json()
+    } catch {
+      body = null
+    }
+
+    const result = await deleteSkill(
+      name,
+      body && typeof body.expectedHash === 'string' ? body.expectedHash : undefined,
+    )
+    if (!result.ok) {
+      const status =
+        result.error === 'not_found' ? 404
+        : result.error === 'conflict' ? 409
+        : result.error === 'kb_unavailable' ? 503
+        : 500
+      return NextResponse.json({ error: result.error }, { status })
+    }
+
+    await auditEvent({
+      actorUserId: user.id,
+      action: 'skill.deleted',
+      metadata: { slug, skillName: name },
+    })
+
+    return NextResponse.json({ hash: result.hash })
+  }
+)

--- a/apps/web/src/app/api/u/[slug]/skills/import/route.ts
+++ b/apps/web/src/app/api/u/[slug]/skills/import/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { auditEvent } from '@/lib/auth'
+import { importSkillArchive, readSkill } from '@/lib/skills/skill-store'
+import { parseSkillArchive } from '@/lib/skills/skill-zip'
+import { withAuth } from '@/lib/runtime/with-auth'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+function parseAssignedAgentIds(value: FormDataEntryValue | null): string[] | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown
+    if (!Array.isArray(parsed)) {
+      return null
+    }
+
+    const agentIds: string[] = []
+    for (const entry of parsed) {
+      if (typeof entry !== 'string' || !entry.trim()) {
+        return null
+      }
+
+      agentIds.push(entry.trim())
+    }
+
+    return Array.from(new Set(agentIds)).sort((left, right) => left.localeCompare(right))
+  } catch {
+    return null
+  }
+}
+
+export const POST = withAuth(
+  { csrf: true },
+  async (request: NextRequest, { user, slug }) => {
+    if (user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+    }
+
+    const formData = await request.formData()
+    const file = formData.get('file')
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'missing_file' }, { status: 400 })
+    }
+
+    const assignedAgentIds = parseAssignedAgentIds(formData.get('assignedAgentIds'))
+    if (!assignedAgentIds) {
+      return NextResponse.json({ error: 'invalid_assigned_agents' }, { status: 400 })
+    }
+
+    const parsedArchive = parseSkillArchive(new Uint8Array(await file.arrayBuffer()))
+    if (!parsedArchive.ok) {
+      const status = parsedArchive.error === 'archive_too_large' ? 413 : 400
+      return NextResponse.json({ error: parsedArchive.error }, { status })
+    }
+
+    const result = await importSkillArchive({
+      archive: parsedArchive.archive,
+      assignedAgentIds,
+      expectedHash: typeof formData.get('expectedHash') === 'string' ? String(formData.get('expectedHash')) : undefined,
+    })
+    if (!result.ok) {
+      const status =
+        result.error === 'conflict' ? 409
+        : result.error === 'unknown_agent' ? 400
+        : result.error === 'kb_unavailable' ? 503
+        : 500
+      return NextResponse.json({ error: result.error }, { status })
+    }
+
+    const imported = await readSkill(parsedArchive.archive.skill.frontmatter.name)
+    if (!imported.ok) {
+      return NextResponse.json({ error: 'read_failed' }, { status: 500 })
+    }
+
+    await auditEvent({
+      actorUserId: user.id,
+      action: 'skill.imported',
+      metadata: { slug, skillName: parsedArchive.archive.skill.frontmatter.name },
+    })
+
+    return NextResponse.json({ skill: imported.data, hash: result.hash }, { status: 201 })
+  }
+)

--- a/apps/web/src/app/api/u/[slug]/skills/import/route.ts
+++ b/apps/web/src/app/api/u/[slug]/skills/import/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { auditEvent } from '@/lib/auth'
 import { importSkillArchive, readSkill } from '@/lib/skills/skill-store'
-import { parseSkillArchive } from '@/lib/skills/skill-zip'
+import { MAX_SKILL_ARCHIVE_BYTES, parseSkillArchive } from '@/lib/skills/skill-zip'
 import { withAuth } from '@/lib/runtime/with-auth'
 
 export const runtime = 'nodejs'
@@ -45,6 +45,10 @@ export const POST = withAuth(
     const file = formData.get('file')
     if (!(file instanceof File)) {
       return NextResponse.json({ error: 'missing_file' }, { status: 400 })
+    }
+
+    if (file.size > MAX_SKILL_ARCHIVE_BYTES) {
+      return NextResponse.json({ error: 'archive_too_large' }, { status: 413 })
     }
 
     const assignedAgentIds = parseAssignedAgentIds(formData.get('assignedAgentIds'))

--- a/apps/web/src/app/api/u/[slug]/skills/route.ts
+++ b/apps/web/src/app/api/u/[slug]/skills/route.ts
@@ -1,0 +1,135 @@
+import { NextResponse } from 'next/server'
+
+import { auditEvent } from '@/lib/auth'
+import {
+  listSkills,
+  saveSkillDocument,
+} from '@/lib/skills/skill-store'
+import { SKILL_NAME_PATTERN } from '@/lib/skills/types'
+import { withAuth } from '@/lib/runtime/with-auth'
+
+type SkillListItem = {
+  assignedAgentIds: string[]
+  description: string
+  hasResources: boolean
+  name: string
+  resourcePaths: string[]
+}
+
+type SkillsListResponse = {
+  hash?: string | null
+  skills: SkillListItem[]
+}
+
+type CreateSkillRequest = {
+  assignedAgentIds?: unknown
+  body?: unknown
+  description?: unknown
+  expectedHash?: unknown
+  name?: unknown
+}
+
+function parseAssignedAgentIds(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null
+  }
+
+  const agentIds: string[] = []
+  for (const entry of value) {
+    if (typeof entry !== 'string' || !entry.trim()) {
+      return null
+    }
+
+    agentIds.push(entry.trim())
+  }
+
+  return Array.from(new Set(agentIds)).sort((left, right) => left.localeCompare(right))
+}
+
+export const GET = withAuth<SkillsListResponse | { error: string }>(
+  { csrf: false },
+  async () => {
+    const result = await listSkills()
+    if (!result.ok) {
+      const status = result.error === 'kb_unavailable' ? 503 : 500
+      return NextResponse.json({ error: result.error }, { status })
+    }
+
+    return NextResponse.json({ skills: result.data, hash: result.hash })
+  }
+)
+
+export const POST = withAuth<{ hash?: string; skill: SkillListItem } | { error: string }>(
+  { csrf: true },
+  async (request, { user, slug }) => {
+    if (user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+    }
+
+    let body: CreateSkillRequest
+    try {
+      body = await request.json()
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+      }
+
+      throw error
+    }
+
+    const name = typeof body.name === 'string' ? body.name.trim() : ''
+    if (!name || name.length > 64 || !SKILL_NAME_PATTERN.test(name)) {
+      return NextResponse.json({ error: 'invalid_name' }, { status: 400 })
+    }
+
+    const description = typeof body.description === 'string' ? body.description.trim() : ''
+    if (!description || description.length > 1024) {
+      return NextResponse.json({ error: 'invalid_description' }, { status: 400 })
+    }
+
+    if (typeof body.body !== 'string') {
+      return NextResponse.json({ error: 'invalid_body' }, { status: 400 })
+    }
+
+    const assignedAgentIds = parseAssignedAgentIds(body.assignedAgentIds)
+    if (!assignedAgentIds) {
+      return NextResponse.json({ error: 'invalid_assigned_agents' }, { status: 400 })
+    }
+
+    const result = await saveSkillDocument({
+      mode: 'create',
+      name,
+      description,
+      body: body.body,
+      assignedAgentIds,
+      expectedHash: typeof body.expectedHash === 'string' ? body.expectedHash : undefined,
+    })
+    if (!result.ok) {
+      const status =
+        result.error === 'skill_exists' ? 409
+        : result.error === 'conflict' ? 409
+        : result.error === 'unknown_agent' ? 400
+        : result.error === 'kb_unavailable' ? 503
+        : 500
+      return NextResponse.json({ error: result.error }, { status })
+    }
+
+    const skills = await listSkills()
+    if (!skills.ok) {
+      return NextResponse.json({ error: 'read_failed' }, { status: 500 })
+    }
+
+    const createdSkill = skills.data.find((entry) => entry.name === name)
+    if (!createdSkill) {
+      return NextResponse.json({ error: 'read_failed' }, { status: 500 })
+    }
+
+    await auditEvent({
+      actorUserId: user.id,
+      action: 'skill.created',
+      metadata: { slug, skillName: name },
+    })
+
+    return NextResponse.json({ skill: createdSkill, hash: result.hash }, { status: 201 })
+  }
+)

--- a/apps/web/src/app/u/[slug]/skills/[name]/page.tsx
+++ b/apps/web/src/app/u/[slug]/skills/[name]/page.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+
+import { WebSkillForm } from '@/components/skills/web-skill-form'
+import { getSession } from '@/lib/runtime/session'
+
+export default async function EditSkillPage({
+  params,
+}: {
+  params: Promise<{ name: string; slug: string }>
+}) {
+  const { slug, name } = await params
+
+  const session = await getSession()
+  if (session?.user.role !== 'ADMIN') {
+    redirect(`/u/${slug}/skills`)
+  }
+
+  return (
+    <main className="relative mx-auto max-w-3xl px-6 py-10">
+      <div className="space-y-8">
+        <div>
+          <div className="mb-5">
+            <Link
+              href={`/u/${slug}/skills`}
+              className="inline-flex text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              &larr; Back to skills
+            </Link>
+          </div>
+          <div className="space-y-2">
+            <h1 className="type-display text-3xl font-semibold tracking-tight">Edit skill</h1>
+            <p className="text-muted-foreground">
+              Update the `SKILL.md` instructions and default agent assignments.
+            </p>
+          </div>
+        </div>
+
+        <WebSkillForm slug={slug} mode="edit" skillName={name} />
+      </div>
+    </main>
+  )
+}

--- a/apps/web/src/app/u/[slug]/skills/new/page.tsx
+++ b/apps/web/src/app/u/[slug]/skills/new/page.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+
+import { WebSkillForm } from '@/components/skills/web-skill-form'
+import { getSession } from '@/lib/runtime/session'
+
+export default async function NewSkillPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  const session = await getSession()
+  if (session?.user.role !== 'ADMIN') {
+    redirect(`/u/${slug}/skills`)
+  }
+
+  return (
+    <main className="relative mx-auto max-w-3xl px-6 py-10">
+      <div className="space-y-8">
+        <div>
+          <div className="mb-5">
+            <Link
+              href={`/u/${slug}/skills`}
+              className="inline-flex text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              &larr; Back to skills
+            </Link>
+          </div>
+          <div className="space-y-2">
+            <h1 className="type-display text-3xl font-semibold tracking-tight">Create skill</h1>
+            <p className="text-muted-foreground">
+              Define a new `SKILL.md` bundle and choose which agents can use it.
+            </p>
+          </div>
+        </div>
+
+        <WebSkillForm slug={slug} mode="create" />
+      </div>
+    </main>
+  )
+}

--- a/apps/web/src/app/u/[slug]/skills/page.tsx
+++ b/apps/web/src/app/u/[slug]/skills/page.tsx
@@ -1,0 +1,32 @@
+import { redirect } from 'next/navigation'
+
+import { SkillsPageClient } from '@/components/skills/skills-page'
+import { getCurrentDesktopVault, getDesktopWorkspaceHref } from '@/lib/runtime/desktop/current-vault'
+import { isDesktop } from '@/lib/runtime/mode'
+import { getSession } from '@/lib/runtime/session'
+
+export default async function SkillsPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  if (isDesktop()) {
+    const vault = getCurrentDesktopVault()
+    if (!vault) {
+      redirect('/')
+    }
+
+    redirect(getDesktopWorkspaceHref(slug, 'skills'))
+  }
+
+  const session = await getSession()
+  const isAdmin = session?.user.role === 'ADMIN'
+
+  return (
+    <main className="relative mx-auto max-w-6xl px-6 py-10">
+      <SkillsPageClient slug={slug} isAdmin={isAdmin} />
+    </main>
+  )
+}

--- a/apps/web/src/components/agents/agent-form.tsx
+++ b/apps/web/src/components/agents/agent-form.tsx
@@ -38,6 +38,11 @@ type ConnectorListItem = {
   enabled: boolean
 }
 
+type SkillListItem = {
+  description: string
+  name: string
+}
+
 export function AgentForm({
   slug,
   mode,
@@ -57,7 +62,9 @@ export function AgentForm({
   const [isPrimary, setIsPrimary] = useState(false)
   const [enabledTools, setEnabledTools] = useState<OpenCodeAgentToolId[]>([])
   const [enabledMcpConnectorIds, setEnabledMcpConnectorIds] = useState<string[]>([])
+  const [enabledSkillIds, setEnabledSkillIds] = useState<string[]>([])
   const [connectors, setConnectors] = useState<ConnectorListItem[]>([])
+  const [skills, setSkills] = useState<SkillListItem[]>([])
   const [modelOptions, setModelOptions] = useState<ModelOption[]>([])
   const [hash, setHash] = useState<string | undefined>()
   const [isLoading, setIsLoading] = useState(mode === 'edit')
@@ -72,9 +79,10 @@ export function AgentForm({
     let cancelled = false
 
     async function loadFormOptions() {
-      const [modelsResponse, connectorsResponse] = await Promise.all([
+      const [modelsResponse, connectorsResponse, skillsResponse] = await Promise.all([
         fetch(`/api/u/${slug}/agents/models`, { cache: 'no-store' }).catch(() => null),
         fetch(`/api/u/${slug}/connectors`, { cache: 'no-store' }).catch(() => null),
+        fetch(`/api/u/${slug}/skills`, { cache: 'no-store' }).catch(() => null),
       ])
 
       if (cancelled) return
@@ -97,6 +105,15 @@ export function AgentForm({
             enabledConnectorList.some((connector) => connector.id === connectorId)
           )
         )
+      }
+
+      if (skillsResponse?.ok) {
+        const data = (await skillsResponse.json().catch(() => null)) as
+          | { skills?: SkillListItem[] }
+          | null
+        const availableSkills = data?.skills ?? []
+        setSkills(availableSkills)
+        setEnabledSkillIds((current) => current.filter((skillId) => availableSkills.some((skill) => skill.name === skillId)))
       }
     }
 
@@ -144,6 +161,7 @@ export function AgentForm({
           setIsPrimary(data.agent.isPrimary)
           setEnabledTools((data.agent.capabilities?.tools ?? []) as OpenCodeAgentToolId[])
           setEnabledMcpConnectorIds(data.agent.capabilities?.mcpConnectorIds ?? [])
+          setEnabledSkillIds(data.agent.capabilities?.skillIds ?? [])
           setHash(data.hash)
         })
         .catch(() => setLoadError('network_error'))
@@ -232,6 +250,14 @@ export function AgentForm({
     )
   }
 
+  const toggleSkill = (skillId: string) => {
+    setEnabledSkillIds((current) =>
+      current.includes(skillId)
+        ? current.filter((idEntry) => idEntry !== skillId)
+        : [...current, skillId]
+    )
+  }
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     if (isSaving) return
@@ -246,6 +272,7 @@ export function AgentForm({
     }
 
     const capabilities: AgentCapabilities = {
+      skillIds: enabledSkillIds,
       tools: enabledTools,
       mcpConnectorIds: enabledMcpConnectorIds,
     }
@@ -481,6 +508,46 @@ export function AgentForm({
                   />
                   <span className="font-medium">{connector.name}</span>
                   <span className="text-xs text-muted-foreground">{connector.type}</span>
+                </label>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        <Label>Capabilities - Skills</Label>
+        <p className="text-xs text-muted-foreground">
+          Allow this agent to load the selected skills. Arche enables the OpenCode `skill` tool automatically.
+        </p>
+        {skills.length === 0 ? (
+          <div className="rounded-lg border border-border/60 bg-card/50 p-3 text-sm text-muted-foreground">
+            No skills available.
+          </div>
+        ) : (
+          <div className="grid gap-2 md:grid-cols-2">
+            {skills.map((skill) => {
+              const checked = enabledSkillIds.includes(skill.name)
+              return (
+                <label
+                  key={skill.name}
+                  className={cn(
+                    'flex items-start gap-2 rounded-lg border px-3 py-2 text-sm transition-colors',
+                    checked
+                      ? 'border-primary/40 bg-primary/5 text-foreground'
+                      : 'border-border/60 bg-card/40 text-muted-foreground hover:bg-card/70'
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleSkill(skill.name)}
+                    className={checkboxClassName}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block font-medium">{skill.name}</span>
+                    <span className="block text-xs text-muted-foreground">{skill.description}</span>
+                  </span>
                 </label>
               )
             })}

--- a/apps/web/src/components/dashboard/dashboard-nav.tsx
+++ b/apps/web/src/components/dashboard/dashboard-nav.tsx
@@ -8,6 +8,7 @@ import { ArrowUpRight, List, X } from '@phosphor-icons/react'
 const webNavItems = [
   { label: 'Overview', href: '' },
   { label: 'Agents', href: '/agents' },
+  { label: 'Skills', href: '/skills' },
   { label: 'Connectors', href: '/connectors' },
   { label: 'Team', href: '/team' },
   { label: 'Settings', href: '/settings/security' },
@@ -16,6 +17,7 @@ const webNavItems = [
 const desktopNavItems = [
   { label: 'Workspace', href: '/w/local' },
   { label: 'Agents', href: '/u/local/agents' },
+  { label: 'Skills', href: '/w/local?settings=skills' },
   { label: 'Connectors', href: '/w/local?settings=connectors' },
   { label: 'Providers', href: '/w/local?settings=providers' },
   { label: 'Settings', href: '/w/local?settings=appearance' },

--- a/apps/web/src/components/desktop/__tests__/desktop-settings-dialog.test.tsx
+++ b/apps/web/src/components/desktop/__tests__/desktop-settings-dialog.test.tsx
@@ -29,6 +29,10 @@ vi.mock('@/components/settings/agents-settings-panel', () => ({
   AgentsSettingsPanel: () => <div>Agents Panel</div>,
 }))
 
+vi.mock('@/components/settings/skills-settings-panel', () => ({
+  SkillsSettingsPanel: () => <div>Skills Panel</div>,
+}))
+
 vi.mock('@/components/settings/advanced-settings-panel', () => ({
   AdvancedSettingsPanel: () => <div>Advanced Panel</div>,
 }))
@@ -48,6 +52,9 @@ describe('DesktopSettingsDialog', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Agents' }))
     expect(replaceMock).toHaveBeenCalledWith('/w/local?settings=agents')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skills' }))
+    expect(replaceMock).toHaveBeenCalledWith('/w/local?settings=skills')
   })
 
   it('removes the settings query string when closed', () => {

--- a/apps/web/src/components/desktop/desktop-settings-dialog.tsx
+++ b/apps/web/src/components/desktop/desktop-settings-dialog.tsx
@@ -9,6 +9,7 @@ import { ProviderCredentialsPanel } from '@/components/providers/provider-creden
 import { AdvancedSettingsPanel } from '@/components/settings/advanced-settings-panel'
 import { AgentsSettingsPanel } from '@/components/settings/agents-settings-panel'
 import { AppearanceSettingsPanel } from '@/components/settings/appearance-settings-panel'
+import { SkillsSettingsPanel } from '@/components/settings/skills-settings-panel'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -31,6 +32,7 @@ const SECTION_LABELS: Record<DesktopSettingsSection, string> = {
   providers: 'Providers',
   connectors: 'Connectors',
   agents: 'Agents',
+  skills: 'Skills',
   appearance: 'Appearance',
   advanced: 'Advanced',
 }
@@ -75,6 +77,8 @@ export function DesktopSettingsDialog({ slug, currentSection }: DesktopSettingsD
         return <AppearanceSettingsPanel />
       case 'agents':
         return <AgentsSettingsPanel slug={slug} />
+      case 'skills':
+        return <SkillsSettingsPanel slug={slug} />
       case 'advanced':
         return <AdvancedSettingsPanel slug={slug} />
       default:
@@ -87,7 +91,7 @@ export function DesktopSettingsDialog({ slug, currentSection }: DesktopSettingsD
       <DialogContent showCloseButton={false} className="max-h-[90vh] overflow-hidden p-0 sm:max-w-6xl">
         <DialogTitle className="sr-only">Desktop settings</DialogTitle>
         <DialogDescription className="sr-only">
-          Configure providers, connectors, agents, appearance, and advanced desktop workspace settings.
+          Configure providers, connectors, agents, skills, appearance, and advanced desktop workspace settings.
         </DialogDescription>
 
         <div className="flex h-[80vh] min-h-[640px] flex-col">

--- a/apps/web/src/components/settings/__tests__/skills-settings-panel.test.tsx
+++ b/apps/web/src/components/settings/__tests__/skills-settings-panel.test.tsx
@@ -1,0 +1,101 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SkillsSettingsPanel } from '@/components/settings/skills-settings-panel'
+
+const reloadMock = vi.fn()
+const useSkillsCatalogMock = vi.fn()
+const useAgentsCatalogMock = vi.fn()
+
+vi.mock('@/hooks/use-skills-catalog', () => ({
+  useSkillsCatalog: (...args: unknown[]) => useSkillsCatalogMock(...args),
+}))
+
+vi.mock('@/hooks/use-agents-catalog', () => ({
+  useAgentsCatalog: (...args: unknown[]) => useAgentsCatalogMock(...args),
+}))
+
+const skillFormMock = vi.fn()
+vi.mock('@/components/skills/skill-form', () => ({
+  SkillForm: (props: {
+    mode: 'create' | 'edit'
+    onCancel?: () => void
+    onSaved?: () => Promise<void>
+    skillName?: string
+  }) => {
+    skillFormMock(props)
+    return (
+      <div>
+        <p>Skill Form {props.mode}</p>
+        <p>{props.skillName ?? 'new-skill'}</p>
+        <button type="button" onClick={() => props.onSaved?.()}>
+          Save form
+        </button>
+        <button type="button" onClick={() => props.onCancel?.()}>
+          Cancel form
+        </button>
+      </div>
+    )
+  },
+}))
+
+vi.mock('@/components/skills/import-skill-dialog', () => ({
+  ImportSkillDialog: () => <div>Import Skill Dialog</div>,
+}))
+
+describe('SkillsSettingsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    reloadMock.mockResolvedValue(undefined)
+    useSkillsCatalogMock.mockReturnValue({
+      skills: [
+        {
+          name: 'pdf-processing',
+          description: 'Handle PDFs',
+          assignedAgentIds: ['assistant'],
+          hasResources: false,
+          resourcePaths: [],
+        },
+      ],
+      hash: 'hash-1',
+      isLoading: false,
+      loadError: null,
+      reload: reloadMock,
+    })
+    useAgentsCatalogMock.mockReturnValue({
+      agents: [
+        { id: 'assistant', displayName: 'Assistant', isPrimary: true },
+      ],
+      isLoading: false,
+      loadError: null,
+      reload: vi.fn(),
+    })
+  })
+
+  it('renders the skill catalog and opens the embedded editor', async () => {
+    render(<SkillsSettingsPanel slug="local" />)
+
+    expect(screen.getByRole('heading', { name: 'Skills' })).toBeTruthy()
+    expect(screen.getByText('pdf-processing')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(screen.getByText('Skill Form edit')).toBeTruthy()
+    expect(screen.getByText('pdf-processing')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save form' }))
+
+    await waitFor(() => {
+      expect(reloadMock).toHaveBeenCalledTimes(1)
+      expect(screen.getByRole('heading', { name: 'Skills' })).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create skill' }))
+    expect(screen.getByText('Skill Form create')).toBeTruthy()
+    expect(screen.getByText('new-skill')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel form' }))
+    expect(screen.getByRole('heading', { name: 'Skills' })).toBeTruthy()
+  })
+})

--- a/apps/web/src/components/settings/skills-settings-panel.tsx
+++ b/apps/web/src/components/settings/skills-settings-panel.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { SpinnerGap } from '@phosphor-icons/react'
+
+import { ImportSkillDialog } from '@/components/skills/import-skill-dialog'
+import { SkillForm } from '@/components/skills/skill-form'
+import { SkillsList } from '@/components/skills/skills-list'
+import { Button } from '@/components/ui/button'
+import { useAgentsCatalog } from '@/hooks/use-agents-catalog'
+import { useSkillsCatalog } from '@/hooks/use-skills-catalog'
+
+type SkillsSettingsPanelProps = {
+  slug: string
+}
+
+type EditorState =
+  | { mode: 'create' }
+  | { mode: 'edit'; skillName: string }
+
+export function SkillsSettingsPanel({ slug }: SkillsSettingsPanelProps) {
+  const { skills, hash, isLoading, loadError, reload } = useSkillsCatalog(slug)
+  const { agents } = useAgentsCatalog(slug)
+  const [editorState, setEditorState] = useState<EditorState | null>(null)
+  const [isImportDialogOpen, setIsImportDialogOpen] = useState(false)
+
+  const editingSkill = editorState?.mode === 'edit'
+    ? skills.find((skill) => skill.name === editorState.skillName) ?? null
+    : null
+
+  const agentOptions = useMemo(
+    () => agents.map((agent) => ({ id: agent.id, displayName: agent.displayName, isPrimary: agent.isPrimary })),
+    [agents]
+  )
+
+  async function handleEditorFinished() {
+    await reload()
+    setEditorState(null)
+  }
+
+  if (editorState) {
+    return (
+      <section className="space-y-6">
+        <div>
+          <h2 className="text-lg font-medium text-foreground">
+            {editorState.mode === 'create' ? 'Create skill' : `Edit ${editingSkill?.name ?? 'skill'}`}
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {editorState.mode === 'create'
+              ? 'Define the SKILL.md instructions and choose which agents can use the new skill.'
+              : 'Update the SKILL.md instructions and the default agent assignments for this skill.'}
+          </p>
+        </div>
+
+        <SkillForm
+          slug={slug}
+          mode={editorState.mode}
+          skillName={editorState.mode === 'edit' ? editorState.skillName : undefined}
+          cancelLabel="Back to skills"
+          onCancel={() => setEditorState(null)}
+          onDeleted={handleEditorFinished}
+          onSaved={handleEditorFinished}
+        />
+      </section>
+    )
+  }
+
+  return (
+    <section className="space-y-8">
+      <div>
+        <h2 className="text-lg font-medium text-foreground">Skills</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Manage reusable skill bundles and choose which agents can use them inside this desktop workspace.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button type="button" variant="outline" onClick={() => setIsImportDialogOpen(true)}>
+          Import skill
+        </Button>
+        <Button type="button" variant="outline" onClick={() => setEditorState({ mode: 'create' })}>
+          Create skill
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="flex min-h-[240px] items-center justify-center">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <SpinnerGap size={16} className="animate-spin" />
+            Loading skills...
+          </div>
+        </div>
+      ) : null}
+
+      {loadError ? (
+        <div className="space-y-4 rounded-xl border border-border/60 bg-card/50 p-5">
+          <p className="text-sm text-destructive">Failed to load: {loadError}</p>
+          <Button type="button" variant="outline" onClick={() => void reload()}>
+            Retry
+          </Button>
+        </div>
+      ) : null}
+
+      {!isLoading && !loadError ? (
+        <SkillsList
+          slug={slug}
+          skills={skills}
+          isAdmin
+          onEdit={(skillName) => setEditorState({ mode: 'edit', skillName })}
+          emptyMessage="No skills configured yet."
+        />
+      ) : null}
+
+      <ImportSkillDialog
+        slug={slug}
+        open={isImportDialogOpen}
+        onOpenChange={setIsImportDialogOpen}
+        agents={agentOptions}
+        expectedHash={hash}
+        onImported={reload}
+      />
+    </section>
+  )
+}

--- a/apps/web/src/components/skills/import-skill-dialog.tsx
+++ b/apps/web/src/components/skills/import-skill-dialog.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import { useMemo, useRef, useState } from 'react'
+import { SpinnerGap, UploadSimple } from '@phosphor-icons/react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import { notifyWorkspaceConfigChanged } from '@/lib/runtime/config-status-events'
+import { cn } from '@/lib/utils'
+
+type AgentOption = {
+  displayName: string
+  id: string
+  isPrimary: boolean
+}
+
+type ImportSkillDialogProps = {
+  agents: AgentOption[]
+  expectedHash?: string | null
+  onImported: () => void | Promise<void>
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  slug: string
+}
+
+export function ImportSkillDialog({
+  slug,
+  open,
+  onOpenChange,
+  agents,
+  expectedHash,
+  onImported,
+}: ImportSkillDialogProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [assignedAgentIds, setAssignedAgentIds] = useState<string[]>([])
+  const [isImporting, setIsImporting] = useState(false)
+  const [importError, setImportError] = useState<string | null>(null)
+
+  const sortedAgents = useMemo(
+    () => [...agents].sort((left, right) => {
+      if (left.isPrimary && !right.isPrimary) return -1
+      if (!left.isPrimary && right.isPrimary) return 1
+      return left.displayName.localeCompare(right.displayName)
+    }),
+    [agents]
+  )
+
+  function resetDialog() {
+    setSelectedFile(null)
+    setAssignedAgentIds([])
+    setImportError(null)
+    setIsImporting(false)
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    onOpenChange(nextOpen)
+    if (!nextOpen) {
+      resetDialog()
+    }
+  }
+
+  function toggleAssignedAgent(agentId: string) {
+    setAssignedAgentIds((current) =>
+      current.includes(agentId)
+        ? current.filter((entry) => entry !== agentId)
+        : [...current, agentId]
+    )
+  }
+
+  async function handleImport() {
+    if (!selectedFile || isImporting) {
+      return
+    }
+
+    setIsImporting(true)
+    setImportError(null)
+
+    try {
+      const formData = new FormData()
+      formData.set('file', selectedFile)
+      formData.set('assignedAgentIds', JSON.stringify(assignedAgentIds))
+      if (typeof expectedHash === 'string' && expectedHash) {
+        formData.set('expectedHash', expectedHash)
+      }
+
+      const response = await fetch(`/api/u/${slug}/skills/import`, {
+        method: 'POST',
+        body: formData,
+      })
+      const data = (await response.json().catch(() => null)) as { error?: string } | null
+      if (!response.ok) {
+        setImportError(data?.error ?? 'import_failed')
+        return
+      }
+
+      notifyWorkspaceConfigChanged()
+      await onImported()
+      handleOpenChange(false)
+    } catch {
+      setImportError('network_error')
+    } finally {
+      setIsImporting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Import skill</DialogTitle>
+          <DialogDescription>
+            Upload a `.zip` bundle with a `SKILL.md` file. If the skill already exists, the import replaces it.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          <div className="space-y-2">
+            <Label>Archive</Label>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".zip,application/zip"
+              className="hidden"
+              onChange={(event) => setSelectedFile(event.target.files?.[0] ?? null)}
+            />
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className={cn(
+                'flex w-full items-center justify-between rounded-xl border border-dashed px-4 py-4 text-left transition-colors',
+                selectedFile
+                  ? 'border-primary/40 bg-primary/5 text-foreground'
+                  : 'border-border/60 bg-card/40 text-muted-foreground hover:bg-card/70'
+              )}
+            >
+              <div>
+                <p className="text-sm font-medium">{selectedFile?.name ?? 'Choose a skill archive'}</p>
+                <p className="text-xs text-muted-foreground">
+                  {selectedFile ? `${Math.ceil(selectedFile.size / 1024)} KB` : 'ZIP bundles only'}
+                </p>
+              </div>
+              <UploadSimple size={18} weight="bold" />
+            </button>
+          </div>
+
+          <div className="space-y-3">
+            <Label>Assigned agents</Label>
+            <div className="grid gap-2 md:grid-cols-2">
+              {sortedAgents.map((agent) => {
+                const checked = assignedAgentIds.includes(agent.id)
+                return (
+                  <label
+                    key={agent.id}
+                    className={cn(
+                      'flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors',
+                      checked
+                        ? 'border-primary/40 bg-primary/5 text-foreground'
+                        : 'border-border/60 bg-card/40 text-muted-foreground hover:bg-card/70'
+                    )}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleAssignedAgent(agent.id)}
+                      className="h-4 w-4 rounded border border-border/70 bg-card/70 accent-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                    />
+                    <span className="font-medium">{agent.displayName}</span>
+                    {agent.isPrimary ? <span className="text-xs">(Primary)</span> : null}
+                  </label>
+                )
+              })}
+            </div>
+          </div>
+
+          {importError ? (
+            <div className="rounded-lg border border-border/60 bg-card/50 p-4 text-sm text-destructive">
+              Error: {importError}
+            </div>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={() => void handleImport()} disabled={!selectedFile || isImporting}>
+            {isImporting ? <SpinnerGap size={16} className="animate-spin" /> : null}
+            {isImporting ? 'Importing...' : 'Import skill'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/skills/skill-form.tsx
+++ b/apps/web/src/components/skills/skill-form.tsx
@@ -1,0 +1,365 @@
+'use client'
+
+import type { FormEvent } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { SpinnerGap } from '@phosphor-icons/react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useAgentsCatalog } from '@/hooks/use-agents-catalog'
+import { notifyWorkspaceConfigChanged } from '@/lib/runtime/config-status-events'
+import { cn } from '@/lib/utils'
+
+type SkillFormProps = {
+  cancelLabel?: string
+  mode: 'create' | 'edit'
+  onCancel?: () => void
+  onDeleted?: (result: { name: string }) => void | Promise<void>
+  onSaved?: (result: { mode: 'create' | 'edit'; name: string }) => void | Promise<void>
+  skillName?: string
+  slug: string
+}
+
+type SkillDetailResponse = {
+  hash?: string | null
+  skill?: {
+    assignedAgentIds: string[]
+    body: string
+    description: string
+    hasResources: boolean
+    name: string
+    resourcePaths: string[]
+  }
+  error?: string
+}
+
+const TEXTAREA_CLASS_NAME =
+  'min-h-[120px] w-full rounded-lg border border-border/60 bg-card/50 px-3 py-2 text-sm text-foreground outline-none focus:ring-2 focus:ring-ring/30'
+
+export function SkillForm({
+  slug,
+  mode,
+  skillName,
+  cancelLabel = 'Cancel',
+  onCancel,
+  onDeleted,
+  onSaved,
+}: SkillFormProps) {
+  const { agents, isLoading: isLoadingAgents, loadError: agentsLoadError } = useAgentsCatalog(slug)
+
+  const [name, setName] = useState(skillName ?? '')
+  const [description, setDescription] = useState('')
+  const [body, setBody] = useState('')
+  const [assignedAgentIds, setAssignedAgentIds] = useState<string[]>([])
+  const [resourcePaths, setResourcePaths] = useState<string[]>([])
+  const [hash, setHash] = useState<string | null>()
+  const [isLoading, setIsLoading] = useState(mode === 'edit')
+  const [isSaving, setIsSaving] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saveSuccess, setSaveSuccess] = useState(false)
+
+  useEffect(() => {
+    if (mode === 'edit' && skillName) {
+      setIsLoading(true)
+      setLoadError(null)
+
+      fetch(`/api/u/${slug}/skills/${skillName}`, { cache: 'no-store' })
+        .then(async (response) => {
+          const data = (await response.json().catch(() => null)) as SkillDetailResponse | null
+          if (!response.ok || !data?.skill) {
+            setLoadError(data?.error ?? 'load_failed')
+            return
+          }
+
+          setName(data.skill.name)
+          setDescription(data.skill.description)
+          setBody(data.skill.body)
+          setAssignedAgentIds(data.skill.assignedAgentIds)
+          setResourcePaths(data.skill.resourcePaths)
+          setHash(data.hash)
+        })
+        .catch(() => setLoadError('network_error'))
+        .finally(() => setIsLoading(false))
+
+      return
+    }
+
+    fetch(`/api/u/${slug}/skills`, { cache: 'no-store' })
+      .then(async (response) => {
+        const data = (await response.json().catch(() => null)) as { hash?: string | null } | null
+        if (response.ok) {
+          setHash(data?.hash)
+        }
+      })
+      .catch(() => {})
+  }, [mode, skillName, slug])
+
+  const sortedAgents = useMemo(
+    () => [...agents].sort((left, right) => {
+      if (left.isPrimary && !right.isPrimary) return -1
+      if (!left.isPrimary && right.isPrimary) return 1
+      return left.displayName.localeCompare(right.displayName)
+    }),
+    [agents]
+  )
+
+  const hasResources = resourcePaths.length > 0
+
+  function toggleAssignedAgent(agentId: string) {
+    setAssignedAgentIds((current) =>
+      current.includes(agentId)
+        ? current.filter((entry) => entry !== agentId)
+        : [...current, agentId]
+    )
+  }
+
+  async function handleDelete() {
+    if (!skillName) return
+    const confirmed = window.confirm(`Delete the skill "${skillName}"?`)
+    if (!confirmed) return
+
+    setSaveError(null)
+    setIsSaving(true)
+
+    try {
+      const response = await fetch(`/api/u/${slug}/skills/${skillName}`, {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ expectedHash: hash }),
+      })
+      const data = (await response.json().catch(() => null)) as { error?: string } | null
+      if (!response.ok) {
+        setSaveError(data?.error ?? 'delete_failed')
+        return
+      }
+
+      notifyWorkspaceConfigChanged()
+      await onDeleted?.({ name: skillName })
+    } catch {
+      setSaveError('network_error')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (isSaving) return
+
+    const normalizedName = name.trim()
+    const normalizedDescription = description.trim()
+    if (!normalizedName) {
+      setSaveError('Skill name is required.')
+      return
+    }
+    if (!normalizedDescription) {
+      setSaveError('Description is required.')
+      return
+    }
+
+    setIsSaving(true)
+    setSaveError(null)
+    setSaveSuccess(false)
+
+    try {
+      if (mode === 'create') {
+        const response = await fetch(`/api/u/${slug}/skills`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            name: normalizedName,
+            description: normalizedDescription,
+            body,
+            assignedAgentIds,
+            expectedHash: hash,
+          }),
+        })
+        const data = (await response.json().catch(() => null)) as { error?: string; hash?: string | null } | null
+        if (!response.ok) {
+          setSaveError(data?.error ?? 'create_failed')
+          return
+        }
+
+        setHash(data?.hash)
+        setSaveSuccess(true)
+        notifyWorkspaceConfigChanged()
+        await onSaved?.({ name: normalizedName, mode })
+        setTimeout(() => setSaveSuccess(false), 2000)
+        return
+      }
+
+      const response = await fetch(`/api/u/${slug}/skills/${skillName}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          description: normalizedDescription,
+          body,
+          assignedAgentIds,
+          expectedHash: hash,
+        }),
+      })
+      const data = (await response.json().catch(() => null)) as { error?: string; hash?: string | null } | null
+      if (!response.ok) {
+        setSaveError(data?.error ?? 'update_failed')
+        return
+      }
+
+      setHash(data?.hash)
+      setSaveSuccess(true)
+      notifyWorkspaceConfigChanged()
+      await onSaved?.({ name: skillName ?? normalizedName, mode })
+      setTimeout(() => setSaveSuccess(false), 2000)
+    } catch {
+      setSaveError('network_error')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  if (isLoading || isLoadingAgents) {
+    return (
+      <div className="flex min-h-[320px] items-center justify-center">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <SpinnerGap size={16} className="animate-spin" />
+          Loading skill...
+        </div>
+      </div>
+    )
+  }
+
+  if (loadError || agentsLoadError) {
+    return (
+      <div className="rounded-lg border border-border/60 bg-card/50 p-4 text-sm text-destructive">
+        Failed to load: {loadError ?? agentsLoadError}
+      </div>
+    )
+  }
+
+  const saveLabel = isSaving
+    ? 'Saving...'
+    : saveSuccess
+      ? 'Saved'
+      : mode === 'create'
+        ? 'Create skill'
+        : 'Save changes'
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="space-y-2">
+        <Label htmlFor="skill-name">Skill name</Label>
+        <Input
+          id="skill-name"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="pdf-processing"
+          disabled={mode === 'edit'}
+          required
+        />
+        <p className="text-xs text-muted-foreground">
+          Lowercase letters, numbers, and hyphens only. This identifier is immutable after creation.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="skill-description">Description</Label>
+        <textarea
+          id="skill-description"
+          className={cn(TEXTAREA_CLASS_NAME, 'min-h-[96px]')}
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          placeholder="Describe what the skill does and when an agent should use it."
+          required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="skill-body">SKILL.md body</Label>
+        <textarea
+          id="skill-body"
+          className={cn(TEXTAREA_CLASS_NAME, 'min-h-[320px]')}
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          placeholder="# When to use this skill\n\nExplain the workflow and important constraints..."
+        />
+      </div>
+
+      {hasResources ? (
+        <div className="rounded-lg border border-border/60 bg-card/50 p-4 text-sm text-muted-foreground">
+          This skill includes {resourcePaths.length} bundled file{resourcePaths.length === 1 ? '' : 's'}.
+          Edit them by exporting the skill, changing the bundle locally, and importing it again.
+        </div>
+      ) : null}
+
+      <div className="space-y-3">
+        <Label>Assigned agents</Label>
+        <p className="text-xs text-muted-foreground">
+          Choose which agents can use this skill by default.
+        </p>
+
+        {sortedAgents.length === 0 ? (
+          <div className="rounded-lg border border-border/60 bg-card/50 p-3 text-sm text-muted-foreground">
+            No agents available.
+          </div>
+        ) : (
+          <div className="grid gap-2 md:grid-cols-2">
+            {sortedAgents.map((agent) => {
+              const checked = assignedAgentIds.includes(agent.id)
+              return (
+                <label
+                  key={agent.id}
+                  className={cn(
+                    'flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors',
+                    checked
+                      ? 'border-primary/40 bg-primary/5 text-foreground'
+                      : 'border-border/60 bg-card/40 text-muted-foreground hover:bg-card/70'
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleAssignedAgent(agent.id)}
+                    className="h-4 w-4 rounded border border-border/70 bg-card/70 accent-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                  />
+                  <span className="font-medium">{agent.displayName}</span>
+                  {agent.isPrimary ? <span className="text-xs">(Primary)</span> : null}
+                </label>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {saveError ? (
+        <div className="rounded-lg border border-border/60 bg-card/50 p-4 text-sm text-destructive">
+          Error: {saveError}
+        </div>
+      ) : null}
+
+      <div className="flex items-center justify-between border-t border-border/40 pt-6">
+        <div className="flex items-center gap-3">
+          <Button type="submit" disabled={isSaving} variant={saveSuccess ? 'secondary' : 'default'}>
+            {saveLabel}
+          </Button>
+          {onCancel ? (
+            <Button type="button" variant="ghost" onClick={onCancel}>
+              {cancelLabel}
+            </Button>
+          ) : null}
+        </div>
+
+        {mode === 'edit' ? (
+          <button
+            type="button"
+            onClick={() => void handleDelete()}
+            disabled={isSaving}
+            className="text-sm text-destructive underline-offset-2 hover:underline disabled:opacity-50"
+          >
+            Delete skill
+          </button>
+        ) : null}
+      </div>
+    </form>
+  )
+}

--- a/apps/web/src/components/skills/skills-list.tsx
+++ b/apps/web/src/components/skills/skills-list.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import Link from 'next/link'
+
+import { Button } from '@/components/ui/button'
+import type { SkillListItem } from '@/hooks/use-skills-catalog'
+
+type SkillsListProps = {
+  emptyMessage: string
+  isAdmin: boolean
+  onEdit?: (skillName: string) => void
+  skills: SkillListItem[]
+  slug: string
+}
+
+export function SkillsList({ slug, skills, isAdmin, onEdit, emptyMessage }: SkillsListProps) {
+  if (skills.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-border/60 bg-card/40 p-8 text-center text-sm text-muted-foreground">
+        {emptyMessage}
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {skills.map((skill) => (
+        <article key={skill.name} className="rounded-xl border border-border/60 bg-card/40 p-5">
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <h2 className="text-lg font-medium text-foreground">{skill.name}</h2>
+              <p className="text-sm text-muted-foreground">{skill.description}</p>
+            </div>
+
+            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+              <span className="rounded-full border border-border/60 px-2 py-1">
+                {skill.assignedAgentIds.length} agent{skill.assignedAgentIds.length === 1 ? '' : 's'}
+              </span>
+              <span className="rounded-full border border-border/60 px-2 py-1">
+                {skill.hasResources ? `${skill.resourcePaths.length} bundled file${skill.resourcePaths.length === 1 ? '' : 's'}` : 'SKILL.md only'}
+              </span>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2 pt-2">
+              <Button type="button" variant="outline" asChild>
+                <a href={`/api/u/${slug}/skills/${skill.name}/export`}>Export</a>
+              </Button>
+
+              {isAdmin ? (
+                onEdit ? (
+                  <Button type="button" variant="ghost" onClick={() => onEdit(skill.name)}>
+                    Edit
+                  </Button>
+                ) : (
+                  <Button type="button" variant="ghost" asChild>
+                    <Link href={`/u/${slug}/skills/${skill.name}`}>Edit</Link>
+                  </Button>
+                )
+              ) : null}
+            </div>
+          </div>
+        </article>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/components/skills/skills-page.tsx
+++ b/apps/web/src/components/skills/skills-page.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { SpinnerGap } from '@phosphor-icons/react'
+
+import { ImportSkillDialog } from '@/components/skills/import-skill-dialog'
+import { SkillsList } from '@/components/skills/skills-list'
+import { Button } from '@/components/ui/button'
+import { useAgentsCatalog } from '@/hooks/use-agents-catalog'
+import { useSkillsCatalog } from '@/hooks/use-skills-catalog'
+
+type SkillsPageClientProps = {
+  isAdmin: boolean
+  slug: string
+}
+
+export function SkillsPageClient({ slug, isAdmin }: SkillsPageClientProps) {
+  const { skills, hash, isLoading, loadError, reload } = useSkillsCatalog(slug)
+  const { agents } = useAgentsCatalog(slug)
+  const [isImportDialogOpen, setIsImportDialogOpen] = useState(false)
+
+  const agentOptions = useMemo(
+    () => agents.map((agent) => ({ id: agent.id, displayName: agent.displayName, isPrimary: agent.isPrimary })),
+    [agents]
+  )
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-2">
+          <h1 className="type-display text-3xl font-semibold tracking-tight">Skills</h1>
+          <p className="text-muted-foreground">
+            Manage reusable OpenCode skills and assign them to the agents that can use them.
+          </p>
+        </div>
+
+        {isAdmin ? (
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" variant="outline" onClick={() => setIsImportDialogOpen(true)}>
+              Import skill
+            </Button>
+            <Button type="button" variant="outline" asChild>
+              <Link href={`/u/${slug}/skills/new`}>Create skill</Link>
+            </Button>
+          </div>
+        ) : null}
+      </div>
+
+      {isLoading ? (
+        <div className="flex min-h-[220px] items-center justify-center">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <SpinnerGap size={16} className="animate-spin" />
+            Loading skills...
+          </div>
+        </div>
+      ) : null}
+
+      {loadError ? (
+        <div className="space-y-4 rounded-xl border border-border/60 bg-card/50 p-5">
+          <p className="text-sm text-destructive">Failed to load: {loadError}</p>
+          <Button type="button" variant="outline" onClick={() => void reload()}>
+            Retry
+          </Button>
+        </div>
+      ) : null}
+
+      {!isLoading && !loadError ? (
+        <SkillsList
+          slug={slug}
+          skills={skills}
+          isAdmin={isAdmin}
+          emptyMessage="No skills configured yet."
+        />
+      ) : null}
+
+      <ImportSkillDialog
+        slug={slug}
+        open={isImportDialogOpen}
+        onOpenChange={setIsImportDialogOpen}
+        agents={agentOptions}
+        expectedHash={hash}
+        onImported={reload}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/skills/web-skill-form.tsx
+++ b/apps/web/src/components/skills/web-skill-form.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+
+import { SkillForm } from '@/components/skills/skill-form'
+
+type WebSkillFormProps = {
+  mode: 'create' | 'edit'
+  skillName?: string
+  slug: string
+}
+
+export function WebSkillForm({ slug, mode, skillName }: WebSkillFormProps) {
+  const router = useRouter()
+
+  const handleCancel = useCallback(() => {
+    router.push(`/u/${slug}/skills`)
+  }, [router, slug])
+
+  const handleDelete = useCallback(() => {
+    router.push(`/u/${slug}/skills`)
+  }, [router, slug])
+
+  const handleSave = useCallback(async ({ mode: currentMode }: { mode: 'create' | 'edit'; name: string }) => {
+    if (currentMode === 'create') {
+      router.push(`/u/${slug}/skills`)
+    }
+  }, [router, slug])
+
+  return (
+    <SkillForm
+      slug={slug}
+      mode={mode}
+      skillName={skillName}
+      onCancel={handleCancel}
+      onDeleted={handleDelete}
+      onSaved={handleSave}
+    />
+  )
+}

--- a/apps/web/src/components/workspace/__tests__/inspector-panel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/inspector-panel.test.tsx
@@ -1,5 +1,6 @@
 /** @vitest-environment jsdom */
 
+import { useState } from 'react'
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -7,14 +8,30 @@ import { InspectorPanel } from "@/components/workspace/inspector-panel";
 
 const markdownEditorMock = vi.fn(
   ({ onOpenInternalLink }: { onOpenInternalLink?: (path: string) => void }) => (
+    <MockMarkdownEditor onOpenInternalLink={onOpenInternalLink} />
+  )
+);
+
+function MockMarkdownEditor({
+  onOpenInternalLink,
+}: {
+  onOpenInternalLink?: (path: string) => void
+}) {
+  const [label, setLabel] = useState('initial')
+
+  return (
     <div>
       <button type="button" onClick={() => onOpenInternalLink?.("docs/target.md")}>
         Open link
       </button>
+      <button type="button" onClick={() => setLabel('dirty')}>
+        Mutate editor
+      </button>
+      <span>Editor state: {label}</span>
       Markdown editor
     </div>
   )
-);
+}
 
 vi.mock("@/components/workspace/markdown-editor", () => ({
   MarkdownEditor: (props: unknown) => markdownEditorMock(props as { onOpenInternalLink?: (path: string) => void }),
@@ -143,4 +160,65 @@ describe("InspectorPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open link" }));
     expect(onOpenFile).toHaveBeenCalledWith("docs/target.md");
   });
+
+  it('remounts the markdown editor when switching active files', () => {
+    const onSaveFile = vi.fn().mockResolvedValue({ ok: true })
+
+    const { rerender } = render(
+      <InspectorPanel
+        {...defaultProps}
+        openFiles={[
+          {
+            path: 'first.md',
+            title: 'first.md',
+            content: '# First',
+            updatedAt: 'now',
+            size: '1 KB',
+            kind: 'markdown' as const,
+          },
+          {
+            path: 'second.md',
+            title: 'second.md',
+            content: '# Second',
+            updatedAt: 'now',
+            size: '1 KB',
+            kind: 'markdown' as const,
+          },
+        ]}
+        activeFilePath='first.md'
+        onSaveFile={onSaveFile}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mutate editor' }))
+    expect(screen.getByText('Editor state: dirty')).toBeTruthy()
+
+    rerender(
+      <InspectorPanel
+        {...defaultProps}
+        openFiles={[
+          {
+            path: 'first.md',
+            title: 'first.md',
+            content: '# First',
+            updatedAt: 'now',
+            size: '1 KB',
+            kind: 'markdown' as const,
+          },
+          {
+            path: 'second.md',
+            title: 'second.md',
+            content: '# Second',
+            updatedAt: 'now',
+            size: '1 KB',
+            kind: 'markdown' as const,
+          },
+        ]}
+        activeFilePath='second.md'
+        onSaveFile={onSaveFile}
+      />
+    )
+
+    expect(screen.getByText('Editor state: initial')).toBeTruthy()
+  })
 });

--- a/apps/web/src/components/workspace/__tests__/left-panel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/left-panel.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LeftPanel } from "@/components/workspace/left-panel";
 import { WorkspaceThemeProvider } from "@/contexts/workspace-theme-context";
 import type { AgentCatalogItem } from "@/hooks/use-workspace";
+import type { SkillListItem } from '@/hooks/use-skills-catalog'
 import type { WorkspaceFileNode, WorkspaceSession } from "@/lib/opencode/types";
 
 const sessions: WorkspaceSession[] = [
@@ -68,6 +69,16 @@ const agents: AgentCatalogItem[] = [
   },
 ];
 
+const skills: SkillListItem[] = [
+  {
+    name: 'pdf-processing',
+    description: 'Process PDF documents',
+    assignedAgentIds: ['a2'],
+    hasResources: false,
+    resourcePaths: [],
+  },
+];
+
 const defaultProps = {
   slug: "alice",
   status: "active" as const,
@@ -84,6 +95,8 @@ const defaultProps = {
   agents,
   onSelectAgent: vi.fn(),
   onOpenExpertsSettings: vi.fn(),
+  skills,
+  onOpenSkillsSettings: vi.fn(),
   fileNodes,
   activeFilePath: null as string | null,
   onSelectFile: vi.fn(),
@@ -146,7 +159,7 @@ describe("LeftPanel", () => {
   it("filters sections using internal search state", () => {
     renderLeftPanel();
 
-    const searchInput = screen.getByLabelText("Search chats, knowledge, and experts");
+    const searchInput = screen.getByLabelText("Search chats, knowledge, experts, and skills");
     if (!(searchInput instanceof HTMLInputElement)) {
       throw new Error("Expected search input element");
     }
@@ -160,6 +173,7 @@ describe("LeftPanel", () => {
 
     expect(screen.queryByText("Alpha Agent")).toBeNull();
     expect(screen.getByText("Beta Agent")).toBeTruthy();
+    expect(screen.queryByText('pdf-processing')).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
 
@@ -168,6 +182,7 @@ describe("LeftPanel", () => {
     expect(screen.getByText("alpha.md")).toBeTruthy();
     expect(screen.queryByText("Alpha Agent")).toBeNull();
     expect(screen.getByText("Beta Agent")).toBeTruthy();
+    expect(screen.getByText('pdf-processing')).toBeTruthy();
   });
 
   it("creates a markdown file in the selected directory", async () => {
@@ -199,7 +214,10 @@ describe("LeftPanel", () => {
   it("hydrates subpanel collapsed state from storage", () => {
     localStorage.setItem(
       "arche.workspace.alice.left-panel",
-      JSON.stringify({ topCollapsed: true, midCollapsed: false, bottomCollapsed: true })
+      JSON.stringify({
+        collapsed: { chats: true, knowledge: false, experts: true, skills: false },
+        ratios: { chats: 0.32, knowledge: 0.32, experts: 0.18, skills: 0.18 },
+      })
     );
 
     renderLeftPanel();
@@ -214,37 +232,41 @@ describe("LeftPanel", () => {
     expect(chatHeaders.length).toBeGreaterThan(0);
     // topCollapsed = true means the section has flexBasis: HEADER_HEIGHT and grow: 0
     // We can check that the persisted value was loaded by verifying what gets persisted back
-    expect(localStorage.getItem("arche.workspace.alice.left-panel")).toContain('"topCollapsed":true');
+    expect(localStorage.getItem("arche.workspace.alice.left-panel")).toContain('"chats":true');
   });
 
   it("hydrates subpanel collapsed state from the cookie when localStorage is empty", () => {
     document.cookie = `arche-workspace-left-panel-alice=${encodeURIComponent(JSON.stringify({
-      topCollapsed: true,
-      midCollapsed: false,
-      bottomCollapsed: true,
-      topRatio: 0.42,
-      midRatio: 0.33,
+      collapsed: { chats: true, knowledge: false, experts: true, skills: true },
+      ratios: { chats: 0.42, knowledge: 0.33, experts: 0.15, skills: 0.1 },
     }))}; Path=/`;
 
     renderLeftPanel();
 
-    expect(localStorage.getItem("arche.workspace.alice.left-panel")).toContain('"topCollapsed":true');
-    expect(localStorage.getItem("arche.workspace.alice.left-panel")).toContain('"bottomCollapsed":true');
+    expect(localStorage.getItem("arche.workspace.alice.left-panel")).toContain('"chats":true');
+    expect(localStorage.getItem("arche.workspace.alice.left-panel")).toContain('"skills":true');
   });
 
   it("hydrates subpanel collapsed state from the initial server state", () => {
     renderLeftPanel({
       initialPanelState: {
-        topRatio: 0.42,
-        midRatio: 0.33,
-        topCollapsed: true,
-        midCollapsed: false,
-        bottomCollapsed: true,
+        ratios: {
+          chats: 0.42,
+          knowledge: 0.33,
+          experts: 0.15,
+          skills: 0.1,
+        },
+        collapsed: {
+          chats: true,
+          knowledge: false,
+          experts: true,
+          skills: true,
+        },
       },
     });
 
-    expect(localStorage.getItem("arche.workspace.alice.left-panel")).toContain('"topCollapsed":true');
-    expect(localStorage.getItem("arche.workspace.alice.left-panel")).toContain('"bottomCollapsed":true');
+    expect(localStorage.getItem("arche.workspace.alice.left-panel")).toContain('"chats":true');
+    expect(localStorage.getItem("arche.workspace.alice.left-panel")).toContain('"skills":true');
   });
 
   it("persists subpanel collapsed state to storage on toggle", () => {
@@ -266,7 +288,7 @@ describe("LeftPanel", () => {
     const stored = localStorage.getItem("arche.workspace.alice.left-panel");
     expect(stored).not.toBeNull();
     const parsed = JSON.parse(stored!);
-    expect(parsed.topCollapsed).toBe(true);
+    expect(parsed.collapsed.chats).toBe(true);
   });
 
   it("shows a new chat button when the left panel is collapsed", () => {

--- a/apps/web/src/components/workspace/__tests__/left-panel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/left-panel.test.tsx
@@ -96,6 +96,7 @@ const defaultProps = {
   onSelectAgent: vi.fn(),
   onOpenExpertsSettings: vi.fn(),
   skills,
+  onSelectSkill: vi.fn(),
   onOpenSkillsSettings: vi.fn(),
   fileNodes,
   activeFilePath: null as string | null,

--- a/apps/web/src/components/workspace/__tests__/markdown-editor.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/markdown-editor.test.tsx
@@ -163,6 +163,30 @@ describe("MarkdownEditor", () => {
     expect(onChange).toHaveBeenCalledWith(["---", "title: Beta", "---", "# Body"].join("\n"));
   });
 
+  it("does not coerce cleared numeric properties to zero while typing", () => {
+    const onChange = vi.fn();
+
+    render(
+      <MarkdownEditor
+        value={["---", "rating: 4", "---", "# Body"].join("\n")}
+        onChange={onChange}
+        saveState="saved"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    const input = screen.getByLabelText("Property 1 value") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(input.value).toBe("");
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.change(input, { target: { value: "42" } });
+
+    expect(onChange).toHaveBeenCalledWith(["---", "rating: 42", "---", "# Body"].join("\n"));
+  });
+
   it("does not persist a blank property when adding a new row", () => {
     const onChange = vi.fn();
 

--- a/apps/web/src/components/workspace/__tests__/workspace-shell.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/workspace-shell.test.tsx
@@ -76,6 +76,16 @@ vi.mock("@/hooks/use-workspace", () => ({
   }),
 }));
 
+vi.mock('@/hooks/use-skills-catalog', () => ({
+  useSkillsCatalog: () => ({
+    skills: [],
+    hash: null,
+    isLoading: false,
+    loadError: null,
+    reload: vi.fn(),
+  }),
+}))
+
 vi.mock("@/components/workspace/chat-panel", () => ({
   ChatPanel: ({ onShowContext, pendingInsert }: { onShowContext?: () => void; pendingInsert?: string | null }) => (
     <div>

--- a/apps/web/src/components/workspace/inspector-panel.tsx
+++ b/apps/web/src/components/workspace/inspector-panel.tsx
@@ -469,6 +469,7 @@ function ExpandedInspectorPanel({
                 <div className="flex-1 min-h-0 overflow-y-auto scrollbar-none">
                   {activeFile.kind === "markdown" && activeDraft != null && canEditMarkdown ? (
                     <MarkdownEditor
+                      key={activeFile.path}
                       value={activeDraft}
                       onChange={(next) =>
                         handleChange(activeFile.path, next, activeFile.content, activeFile.hash)

--- a/apps/web/src/components/workspace/left-panel.tsx
+++ b/apps/web/src/components/workspace/left-panel.tsx
@@ -15,11 +15,12 @@ import {
   Plugs,
    Plus,
    Robot,
-   ArrowLineLeft,
-   SlidersHorizontal,
-   Sun,
-   Warning,
-   X,
+    ArrowLineLeft,
+    Lightning,
+    SlidersHorizontal,
+    Sun,
+    Warning,
+    X,
 } from "@phosphor-icons/react";
 
 import { DesktopVaultSwitcher } from '@/components/desktop/desktop-vault-switcher'
@@ -50,6 +51,7 @@ import { Label } from "@/components/ui/label";
 import type { SyncKbResult } from "@/app/api/instances/[slug]/sync-kb/route";
 import { useWorkspaceTheme } from "@/contexts/workspace-theme-context";
 import type { AgentCatalogItem } from "@/hooks/use-workspace";
+import type { SkillListItem } from '@/hooks/use-skills-catalog'
 import {
   getConfigChangeMessage,
   type ConfigChangeReason,
@@ -58,8 +60,10 @@ import type { WorkspaceFileNode, WorkspaceSession } from "@/lib/opencode/types";
 import { getProviderLabel } from "@/lib/providers/catalog";
 import {
   DEFAULT_LEFT_PANEL_STATE,
+  LEFT_PANEL_SECTION_IDS,
   getWorkspaceLeftPanelCookieName,
   getWorkspaceLeftPanelStorageKey,
+  type LeftPanelSectionId,
   normalizeLeftPanelState,
   type NormalizedLeftPanelState,
   parseStoredLeftPanelState,
@@ -72,6 +76,7 @@ import { cn } from "@/lib/utils";
 import { AgentsPanel } from "./agents-panel";
 import { FileTreePanel } from "./file-tree-panel";
 import { SessionsPanel } from "./sessions-panel";
+import { SkillsPanel } from './skills-panel'
 import { SyncKbButton } from "./sync-kb-button";
 
 const MIN_SECTION_PX = 60;
@@ -158,6 +163,10 @@ type LeftPanelProps = {
   agents: AgentCatalogItem[];
   onSelectAgent: (agent: AgentCatalogItem) => void;
   onOpenExpertsSettings: () => void;
+
+  // Skills
+  skills: SkillListItem[];
+  onOpenSkillsSettings: () => void;
 
   // Knowledge (file tree)
   fileNodes: WorkspaceFileNode[];
@@ -265,7 +274,7 @@ function MinifiedLeftPanel({
   showConfigRestartNotice?: boolean;
   onCreateSession: () => void;
   onToggleLeft: () => void;
-  onExpandWithSection: (section: "chats" | "knowledge" | "experts") => void;
+  onExpandWithSection: (section: "chats" | "knowledge" | "experts" | "skills") => void;
   onSyncComplete?: (status: SyncKbResult["status"]) => void;
   onNavigateSettings: () => void;
 }) {
@@ -363,8 +372,22 @@ function MinifiedLeftPanel({
               <Robot size={16} weight="bold" />
             </button>
           </TooltipTrigger>
-          <TooltipContent side="right">Experts</TooltipContent>
-        </Tooltip>
+           <TooltipContent side="right">Experts</TooltipContent>
+         </Tooltip>
+
+         <Tooltip>
+           <TooltipTrigger asChild>
+             <button
+               type="button"
+               onClick={() => onExpandWithSection("skills")}
+               className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"
+               aria-label="Skills"
+             >
+               <Lightning size={16} weight="bold" />
+             </button>
+           </TooltipTrigger>
+           <TooltipContent side="right">Skills</TooltipContent>
+         </Tooltip>
 
         {/* Spacer */}
         <div className="flex-1" />
@@ -527,6 +550,8 @@ export function LeftPanel({
   agents,
   onSelectAgent,
   onOpenExpertsSettings,
+  skills,
+  onOpenSkillsSettings,
   fileNodes,
   activeFilePath,
   onSelectFile,
@@ -536,10 +561,11 @@ export function LeftPanel({
   hideCollapseButton = false,
   initialPanelState,
   searchInputRef,
-}: LeftPanelProps) {
-  const pendingSectionRef = useRef<"chats" | "knowledge" | "experts" | null>(null);
 
-  const handleExpandWithSection = useCallback((section: "chats" | "knowledge" | "experts") => {
+}: LeftPanelProps) {
+  const pendingSectionRef = useRef<"chats" | "knowledge" | "experts" | "skills" | null>(null);
+
+  const handleExpandWithSection = useCallback((section: "chats" | "knowledge" | "experts" | "skills") => {
     pendingSectionRef.current = section;
     onToggleLeft();
   }, [onToggleLeft]);
@@ -582,15 +608,17 @@ export function LeftPanel({
       onSyncComplete={onSyncComplete}
       onNavigateDashboard={onNavigateDashboard}
       onNavigateSettings={onNavigateSettings}
-      sessions={sessions}
-      activeSessionId={activeSessionId}
-      unseenCompletedSessions={unseenCompletedSessions}
-      onSelectSession={onSelectSession}
-      onCreateSession={onCreateSession}
-      agents={agents}
-      onSelectAgent={onSelectAgent}
-      onOpenExpertsSettings={onOpenExpertsSettings}
-      fileNodes={fileNodes}
+       sessions={sessions}
+        activeSessionId={activeSessionId}
+        unseenCompletedSessions={unseenCompletedSessions}
+        onSelectSession={onSelectSession}
+        onCreateSession={onCreateSession}
+        agents={agents}
+        onSelectAgent={onSelectAgent}
+        onOpenExpertsSettings={onOpenExpertsSettings}
+        skills={skills}
+        onOpenSkillsSettings={onOpenSkillsSettings}
+        fileNodes={fileNodes}
       activeFilePath={activeFilePath}
       onSelectFile={onSelectFile}
       onDownloadFile={onDownloadFile}
@@ -626,6 +654,8 @@ function ExpandedLeftPanel({
   agents,
   onSelectAgent,
   onOpenExpertsSettings,
+  skills,
+  onOpenSkillsSettings,
   fileNodes,
   activeFilePath,
   onSelectFile,
@@ -636,7 +666,7 @@ function ExpandedLeftPanel({
   initialPanelState,
   searchInputRef,
   pendingSectionRef,
-}: LeftPanelProps & { pendingSectionRef?: RefObject<"chats" | "knowledge" | "experts" | null> }) {
+}: LeftPanelProps & { pendingSectionRef?: RefObject<"chats" | "knowledge" | "experts" | "skills" | null> }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const newFileNameRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -656,21 +686,16 @@ function ExpandedLeftPanel({
   );
   const showRestartNotice = Boolean(currentVault && (configChangePending || configRestartError) && onRestartConfig);
 
-  const [topRatio, setTopRatio] = useState(resolvedInitialPanelState.topRatio);
-  const [midRatio, setMidRatio] = useState(resolvedInitialPanelState.midRatio);
-
-  const [topCollapsed, setTopCollapsed] = useState(resolvedInitialPanelState.topCollapsed);
-  const [midCollapsed, setMidCollapsed] = useState(resolvedInitialPanelState.midCollapsed);
-  const [bottomCollapsed, setBottomCollapsed] = useState(resolvedInitialPanelState.bottomCollapsed);
+  const sectionOrder = LEFT_PANEL_SECTION_IDS;
+  const [ratios, setRatios] = useState(resolvedInitialPanelState.ratios);
+  const [collapsedSections, setCollapsedSections] = useState(resolvedInitialPanelState.collapsed);
 
   // Expand the requested section when coming from a minified panel click
   useEffect(() => {
     const section = pendingSectionRef?.current;
     if (!section) return;
     pendingSectionRef.current = null;
-    if (section === "chats") setTopCollapsed(false);
-    else if (section === "knowledge") setMidCollapsed(false);
-    else if (section === "experts") setBottomCollapsed(false);
+    setCollapsedSections((current) => ({ ...current, [section]: false }));
   }, [pendingSectionRef]);
 
   const directoryOptions = useMemo(
@@ -747,8 +772,11 @@ function ExpandedLeftPanel({
   );
 
   useEffect(() => {
-    persistLeftPanelState(leftPanelStorageKey, leftPanelCookieName, { topRatio, midRatio, topCollapsed, midCollapsed, bottomCollapsed });
-  }, [leftPanelCookieName, leftPanelStorageKey, topRatio, midRatio, topCollapsed, midCollapsed, bottomCollapsed]);
+    persistLeftPanelState(leftPanelStorageKey, leftPanelCookieName, {
+      ratios,
+      collapsed: collapsedSections,
+    });
+  }, [collapsedSections, leftPanelCookieName, leftPanelStorageKey, ratios]);
 
   useEffect(() => {
     if (!isCreateFileDialogOpen) return;
@@ -823,81 +851,32 @@ function ExpandedLeftPanel({
     [isCreatingFile, newFileName, onCreateKnowledgeFile, resetCreateFileDialog, selectedDirectoryPath]
   );
 
-  // Effective ratios — redistribute space proportionally among expanded sections
-  const baseBot = 1 - topRatio - midRatio;
-  const expandedSum =
-    (topCollapsed ? 0 : topRatio) +
-    (midCollapsed ? 0 : midRatio) +
-    (bottomCollapsed ? 0 : baseBot);
-
-  const effectiveTop = expandedSum > 0 ? topRatio / expandedSum : 1;
-  const effectiveMid = expandedSum > 0 ? midRatio / expandedSum : 1;
-  const effectiveBot = expandedSum > 0 ? baseBot / expandedSum : 1;
-
-  const handleResizeTop = useCallback(
-    (event: React.PointerEvent<HTMLDivElement>) => {
-      event.preventDefault();
-      const container = containerRef.current;
-      if (!container) return;
-      const containerHeight = container.getBoundingClientRect().height;
-      const handle = event.currentTarget;
-      const startY = event.clientY;
-      const startTopRatio = topRatio;
-      const startMidRatio = midRatio;
-
-      setIsDragging(true);
-      handle.setPointerCapture(event.pointerId);
-      document.body.style.cursor = "row-resize";
-      document.body.style.userSelect = "none";
-
-      const onMove = (moveEvent: PointerEvent) => {
-        const deltaY = moveEvent.clientY - startY;
-        const deltaRatio = deltaY / containerHeight;
-        const minRatio = MIN_SECTION_PX / containerHeight;
-
-        let newTop = startTopRatio + deltaRatio;
-        let newMid = startMidRatio - deltaRatio;
-        const bottomRatio = 1 - newTop - newMid;
-
-        if (newTop < minRatio) {
-          newMid = newMid - (minRatio - newTop);
-          newTop = minRatio;
-        }
-        if (newMid < minRatio) {
-          newTop = newTop - (minRatio - newMid);
-          newMid = minRatio;
-        }
-        if (newTop < minRatio) newTop = minRatio;
-        if (bottomRatio < minRatio) return;
-
-        setTopRatio(newTop);
-        setMidRatio(newMid);
-      };
-
-      const onUp = () => {
-        setIsDragging(false);
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
-        handle.releasePointerCapture(event.pointerId);
-        window.removeEventListener("pointermove", onMove);
-        window.removeEventListener("pointerup", onUp);
-      };
-
-      window.addEventListener("pointermove", onMove);
-      window.addEventListener("pointerup", onUp);
-    },
-    [topRatio, midRatio]
+  const expandedRatioTotal = useMemo(
+    () => sectionOrder.reduce((sum, sectionId) => sum + (collapsedSections[sectionId] ? 0 : ratios[sectionId]), 0),
+    [collapsedSections, ratios, sectionOrder]
   );
 
-  const handleResizeMid = useCallback(
-    (event: React.PointerEvent<HTMLDivElement>) => {
+  const effectiveRatios = useMemo(
+    () => Object.fromEntries(
+      sectionOrder.map((sectionId) => [
+        sectionId,
+        expandedRatioTotal > 0 ? ratios[sectionId] / expandedRatioTotal : 1 / sectionOrder.length,
+      ])
+    ) as Record<LeftPanelSectionId, number>,
+    [expandedRatioTotal, ratios, sectionOrder]
+  );
+
+  const handleResize = useCallback(
+    (firstSectionId: LeftPanelSectionId, secondSectionId: LeftPanelSectionId, event: React.PointerEvent<HTMLDivElement>) => {
       event.preventDefault();
       const container = containerRef.current;
       if (!container) return;
+
       const containerHeight = container.getBoundingClientRect().height;
       const handle = event.currentTarget;
       const startY = event.clientY;
-      const startMidRatio = midRatio;
+      const startFirstRatio = ratios[firstSectionId];
+      const startSecondRatio = ratios[secondSectionId];
 
       setIsDragging(true);
       handle.setPointerCapture(event.pointerId);
@@ -909,15 +888,28 @@ function ExpandedLeftPanel({
         const deltaRatio = deltaY / containerHeight;
         const minRatio = MIN_SECTION_PX / containerHeight;
 
-        let newMid = startMidRatio + deltaRatio;
-        const bottomRatio = 1 - topRatio - newMid;
+        let nextFirstRatio = startFirstRatio + deltaRatio;
+        let nextSecondRatio = startSecondRatio - deltaRatio;
 
-        if (newMid < minRatio) newMid = minRatio;
-        if (bottomRatio < minRatio) {
-          newMid = 1 - topRatio - minRatio;
+        if (nextFirstRatio < minRatio) {
+          nextSecondRatio -= minRatio - nextFirstRatio;
+          nextFirstRatio = minRatio;
         }
 
-        setMidRatio(newMid);
+        if (nextSecondRatio < minRatio) {
+          nextFirstRatio -= minRatio - nextSecondRatio;
+          nextSecondRatio = minRatio;
+        }
+
+        if (nextFirstRatio < minRatio || nextSecondRatio < minRatio) {
+          return;
+        }
+
+        setRatios((current) => ({
+          ...current,
+          [firstSectionId]: nextFirstRatio,
+          [secondSectionId]: nextSecondRatio,
+        }));
       };
 
       const onUp = () => {
@@ -932,7 +924,7 @@ function ExpandedLeftPanel({
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);
     },
-    [topRatio, midRatio]
+    [ratios]
   );
 
   const sectionStyle = (collapsed: boolean, ratio: number): React.CSSProperties => ({
@@ -948,6 +940,71 @@ function ExpandedLeftPanel({
     transition: isDragging ? "none" : GRID_TRANSITION,
     minHeight: 0,
   });
+
+  const sectionItems: Array<{
+    actionIcon?: typeof Plus
+    actionLabel?: string
+    content: React.ReactNode
+    icon: typeof ChatCircle
+    id: LeftPanelSectionId
+    label: string
+    onAction?: () => void
+  }> = [
+    {
+      id: "chats",
+      icon: ChatCircle,
+      label: "Chats",
+      onAction: onCreateSession,
+      actionIcon: Plus,
+      actionLabel: "New chat",
+      content: (
+        <SessionsPanel
+          sessions={sessions}
+          activeSessionId={activeSessionId}
+          unseenCompletedSessions={unseenCompletedSessions}
+          onSelectSession={onSelectSession}
+          onCreateSession={onCreateSession}
+          query={searchQuery}
+        />
+      ),
+    },
+    {
+      id: "knowledge",
+      icon: Database,
+      label: "Knowledge",
+      onAction: canCreateKnowledgeFile ? handleOpenCreateFileDialog : undefined,
+      actionIcon: canCreateKnowledgeFile ? Plus : undefined,
+      actionLabel: canCreateKnowledgeFile ? "Create file" : undefined,
+      content: (
+        <FileTreePanel
+          nodes={fileNodes}
+          activePath={activeFilePath}
+          onSelect={onSelectFile}
+          onDownloadFile={onDownloadFile}
+          hideHeader
+          query={searchQuery}
+        />
+      ),
+    },
+    {
+      id: "experts",
+      icon: Robot,
+      label: "Experts",
+      onAction: onOpenExpertsSettings,
+      actionIcon: SlidersHorizontal,
+      actionLabel: "Edit experts",
+      content: <AgentsPanel agents={agents} onSelectAgent={onSelectAgent} query={searchQuery} />,
+    },
+    {
+      id: "skills",
+      icon: Lightning,
+      label: "Skills",
+      onAction: onOpenSkillsSettings,
+      actionIcon: SlidersHorizontal,
+      actionLabel: "Edit skills",
+      content: <SkillsPanel skills={skills} query={searchQuery} />,
+    },
+  ];
 
   return (
     <div
@@ -997,7 +1054,7 @@ function ExpandedLeftPanel({
             value={searchQuery}
             onChange={(event) => setSearchQuery(event.target.value)}
             placeholder="Search..."
-            aria-label="Search chats, knowledge, and experts"
+            aria-label="Search chats, knowledge, experts, and skills"
             className="w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/40"
           />
           {searchQuery.trim().length > 0 ? (
@@ -1020,105 +1077,45 @@ function ExpandedLeftPanel({
           )}
       </label>
 
-      {/* Section 1: Chats */}
-      <div
-        style={sectionStyle(topCollapsed, effectiveTop)}
-        className="flex min-h-0 flex-col overflow-hidden rounded-xl bg-foreground/[0.03]"
-      >
-        <SectionHeader
-          icon={ChatCircle}
-          label="Chats"
-          onToggle={() => setTopCollapsed(prev => !prev)}
-          onAction={onCreateSession}
-          actionIcon={Plus}
-          actionLabel="New chat"
-        />
-        <div className="min-h-0 flex-1" style={contentStyle(topCollapsed)}>
-          <div className="flex flex-col overflow-hidden" style={{ minHeight: 0 }}>
-            <SessionsPanel
-              sessions={sessions}
-              activeSessionId={activeSessionId}
-              unseenCompletedSessions={unseenCompletedSessions}
-              onSelectSession={onSelectSession}
-              onCreateSession={onCreateSession}
-              query={searchQuery}
-            />
+      {sectionItems.map((section, index) => {
+        const nextSection = sectionItems[index + 1]
+        const isCollapsed = collapsedSections[section.id]
+
+        return (
+          <div key={section.id} className="contents">
+            <div
+              style={sectionStyle(isCollapsed, effectiveRatios[section.id])}
+              className="flex min-h-0 flex-col overflow-hidden rounded-xl bg-foreground/[0.03]"
+            >
+              <SectionHeader
+                icon={section.icon}
+                label={section.label}
+                onToggle={() => setCollapsedSections((current) => ({ ...current, [section.id]: !current[section.id] }))}
+                onAction={section.onAction}
+                actionIcon={section.actionIcon}
+                actionLabel={section.actionLabel}
+              />
+              <div className="min-h-0 flex-1" style={contentStyle(isCollapsed)}>
+                <div className="flex flex-col overflow-hidden" style={{ minHeight: 0 }}>
+                  {section.content}
+                </div>
+              </div>
+            </div>
+
+            {nextSection && !collapsedSections[section.id] && !collapsedSections[nextSection.id] ? (
+              <div
+                className="group relative h-0 w-full shrink-0 cursor-row-resize"
+                onPointerDown={(event) => handleResize(section.id, nextSection.id, event)}
+                role="separator"
+                aria-orientation="horizontal"
+                style={{ marginTop: -SECTION_GAP / 2, marginBottom: -SECTION_GAP / 2 }}
+              >
+                <div className="absolute -top-1 -bottom-1 left-0 right-0" />
+              </div>
+            ) : null}
           </div>
-        </div>
-      </div>
-
-      {/* Resize handle 1 */}
-      {!topCollapsed && !midCollapsed && (
-        <div
-          className="group relative h-0 w-full shrink-0 cursor-row-resize"
-          onPointerDown={handleResizeTop}
-          role="separator"
-          aria-orientation="horizontal"
-          style={{ marginTop: -SECTION_GAP / 2, marginBottom: -SECTION_GAP / 2 }}
-        >
-          <div className="absolute -top-1 -bottom-1 left-0 right-0" />
-        </div>
-      )}
-
-      {/* Section 2: Knowledge */}
-      <div
-        style={sectionStyle(midCollapsed, effectiveMid)}
-        className="flex min-h-0 flex-col overflow-hidden rounded-xl bg-foreground/[0.03]"
-      >
-        <SectionHeader
-          icon={Database}
-          label="Knowledge"
-          onToggle={() => setMidCollapsed(prev => !prev)}
-          onAction={canCreateKnowledgeFile ? handleOpenCreateFileDialog : undefined}
-          actionIcon={canCreateKnowledgeFile ? Plus : undefined}
-          actionLabel={canCreateKnowledgeFile ? "Create file" : undefined}
-        />
-        <div className="min-h-0 flex-1" style={contentStyle(midCollapsed)}>
-          <div className="flex flex-col overflow-hidden" style={{ minHeight: 0 }}>
-            <FileTreePanel
-              nodes={fileNodes}
-              activePath={activeFilePath}
-              onSelect={onSelectFile}
-              onDownloadFile={onDownloadFile}
-              hideHeader
-              query={searchQuery}
-            />
-          </div>
-        </div>
-      </div>
-
-      {/* Resize handle 2 */}
-      {!midCollapsed && !bottomCollapsed && (
-        <div
-          className="group relative h-0 w-full shrink-0 cursor-row-resize"
-          onPointerDown={handleResizeMid}
-          role="separator"
-          aria-orientation="horizontal"
-          style={{ marginTop: -SECTION_GAP / 2, marginBottom: -SECTION_GAP / 2 }}
-        >
-          <div className="absolute -top-1 -bottom-1 left-0 right-0" />
-        </div>
-      )}
-
-      {/* Section 3: Experts */}
-      <div
-        style={sectionStyle(bottomCollapsed, effectiveBot)}
-        className="flex min-h-0 flex-col overflow-hidden rounded-xl bg-foreground/[0.03]"
-      >
-        <SectionHeader
-          icon={Robot}
-          label="Experts"
-          onToggle={() => setBottomCollapsed(prev => !prev)}
-          onAction={onOpenExpertsSettings}
-          actionIcon={SlidersHorizontal}
-          actionLabel="Edit experts"
-        />
-        <div className="min-h-0 flex-1" style={contentStyle(bottomCollapsed)}>
-          <div className="flex flex-col overflow-hidden" style={{ minHeight: 0 }}>
-            <AgentsPanel agents={agents} onSelectAgent={onSelectAgent} query={searchQuery} />
-          </div>
-        </div>
-      </div>
+        )
+      })}
 
       {showRestartNotice ? (
         <div

--- a/apps/web/src/components/workspace/left-panel.tsx
+++ b/apps/web/src/components/workspace/left-panel.tsx
@@ -151,6 +151,8 @@ type LeftPanelProps = {
   onSyncComplete?: (status: SyncKbResult["status"]) => void;
   onNavigateDashboard: () => void;
   onNavigateSettings: () => void;
+  onNavigateConnectors?: () => void;
+  onNavigateProviders?: () => void;
 
   // Sessions
   sessions: WorkspaceSession[];
@@ -166,6 +168,7 @@ type LeftPanelProps = {
 
   // Skills
   skills: SkillListItem[];
+  onSelectSkill: (skill: SkillListItem) => void;
   onOpenSkillsSettings: () => void;
 
   // Knowledge (file tree)
@@ -542,6 +545,8 @@ export function LeftPanel({
   onSyncComplete,
   onNavigateDashboard,
   onNavigateSettings,
+  onNavigateConnectors,
+  onNavigateProviders,
   sessions,
   activeSessionId,
   unseenCompletedSessions,
@@ -551,6 +556,7 @@ export function LeftPanel({
   onSelectAgent,
   onOpenExpertsSettings,
   skills,
+  onSelectSkill,
   onOpenSkillsSettings,
   fileNodes,
   activeFilePath,
@@ -608,6 +614,8 @@ export function LeftPanel({
       onSyncComplete={onSyncComplete}
       onNavigateDashboard={onNavigateDashboard}
       onNavigateSettings={onNavigateSettings}
+      onNavigateConnectors={onNavigateConnectors}
+      onNavigateProviders={onNavigateProviders}
        sessions={sessions}
         activeSessionId={activeSessionId}
         unseenCompletedSessions={unseenCompletedSessions}
@@ -617,6 +625,7 @@ export function LeftPanel({
         onSelectAgent={onSelectAgent}
         onOpenExpertsSettings={onOpenExpertsSettings}
         skills={skills}
+        onSelectSkill={onSelectSkill}
         onOpenSkillsSettings={onOpenSkillsSettings}
         fileNodes={fileNodes}
       activeFilePath={activeFilePath}
@@ -645,6 +654,8 @@ function ExpandedLeftPanel({
   onSyncComplete,
   onNavigateDashboard,
   onNavigateSettings,
+  onNavigateConnectors,
+  onNavigateProviders,
   onRestartConfig,
   sessions,
   activeSessionId,
@@ -655,6 +666,7 @@ function ExpandedLeftPanel({
   onSelectAgent,
   onOpenExpertsSettings,
   skills,
+  onSelectSkill,
   onOpenSkillsSettings,
   fileNodes,
   activeFilePath,
@@ -1002,7 +1014,7 @@ function ExpandedLeftPanel({
       onAction: onOpenSkillsSettings,
       actionIcon: SlidersHorizontal,
       actionLabel: "Edit skills",
-      content: <SkillsPanel skills={skills} query={searchQuery} />,
+      content: <SkillsPanel skills={skills} onSelectSkill={onSelectSkill} query={searchQuery} />,
     },
   ];
 
@@ -1188,7 +1200,19 @@ function ExpandedLeftPanel({
               <TooltipContent side="top">Connectors</TooltipContent>
             </Tooltip>
             <DropdownMenuContent side="top" align="start" className="w-72">
-              <DropdownMenuLabel>Connector status</DropdownMenuLabel>
+              <div className="flex items-center justify-between px-2 py-1.5">
+                <span className="text-sm font-semibold">Connector status</span>
+                {onNavigateConnectors && (
+                  <button
+                    type="button"
+                    onClick={onNavigateConnectors}
+                    className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"
+                    aria-label="Connector settings"
+                  >
+                    <GearSix size={14} weight="bold" />
+                  </button>
+                )}
+              </div>
               <DropdownMenuSeparator />
               {connectors.length === 0 ? (
                 <p className="px-2 py-1.5 text-xs text-muted-foreground">No connectors configured.</p>
@@ -1231,7 +1255,19 @@ function ExpandedLeftPanel({
               <TooltipContent side="top">Providers</TooltipContent>
             </Tooltip>
             <DropdownMenuContent side="top" align="start" className="w-72">
-              <DropdownMenuLabel>Provider status</DropdownMenuLabel>
+              <div className="flex items-center justify-between px-2 py-1.5">
+                <span className="text-sm font-semibold">Provider status</span>
+                {onNavigateProviders && (
+                  <button
+                    type="button"
+                    onClick={onNavigateProviders}
+                    className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"
+                    aria-label="Provider settings"
+                  >
+                    <GearSix size={14} weight="bold" />
+                  </button>
+                )}
+              </div>
               <DropdownMenuSeparator />
               {isLoadingProviders ? (
                 <p className="px-2 py-1.5 text-xs text-muted-foreground">Loading providers...</p>

--- a/apps/web/src/components/workspace/markdown-frontmatter-panel.tsx
+++ b/apps/web/src/components/workspace/markdown-frontmatter-panel.tsx
@@ -136,6 +136,10 @@ export function MarkdownFrontmatterPanel({
 }: MarkdownFrontmatterPanelProps) {
   const [editing, setEditing] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
+  const [activeNumberDraft, setActiveNumberDraft] = useState<{
+    index: number;
+    value: string;
+  } | null>(null);
   const [draftProperties, setDraftProperties] = useState<MarkdownFrontmatterProperty[]>(
     frontmatter.mode === "structured" ? frontmatter.properties : []
   );
@@ -195,6 +199,7 @@ export function MarkdownFrontmatterPanel({
                 variant="ghost"
                 className="h-6 px-2 text-[11px]"
                 onClick={() => {
+                  setActiveNumberDraft(null);
                   updateDraftProperties([...draftProperties, createEmptyFrontmatterProperty()], false);
                 }}
               >
@@ -209,10 +214,12 @@ export function MarkdownFrontmatterPanel({
               className="h-6 px-2 text-[11px] text-muted-foreground/60 hover:text-muted-foreground"
               onClick={() => {
                 if (editing) {
+                  setActiveNumberDraft(null);
                   setEditing(false);
                   return;
                 }
 
+                setActiveNumberDraft(null);
                 setDraftProperties(frontmatter.mode === "structured" ? frontmatter.properties : []);
                 setEditing(true);
               }}
@@ -324,6 +331,7 @@ export function MarkdownFrontmatterPanel({
                 className="flex h-7 w-full appearance-none rounded-md border border-border bg-background bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2210%22%20height%3D%226%22%20fill%3D%22none%22%3E%3Cpath%20d%3D%22M1%201l4%204%204-4%22%20stroke%3D%22%23888%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%3C%2Fsvg%3E')] bg-[length:10px_6px] bg-[right_8px_center] bg-no-repeat px-2 pr-6 text-xs text-foreground transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/30"
                 value={property.type}
                 onChange={(event) => {
+                  setActiveNumberDraft((current) => (current?.index === index ? null : current));
                   const next = [...draftProperties];
                   next[index] = coercePropertyValue(
                     property,
@@ -358,15 +366,25 @@ export function MarkdownFrontmatterPanel({
                     placeholder="0"
                     type="number"
                     className="h-7 rounded-md px-2 text-xs"
-                    value={String(property.value)}
+                    value={activeNumberDraft?.index === index ? activeNumberDraft.value : String(property.value)}
                     onChange={(event) => {
-                      const parsed = Number.parseFloat(event.target.value);
+                      const nextValue = event.target.value;
+                      setActiveNumberDraft({ index, value: nextValue });
+
+                      const parsed = Number.parseFloat(nextValue);
+                      if (!Number.isFinite(parsed)) {
+                        return;
+                      }
+
                       const next = [...draftProperties];
                       next[index] = {
                         ...property,
-                        value: Number.isFinite(parsed) ? parsed : 0,
+                        value: parsed,
                       };
                       updateDraftProperties(next);
+                    }}
+                    onBlur={() => {
+                      setActiveNumberDraft((current) => (current?.index === index ? null : current));
                     }}
                   />
                 ) : null}
@@ -411,6 +429,7 @@ export function MarkdownFrontmatterPanel({
                           className="h-7 w-7 shrink-0"
                           aria-label={`Remove item ${entryIndex + 1}`}
                           onClick={() => {
+                            setActiveNumberDraft((current) => (current?.index === index ? null : current));
                             const next = [...draftProperties];
                             next[index] = {
                               ...property,
@@ -447,6 +466,7 @@ export function MarkdownFrontmatterPanel({
                 className="h-7 w-7 shrink-0"
                 aria-label={`Remove property ${index + 1}`}
                 onClick={() => {
+                  setActiveNumberDraft((current) => (current?.index === index ? null : current));
                   updateDraftProperties(
                     draftProperties.filter((_, candidateIndex) => candidateIndex !== index)
                   );

--- a/apps/web/src/components/workspace/skills-panel.tsx
+++ b/apps/web/src/components/workspace/skills-panel.tsx
@@ -4,14 +4,14 @@ import { useMemo } from 'react'
 import { Lightning } from '@phosphor-icons/react'
 
 import type { SkillListItem } from '@/hooks/use-skills-catalog'
-import { cn } from '@/lib/utils'
 
 type SkillsPanelProps = {
   query?: string
   skills: SkillListItem[]
+  onSelectSkill?: (skill: SkillListItem) => void
 }
 
-export function SkillsPanel({ skills, query = '' }: SkillsPanelProps) {
+export function SkillsPanel({ skills, query = '', onSelectSkill }: SkillsPanelProps) {
   const normalizedQuery = query.trim().toLowerCase()
   const filteredSkills = useMemo(() => {
     if (!normalizedQuery) return skills
@@ -43,20 +43,19 @@ export function SkillsPanel({ skills, query = '' }: SkillsPanelProps) {
 
   return (
     <div className="flex-1 overflow-y-auto px-2 py-1.5 scrollbar-none">
-      <div className="space-y-2">
+      <div className="space-y-0.5">
         {filteredSkills.map((skill) => (
-          <div
+          <button
             key={skill.name}
-            className={cn('rounded-lg border border-border/60 bg-card/40 px-3 py-2 text-left')}
+            type="button"
+            onClick={() => onSelectSkill?.(skill)}
+            className="flex w-full items-center gap-2.5 rounded-lg pl-1.5 pr-2 py-1.5 text-left text-[13px] text-foreground/80 transition-colors hover:bg-foreground/5"
           >
-            <div className="flex items-center gap-2">
-              <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/80 text-muted-foreground">
-                <Lightning size={12} weight="bold" />
-              </div>
-              <span className="truncate text-[13px] font-medium text-foreground/90">{skill.name}</span>
+            <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/80 text-muted-foreground">
+              <Lightning size={12} weight="bold" />
             </div>
-            <p className="mt-2 line-clamp-2 text-xs text-muted-foreground">{skill.description}</p>
-          </div>
+            <span className="flex-1 truncate font-medium">{skill.name}</span>
+          </button>
         ))}
       </div>
     </div>

--- a/apps/web/src/components/workspace/skills-panel.tsx
+++ b/apps/web/src/components/workspace/skills-panel.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useMemo } from 'react'
+import { Lightning } from '@phosphor-icons/react'
+
+import type { SkillListItem } from '@/hooks/use-skills-catalog'
+import { cn } from '@/lib/utils'
+
+type SkillsPanelProps = {
+  query?: string
+  skills: SkillListItem[]
+}
+
+export function SkillsPanel({ skills, query = '' }: SkillsPanelProps) {
+  const normalizedQuery = query.trim().toLowerCase()
+  const filteredSkills = useMemo(() => {
+    if (!normalizedQuery) return skills
+
+    return skills.filter((skill) => {
+      const name = skill.name.toLowerCase()
+      const description = skill.description.toLowerCase()
+      return name.includes(normalizedQuery) || description.includes(normalizedQuery)
+    })
+  }, [normalizedQuery, skills])
+
+  if (skills.length === 0) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 py-8 text-center">
+        <Lightning size={24} weight="bold" className="text-muted-foreground/50" />
+        <p className="text-xs text-muted-foreground">No skills available</p>
+      </div>
+    )
+  }
+
+  if (filteredSkills.length === 0) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 py-8 text-center">
+        <Lightning size={24} weight="bold" className="text-muted-foreground/50" />
+        <p className="text-xs text-muted-foreground">No skills found</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto px-2 py-1.5 scrollbar-none">
+      <div className="space-y-2">
+        {filteredSkills.map((skill) => (
+          <div
+            key={skill.name}
+            className={cn('rounded-lg border border-border/60 bg-card/40 px-3 py-2 text-left')}
+          >
+            <div className="flex items-center gap-2">
+              <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/80 text-muted-foreground">
+                <Lightning size={12} weight="bold" />
+              </div>
+              <span className="truncate text-[13px] font-medium text-foreground/90">{skill.name}</span>
+            </div>
+            <p className="mt-2 line-clamp-2 text-xs text-muted-foreground">{skill.description}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/workspace/workspace-shell.tsx
+++ b/apps/web/src/components/workspace/workspace-shell.tsx
@@ -28,7 +28,7 @@ import { takeWorkspaceStartPrompt } from "@/lib/workspace-start-prompt";
 import { cn } from "@/lib/utils";
 
 import { useConfigStatus } from "@/hooks/use-config-status";
-import { useSkillsCatalog } from '@/hooks/use-skills-catalog'
+import { useSkillsCatalog, type SkillListItem } from '@/hooks/use-skills-catalog'
 
 import { ChatPanel } from "./chat-panel";
 import { ConfigChangeBanner } from "./config-change-banner";
@@ -1104,6 +1104,15 @@ export function WorkspaceShell({
     });
   }, [workspace.activeSessionId]);
 
+  const handleSelectSkill = useCallback((skill: SkillListItem) => {
+    if (!workspace.activeSessionId) return;
+
+    setPendingInsert({
+      sessionId: workspace.activeSessionId,
+      value: `Use the "${skill.name}" skill for this task. `,
+    });
+  }, [workspace.activeSessionId]);
+
   const handlePendingInsertConsumed = useCallback(() => {
     setPendingInsert(null);
   }, []);
@@ -1339,6 +1348,16 @@ export function WorkspaceShell({
           currentVault ? getDesktopWorkspaceHref(slug, 'providers') : `/u/${slug}/settings/security`,
         )
       }
+      onNavigateConnectors={() =>
+        router.push(
+          currentVault ? getDesktopWorkspaceHref(slug, 'connectors') : `/u/${slug}/connectors`,
+        )
+      }
+      onNavigateProviders={() =>
+        router.push(
+          currentVault ? getDesktopWorkspaceHref(slug, 'providers') : `/u/${slug}/settings/security`,
+        )
+      }
       sessions={rootSessions}
       activeSessionId={activeRootSessionId}
       unseenCompletedSessions={workspace.unseenCompletedSessions}
@@ -1348,6 +1367,7 @@ export function WorkspaceShell({
       onSelectAgent={handleSelectAgent}
       onOpenExpertsSettings={handleOpenExpertsSettings}
       skills={skillsCatalog.skills}
+      onSelectSkill={handleSelectSkill}
       onOpenSkillsSettings={handleOpenSkillsSettings}
       fileNodes={workspace.fileTree}
       activeFilePath={activeFilePath}

--- a/apps/web/src/components/workspace/workspace-shell.tsx
+++ b/apps/web/src/components/workspace/workspace-shell.tsx
@@ -28,6 +28,7 @@ import { takeWorkspaceStartPrompt } from "@/lib/workspace-start-prompt";
 import { cn } from "@/lib/utils";
 
 import { useConfigStatus } from "@/hooks/use-config-status";
+import { useSkillsCatalog } from '@/hooks/use-skills-catalog'
 
 import { ChatPanel } from "./chat-panel";
 import { ConfigChangeBanner } from "./config-change-banner";
@@ -314,6 +315,7 @@ export function WorkspaceShell({
     workspaceAgentEnabled,
     reaperEnabled,
   });
+  const skillsCatalog = useSkillsCatalog(slug)
 
   const sessionsById = useMemo(() => {
     const map = new Map<string, WorkspaceSession>();
@@ -935,6 +937,10 @@ export function WorkspaceShell({
     router.push(currentVault ? getDesktopWorkspaceHref(slug, 'agents') : `/u/${slug}/agents`);
   }, [currentVault, router, slug]);
 
+  const handleOpenSkillsSettings = useCallback(() => {
+    router.push(currentVault ? getDesktopWorkspaceHref(slug, 'skills') : `/u/${slug}/skills`);
+  }, [currentVault, router, slug]);
+
   const handleCreateKnowledgeFile = useCallback(
     async (path: string) => {
       if (!workspaceAgentEnabled) {
@@ -1341,6 +1347,8 @@ export function WorkspaceShell({
       agents={workspace.agentCatalog}
       onSelectAgent={handleSelectAgent}
       onOpenExpertsSettings={handleOpenExpertsSettings}
+      skills={skillsCatalog.skills}
+      onOpenSkillsSettings={handleOpenSkillsSettings}
       fileNodes={workspace.fileTree}
       activeFilePath={activeFilePath}
       onSelectFile={handleOpenFile}

--- a/apps/web/src/hooks/use-skills-catalog.ts
+++ b/apps/web/src/hooks/use-skills-catalog.ts
@@ -1,0 +1,64 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+export type SkillListItem = {
+  assignedAgentIds: string[]
+  description: string
+  hasResources: boolean
+  name: string
+  resourcePaths: string[]
+}
+
+type UseSkillsCatalogResult = {
+  hash?: string | null
+  isLoading: boolean
+  loadError: string | null
+  reload: () => Promise<void>
+  skills: SkillListItem[]
+}
+
+export function useSkillsCatalog(slug: string): UseSkillsCatalogResult {
+  const [skills, setSkills] = useState<SkillListItem[]>([])
+  const [hash, setHash] = useState<string | null>()
+  const [isLoading, setIsLoading] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  const reload = useCallback(async () => {
+    setIsLoading(true)
+    setLoadError(null)
+
+    try {
+      const response = await fetch(`/api/u/${slug}/skills`, { cache: 'no-store' })
+      const data = (await response.json().catch(() => null)) as {
+        error?: string
+        hash?: string | null
+        skills?: SkillListItem[]
+      } | null
+
+      if (!response.ok || !data) {
+        setLoadError(data?.error ?? 'load_failed')
+        return
+      }
+
+      setSkills(data.skills ?? [])
+      setHash(data.hash)
+    } catch {
+      setLoadError('network_error')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [slug])
+
+  useEffect(() => {
+    void reload()
+  }, [reload])
+
+  return {
+    hash,
+    skills,
+    isLoading,
+    loadError,
+    reload,
+  }
+}

--- a/apps/web/src/lib/__tests__/agent-capabilities.test.ts
+++ b/apps/web/src/lib/__tests__/agent-capabilities.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildAgentPermissionConfigFromCapabilities,
   buildAgentToolsConfigFromCapabilities,
   extractAgentCapabilitiesFromTools,
   validateAgentCapabilityConnectorIds,
+  validateAgentCapabilitySkillIds,
   validateAgentCapabilityTools,
 } from '@/lib/agent-capabilities'
 
@@ -34,6 +36,7 @@ describe('agent-capabilities', () => {
   it('builds tools config from capabilities', () => {
     const config = buildAgentToolsConfigFromCapabilities(
       {
+        skillIds: ['pdf-processing'],
         tools: ['read', 'grep'],
         mcpConnectorIds: ['cntr1'],
       },
@@ -45,6 +48,7 @@ describe('agent-capabilities', () => {
 
     expect(config.read).toBe(true)
     expect(config.grep).toBe(true)
+    expect(config.skill).toBe(true)
     expect(config.write).toBe(false)
     expect(config['arche_*']).toBe(false)
     expect(config['arche_linear_cntr1_*']).toBe(true)
@@ -52,17 +56,64 @@ describe('agent-capabilities', () => {
   })
 
   it('extracts capabilities from tools config', () => {
-    const capabilities = extractAgentCapabilitiesFromTools({
-      read: true,
-      grep: true,
-      write: false,
-      'arche_*': false,
-      'arche_custom_conn123_*': true,
-    })
+    const capabilities = extractAgentCapabilitiesFromTools(
+      {
+        read: true,
+        grep: true,
+        skill: true,
+        write: false,
+        'arche_*': false,
+        'arche_custom_conn123_*': true,
+      },
+      {
+        skill: {
+          '*': 'deny',
+          'pdf-processing': 'allow',
+        },
+      }
+    )
 
     expect(capabilities).toEqual({
+      skillIds: ['pdf-processing'],
       tools: ['grep', 'read'],
       mcpConnectorIds: ['conn123'],
+    })
+  })
+
+  it('validates skill ids', () => {
+    expect(validateAgentCapabilitySkillIds(['pdf-processing', 'release-notes'])).toEqual({
+      ok: true,
+      skillIds: ['pdf-processing', 'release-notes'],
+    })
+
+    expect(validateAgentCapabilitySkillIds(['BadName'])).toEqual({
+      ok: false,
+      error: 'invalid_skill_ids',
+    })
+  })
+
+  it('builds skill permission config while preserving other permissions', () => {
+    expect(
+      buildAgentPermissionConfigFromCapabilities(
+        {
+          skillIds: ['pdf-processing'],
+          tools: ['read'],
+          mcpConnectorIds: [],
+        },
+        {
+          bash: {
+            '*': 'allow',
+          },
+        }
+      )
+    ).toEqual({
+      bash: {
+        '*': 'allow',
+      },
+      skill: {
+        '*': 'deny',
+        'pdf-processing': 'allow',
+      },
     })
   })
 })

--- a/apps/web/src/lib/__tests__/workspace-panel-state.test.ts
+++ b/apps/web/src/lib/__tests__/workspace-panel-state.test.ts
@@ -6,6 +6,7 @@ import { stubBrowserStorage } from '@/__tests__/storage'
 import {
   getWorkspaceLayoutCookieName,
   getWorkspaceLayoutStorageKey,
+  normalizeLeftPanelState,
   persistWorkspacePanelState,
   readWorkspacePanelState,
 } from '@/lib/workspace-panel-state'
@@ -83,5 +84,56 @@ describe('workspace panel state persistence', () => {
 
     expect(window.localStorage.getItem(storageKey)).toBe(JSON.stringify(state))
     expect(readCookieValue(cookieName)).toBe(JSON.stringify(state))
+  })
+
+  it('normalizes the new left panel state structure', () => {
+    expect(
+      normalizeLeftPanelState({
+        ratios: {
+          chats: 0.5,
+          knowledge: 0.25,
+          experts: 0.15,
+          skills: 0.1,
+        },
+        collapsed: {
+          chats: true,
+          skills: true,
+        },
+      })
+    ).toEqual({
+      ratios: {
+        chats: 0.5,
+        knowledge: 0.25,
+        experts: 0.15,
+        skills: 0.1,
+      },
+      collapsed: {
+        chats: true,
+        knowledge: false,
+        experts: false,
+        skills: true,
+      },
+    })
+  })
+
+  it('migrates the legacy three-section state into the new shape', () => {
+    const migrated = normalizeLeftPanelState({
+      topRatio: 0.4,
+      midRatio: 0.3,
+      topCollapsed: true,
+      midCollapsed: false,
+      bottomCollapsed: true,
+    })
+
+    expect(migrated.collapsed).toEqual({
+      chats: true,
+      knowledge: false,
+      experts: true,
+      skills: true,
+    })
+    expect(migrated.ratios.chats).toBeCloseTo(0.4)
+    expect(migrated.ratios.knowledge).toBeCloseTo(0.3)
+    expect(migrated.ratios.experts).toBeCloseTo(0.15)
+    expect(migrated.ratios.skills).toBeCloseTo(0.15)
   })
 })

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -1,4 +1,5 @@
 import type { ConnectorType } from '@/lib/connectors/types'
+import { SKILL_NAME_PATTERN } from '@/lib/skills/types'
 
 export const OPENCODE_AGENT_TOOLS = [
   'write',
@@ -48,6 +49,7 @@ export const OPENCODE_AGENT_TOOL_OPTIONS: Array<{
 ]
 
 export type AgentCapabilities = {
+  skillIds: string[]
   tools: OpenCodeAgentToolId[]
   mcpConnectorIds: string[]
 }
@@ -67,6 +69,14 @@ function buildMcpServerKey(type: ConnectorType, id: string): string {
 
 function uniqueSorted(values: string[]): string[] {
   return Array.from(new Set(values)).sort((a, b) => a.localeCompare(b))
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isPermissionValue(value: unknown): value is 'allow' | 'ask' | 'deny' {
+  return value === 'allow' || value === 'ask' || value === 'deny'
 }
 
 export function validateAgentCapabilityTools(value: unknown): {
@@ -114,6 +124,34 @@ export function validateAgentCapabilityConnectorIds(value: unknown): {
   return { ok: true, connectorIds: uniqueSorted(connectorIds) }
 }
 
+export function validateAgentCapabilitySkillIds(value: unknown): {
+  ok: true
+  skillIds: string[]
+} | {
+  ok: false
+  error: string
+} {
+  if (!Array.isArray(value)) {
+    return { ok: false, error: 'invalid_skill_ids' }
+  }
+
+  const skillIds: string[] = []
+  for (const skillId of value) {
+    if (typeof skillId !== 'string') {
+      return { ok: false, error: 'invalid_skill_ids' }
+    }
+
+    const normalized = skillId.trim()
+    if (!normalized || normalized.length > 64 || !SKILL_NAME_PATTERN.test(normalized)) {
+      return { ok: false, error: 'invalid_skill_ids' }
+    }
+
+    skillIds.push(normalized)
+  }
+
+  return { ok: true, skillIds: uniqueSorted(skillIds) }
+}
+
 export function buildAgentToolsConfigFromCapabilities(
   capabilities: AgentCapabilities,
   connectors: ConnectorCapabilityRecord[]
@@ -124,6 +162,8 @@ export function buildAgentToolsConfigFromCapabilities(
   for (const toolId of OPENCODE_AGENT_TOOLS) {
     toolConfig[toolId] = enabledTools.has(toolId)
   }
+
+  toolConfig.skill = capabilities.skillIds.length > 0
 
   toolConfig['arche_*'] = false
 
@@ -139,10 +179,12 @@ export function buildAgentToolsConfigFromCapabilities(
 }
 
 export function extractAgentCapabilitiesFromTools(
-  tools: Record<string, boolean> | undefined
+  tools: Record<string, boolean> | undefined,
+  permission?: unknown,
 ): AgentCapabilities {
   if (!tools) {
     return {
+      skillIds: [],
       tools: [],
       mcpConnectorIds: [],
     }
@@ -157,8 +199,37 @@ export function extractAgentCapabilitiesFromTools(
       return [match[2]]
     })
 
+  let skillIds: string[] = []
+  if (tools.skill === true && isRecord(permission) && isRecord(permission.skill)) {
+    skillIds = Object.entries(permission.skill)
+      .filter(([name, value]) => name !== '*' && isPermissionValue(value) && value === 'allow')
+      .map(([name]) => name)
+  }
+
   return {
+    skillIds: uniqueSorted(skillIds),
     tools: uniqueSorted(enabledTools) as OpenCodeAgentToolId[],
     mcpConnectorIds: uniqueSorted(connectorIds),
   }
+}
+
+export function buildAgentPermissionConfigFromCapabilities(
+  capabilities: AgentCapabilities,
+  existingPermission: unknown,
+): Record<string, unknown> | undefined {
+  const nextPermission = isRecord(existingPermission)
+    ? { ...existingPermission }
+    : {}
+
+  if (capabilities.skillIds.length === 0) {
+    delete nextPermission.skill
+    return Object.keys(nextPermission).length > 0 ? nextPermission : undefined
+  }
+
+  nextPermission.skill = {
+    '*': 'deny',
+    ...Object.fromEntries(capabilities.skillIds.map((skillId) => [skillId, 'allow'] as const)),
+  }
+
+  return nextPermission
 }

--- a/apps/web/src/lib/config-repo-store.ts
+++ b/apps/web/src/lib/config-repo-store.ts
@@ -85,6 +85,34 @@ async function listFilesRecursive(rootDir: string, prefix = ''): Promise<ConfigR
   return files
 }
 
+export async function readConfigRepoSnapshot<T>(
+  reader: (context: { repoDir: string; hash: string | null }) => Promise<T>
+): Promise<{ ok: true; data: T; hash: string | null } | { ok: false; error: ConfigRepoReadError }> {
+  const root = await resolveConfigRepoRoot()
+  if (!root) return { ok: false, error: 'kb_unavailable' }
+
+  if (!(await hasBareRepoLayout(root))) {
+    return { ok: false, error: 'kb_unavailable' }
+  }
+
+  if (!(await isGitAvailable())) {
+    return { ok: false, error: 'read_failed' }
+  }
+
+  const clone = await cloneRepoToTemp(root)
+  if (!clone.ok) {
+    return { ok: false, error: 'read_failed' }
+  }
+
+  try {
+    const hash = await getCloneHeadHash(clone.dir, clone.gitEnv)
+    const data = await reader({ repoDir: clone.dir, hash })
+    return { ok: true, data, hash }
+  } finally {
+    await cleanupClone(clone)
+  }
+}
+
 export async function getConfigRepoHash(): Promise<
   | { ok: true; hash: string | null }
   | { ok: false; error: ConfigRepoReadError }

--- a/apps/web/src/lib/config-repo-store.ts
+++ b/apps/web/src/lib/config-repo-store.ts
@@ -1,0 +1,273 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+import {
+  cleanupClone,
+  cloneRepoToTemp,
+  detectDefaultBranch,
+  hasBareRepoLayout,
+  isGitAvailable,
+  resolveRepoRoot,
+  runGit,
+} from '@/lib/git/bare-repo'
+import { getKbConfigRoot } from '@/lib/runtime/paths'
+
+export type ConfigRepoFileEntry = {
+  content: Buffer
+  path: string
+}
+
+type ConfigRepoReadError = 'kb_unavailable' | 'read_failed'
+
+export type ConfigRepoMutationResult =
+  | { ok: true; hash: string }
+  | { ok: false; error: 'conflict' | 'kb_unavailable' | 'write_failed' }
+
+type MutateConfigRepoArgs = {
+  commitMessage: string
+  expectedHash?: string
+  mutate: (context: { repoDir: string }) => Promise<string[]>
+}
+
+function normalizeRepoRelativePath(input: string): string {
+  const normalized = input
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/+/g, '/')
+
+  const segments = normalized
+    .split('/')
+    .filter((segment) => segment.length > 0 && segment !== '.')
+
+  if (segments.some((segment) => segment === '..')) {
+    throw new Error('invalid_repo_path')
+  }
+
+  return segments.join('/')
+}
+
+async function resolveConfigRepoRoot(): Promise<string | null> {
+  return resolveRepoRoot(getKbConfigRoot())
+}
+
+async function getCloneHeadHash(repoDir: string, gitEnv: NodeJS.ProcessEnv): Promise<string | null> {
+  const head = await runGit(['rev-parse', 'HEAD'], { cwd: repoDir, env: gitEnv })
+  if (!head.ok) return null
+
+  const hash = head.stdout.trim()
+  return hash.length > 0 ? hash : null
+}
+
+async function listFilesRecursive(rootDir: string, prefix = ''): Promise<ConfigRepoFileEntry[]> {
+  const entries = await fs.readdir(rootDir, { withFileTypes: true })
+  const files: ConfigRepoFileEntry[] = []
+
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const absolutePath = path.join(rootDir, entry.name)
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name
+
+    if (entry.isDirectory()) {
+      files.push(...await listFilesRecursive(absolutePath, relativePath))
+      continue
+    }
+
+    if (!entry.isFile()) {
+      continue
+    }
+
+    files.push({
+      path: relativePath,
+      content: await fs.readFile(absolutePath),
+    })
+  }
+
+  return files
+}
+
+export async function getConfigRepoHash(): Promise<
+  | { ok: true; hash: string | null }
+  | { ok: false; error: ConfigRepoReadError }
+> {
+  const root = await resolveConfigRepoRoot()
+  if (!root) return { ok: false, error: 'kb_unavailable' }
+
+  if (!(await hasBareRepoLayout(root))) {
+    return { ok: false, error: 'kb_unavailable' }
+  }
+
+  if (!(await isGitAvailable())) {
+    return { ok: false, error: 'read_failed' }
+  }
+
+  const clone = await cloneRepoToTemp(root)
+  if (!clone.ok) {
+    return { ok: false, error: 'read_failed' }
+  }
+
+  try {
+    return { ok: true, hash: await getCloneHeadHash(clone.dir, clone.gitEnv) }
+  } finally {
+    await cleanupClone(clone)
+  }
+}
+
+export async function readConfigRepoFileBuffer(
+  filePath: string
+): Promise<{ ok: true; content: Buffer; hash: string | null } | { ok: false; error: 'not_found' | ConfigRepoReadError }> {
+  const root = await resolveConfigRepoRoot()
+  if (!root) return { ok: false, error: 'kb_unavailable' }
+
+  if (!(await hasBareRepoLayout(root))) {
+    return { ok: false, error: 'kb_unavailable' }
+  }
+
+  if (!(await isGitAvailable())) {
+    return { ok: false, error: 'read_failed' }
+  }
+
+  const clone = await cloneRepoToTemp(root)
+  if (!clone.ok) {
+    return { ok: false, error: 'read_failed' }
+  }
+
+  try {
+    const normalizedPath = normalizeRepoRelativePath(filePath)
+    const absolutePath = path.join(clone.dir, normalizedPath)
+    const content = await fs.readFile(absolutePath)
+
+    return {
+      ok: true,
+      content,
+      hash: await getCloneHeadHash(clone.dir, clone.gitEnv),
+    }
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return { ok: false, error: 'not_found' }
+    }
+
+    return { ok: false, error: 'read_failed' }
+  } finally {
+    await cleanupClone(clone)
+  }
+}
+
+export async function listConfigRepoFiles(
+  directoryPath: string
+): Promise<{ ok: true; files: ConfigRepoFileEntry[]; hash: string | null } | { ok: false; error: ConfigRepoReadError }> {
+  const root = await resolveConfigRepoRoot()
+  if (!root) return { ok: false, error: 'kb_unavailable' }
+
+  if (!(await hasBareRepoLayout(root))) {
+    return { ok: false, error: 'kb_unavailable' }
+  }
+
+  if (!(await isGitAvailable())) {
+    return { ok: false, error: 'read_failed' }
+  }
+
+  const clone = await cloneRepoToTemp(root)
+  if (!clone.ok) {
+    return { ok: false, error: 'read_failed' }
+  }
+
+  try {
+    const normalizedPath = normalizeRepoRelativePath(directoryPath)
+    const absolutePath = path.join(clone.dir, normalizedPath)
+    const stats = await fs.stat(absolutePath).catch(() => null)
+
+    return {
+      ok: true,
+      files: stats?.isDirectory() ? await listFilesRecursive(absolutePath, normalizedPath) : [],
+      hash: await getCloneHeadHash(clone.dir, clone.gitEnv),
+    }
+  } catch {
+    return { ok: false, error: 'read_failed' }
+  } finally {
+    await cleanupClone(clone)
+  }
+}
+
+export async function mutateConfigRepo({
+  commitMessage,
+  expectedHash,
+  mutate,
+}: MutateConfigRepoArgs): Promise<ConfigRepoMutationResult> {
+  const root = await resolveConfigRepoRoot()
+  if (!root) return { ok: false, error: 'kb_unavailable' }
+
+  if (!(await hasBareRepoLayout(root))) {
+    return { ok: false, error: 'kb_unavailable' }
+  }
+
+  if (!(await isGitAvailable())) {
+    return { ok: false, error: 'write_failed' }
+  }
+
+  const clone = await cloneRepoToTemp(root)
+  if (!clone.ok) {
+    return { ok: false, error: 'write_failed' }
+  }
+
+  try {
+    const currentHash = await getCloneHeadHash(clone.dir, clone.gitEnv)
+    if (expectedHash && currentHash && expectedHash !== currentHash) {
+      return { ok: false, error: 'conflict' }
+    }
+
+    const changedPaths = Array.from(new Set((await mutate({ repoDir: clone.dir })).map(normalizeRepoRelativePath)))
+    if (changedPaths.length === 0) {
+      return { ok: true, hash: currentHash ?? '' }
+    }
+
+    const add = await runGit(['add', '-A', '--', ...changedPaths], {
+      cwd: clone.dir,
+      env: clone.gitEnv,
+    })
+    if (!add.ok) {
+      return { ok: false, error: 'write_failed' }
+    }
+
+    const status = await runGit(['status', '--porcelain', '--', ...changedPaths], {
+      cwd: clone.dir,
+      env: clone.gitEnv,
+    })
+    if (!status.ok) {
+      return { ok: false, error: 'write_failed' }
+    }
+
+    if (!status.stdout.trim()) {
+      return { ok: true, hash: currentHash ?? '' }
+    }
+
+    const commit = await runGit(
+      [
+        '-c', 'user.name=Arche Config',
+        '-c', 'user.email=config@arche.local',
+        'commit',
+        '-m', commitMessage,
+      ],
+      { cwd: clone.dir, env: clone.gitEnv }
+    )
+    if (!commit.ok) {
+      return { ok: false, error: 'write_failed' }
+    }
+
+    const branch = await detectDefaultBranch(clone.dir, clone.gitEnv)
+    const push = await runGit(['push', 'origin', `HEAD:refs/heads/${branch}`], {
+      cwd: clone.dir,
+      env: clone.gitEnv,
+    })
+    if (!push.ok) {
+      if (push.stderr.includes('non-fast-forward')) {
+        return { ok: false, error: 'conflict' }
+      }
+
+      return { ok: false, error: 'write_failed' }
+    }
+
+    return { ok: true, hash: (await getCloneHeadHash(clone.dir, clone.gitEnv)) ?? '' }
+  } finally {
+    await cleanupClone(clone)
+  }
+}

--- a/apps/web/src/lib/runtime/__tests__/current-vault.test.ts
+++ b/apps/web/src/lib/runtime/__tests__/current-vault.test.ts
@@ -44,6 +44,7 @@ describe('current desktop vault helpers', () => {
     expect(isDesktopSettingsSection('providers')).toBe(true)
     expect(isDesktopSettingsSection('connectors')).toBe(true)
     expect(isDesktopSettingsSection('agents')).toBe(true)
+    expect(isDesktopSettingsSection('skills')).toBe(true)
     expect(isDesktopSettingsSection('appearance')).toBe(true)
     expect(isDesktopSettingsSection('advanced')).toBe(true)
     expect(isDesktopSettingsSection('security')).toBe(false)

--- a/apps/web/src/lib/runtime/__tests__/workspace-host-desktop.test.ts
+++ b/apps/web/src/lib/runtime/__tests__/workspace-host-desktop.test.ts
@@ -9,6 +9,9 @@ const mockMkdirSync = vi.fn()
 const mockReadFileSync = vi.fn()
 const mockWriteFileSync = vi.fn()
 const mockRandomBytes = vi.fn()
+const mockMkdir = vi.fn()
+const mockRm = vi.fn()
+const mockWriteFile = vi.fn()
 
 vi.mock('crypto', async (importOriginal) => {
   const actual = await importOriginal<typeof import('crypto')>()
@@ -28,6 +31,12 @@ vi.mock('fs', () => ({
   mkdirSync: (...args: unknown[]) => mockMkdirSync(...args),
   readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
   writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+}))
+
+vi.mock('fs/promises', () => ({
+  mkdir: (...args: unknown[]) => mockMkdir(...args),
+  rm: (...args: unknown[]) => mockRm(...args),
+  writeFile: (...args: unknown[]) => mockWriteFile(...args),
 }))
 
 vi.mock('@/lib/runtime/paths', () => ({
@@ -90,6 +99,13 @@ vi.mock('@/lib/opencode/providers', () => ({
 
 vi.mock('@/lib/spawner/mcp-config', () => ({
   buildMcpConfigForSlug: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('@/lib/skills/skill-store', () => ({
+  listSkillBundles: vi.fn().mockResolvedValue({
+    ok: true,
+    data: [],
+  }),
 }))
 
 vi.mock('@/lib/spawner/runtime-config-hash', () => ({
@@ -196,6 +212,9 @@ describe('desktopWorkspaceHost', () => {
     mockExistsSync.mockImplementation((target: string) => target === '/mock/bin/workspace-agent')
     mockReadFileSync.mockReturnValue('')
     mockRandomBytes.mockReturnValue({ toString: () => 'generated-password' })
+    mockMkdir.mockResolvedValue(undefined)
+    mockRm.mockResolvedValue(undefined)
+    mockWriteFile.mockResolvedValue(undefined)
     mockHealthyFetch()
   })
 
@@ -326,6 +345,43 @@ describe('desktopWorkspaceHost', () => {
       expect.stringContaining('AGENTS.md'),
       expect.stringContaining('## Workspace User Identity'),
       'utf-8',
+    )
+  })
+
+  it('materializes runtime skills into the desktop OpenCode config directory', async () => {
+    const opencodeChild = makeChildProcess()
+    const workspaceAgentChild = makeChildProcess()
+    mockSpawn.mockReturnValueOnce(opencodeChild).mockReturnValueOnce(workspaceAgentChild)
+
+    const { listSkillBundles } = await import('@/lib/skills/skill-store')
+    vi.mocked(listSkillBundles).mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          skill: {
+            frontmatter: {
+              name: 'pdf-processing',
+              description: 'Handle PDFs',
+            },
+            body: 'Use this for PDFs.',
+            raw: '',
+          },
+          files: [
+            {
+              path: 'SKILL.md',
+              content: new TextEncoder().encode('---\nname: pdf-processing\ndescription: Handle PDFs\n---\nUse this for PDFs.'),
+            },
+          ],
+        },
+      ],
+    })
+
+    const { desktopWorkspaceHost } = await import('../workspace-host-desktop')
+    await desktopWorkspaceHost.start('local', 'user-1')
+
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      '/tmp/arche/.runtime/opencode/.config/opencode/skills/pdf-processing/SKILL.md',
+      expect.any(Buffer)
     )
   })
 

--- a/apps/web/src/lib/runtime/__tests__/workspace-host-desktop.test.ts
+++ b/apps/web/src/lib/runtime/__tests__/workspace-host-desktop.test.ts
@@ -3,9 +3,11 @@ import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'v
 import type { ChildProcess } from 'child_process'
 
 const mockSpawn = vi.fn()
+const mockExecFile = vi.fn()
 const mockExecFileSync = vi.fn()
 const mockExistsSync = vi.fn()
 const mockMkdirSync = vi.fn()
+const mockReadFile = vi.fn()
 const mockReadFileSync = vi.fn()
 const mockWriteFileSync = vi.fn()
 const mockRandomBytes = vi.fn()
@@ -22,6 +24,7 @@ vi.mock('crypto', async (importOriginal) => {
 })
 
 vi.mock('child_process', () => ({
+  execFile: (...args: unknown[]) => mockExecFile(...args),
   spawn: (...args: unknown[]) => mockSpawn(...args),
   execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
 }))
@@ -29,6 +32,9 @@ vi.mock('child_process', () => ({
 vi.mock('fs', () => ({
   existsSync: (...args: unknown[]) => mockExistsSync(...args),
   mkdirSync: (...args: unknown[]) => mockMkdirSync(...args),
+  promises: {
+    readFile: (...args: unknown[]) => mockReadFile(...args),
+  },
   readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
   writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
 }))
@@ -84,6 +90,14 @@ vi.mock('@/lib/common-workspace-config-store', () => ({
   readConfigRepoFile: vi.fn().mockResolvedValue({ ok: false }),
 }))
 
+vi.mock('@/lib/config-repo-store', () => ({
+  readConfigRepoSnapshot: vi.fn(async (reader: (context: { repoDir: string; hash: string | null }) => Promise<unknown>) => ({
+    ok: true,
+    hash: 'snapshot-hash',
+    data: await reader({ repoDir: '/tmp/mock-config-repo', hash: 'snapshot-hash' }),
+  })),
+}))
+
 vi.mock('@/lib/spawner/config', () => ({
   getWorkspaceAgentPort: vi.fn(() => 4097),
 }))
@@ -102,10 +116,7 @@ vi.mock('@/lib/spawner/mcp-config', () => ({
 }))
 
 vi.mock('@/lib/skills/skill-store', () => ({
-  listSkillBundles: vi.fn().mockResolvedValue({
-    ok: true,
-    data: [],
-  }),
+  readSkillBundlesFromRepoDir: vi.fn().mockResolvedValue([]),
 }))
 
 vi.mock('@/lib/spawner/runtime-config-hash', () => ({
@@ -210,6 +221,26 @@ describe('desktopWorkspaceHost', () => {
     // @ts-expect-error test isolation
     process.resourcesPath = undefined
     mockExistsSync.mockImplementation((target: string) => target === '/mock/bin/workspace-agent')
+    mockReadFile.mockImplementation((target: string) => {
+      if (target.endsWith('/CommonWorkspaceConfig.json')) {
+        return Promise.resolve(
+          JSON.stringify({
+            $schema: 'https://opencode.ai/config.json',
+            default_agent: 'assistant',
+            agent: {
+              assistant: {
+                mode: 'primary',
+                tools: { task: true },
+              },
+            },
+          })
+        )
+      }
+
+      const error = new Error('ENOENT') as NodeJS.ErrnoException
+      error.code = 'ENOENT'
+      return Promise.reject(error)
+    })
     mockReadFileSync.mockReturnValue('')
     mockRandomBytes.mockReturnValue({ toString: () => 'generated-password' })
     mockMkdir.mockResolvedValue(undefined)
@@ -332,10 +363,29 @@ describe('desktopWorkspaceHost', () => {
     const workspaceAgentChild = makeChildProcess()
     mockSpawn.mockReturnValueOnce(opencodeChild).mockReturnValueOnce(workspaceAgentChild)
 
-    const { readConfigRepoFile } = await import('@/lib/common-workspace-config-store')
-    vi.mocked(readConfigRepoFile).mockResolvedValue({
-      ok: true,
-      content: '# AGENTS\n\nUse these guardrails.',
+    mockReadFile.mockImplementation((target: string) => {
+      if (target.endsWith('/CommonWorkspaceConfig.json')) {
+        return Promise.resolve(
+          JSON.stringify({
+            $schema: 'https://opencode.ai/config.json',
+            default_agent: 'assistant',
+            agent: {
+              assistant: {
+                mode: 'primary',
+                tools: { task: true },
+              },
+            },
+          })
+        )
+      }
+
+      if (target.endsWith('/AGENTS.md')) {
+        return Promise.resolve('# AGENTS\n\nUse these guardrails.')
+      }
+
+      const error = new Error('ENOENT') as NodeJS.ErrnoException
+      error.code = 'ENOENT'
+      return Promise.reject(error)
     })
 
     const { desktopWorkspaceHost } = await import('../workspace-host-desktop')
@@ -353,28 +403,25 @@ describe('desktopWorkspaceHost', () => {
     const workspaceAgentChild = makeChildProcess()
     mockSpawn.mockReturnValueOnce(opencodeChild).mockReturnValueOnce(workspaceAgentChild)
 
-    const { listSkillBundles } = await import('@/lib/skills/skill-store')
-    vi.mocked(listSkillBundles).mockResolvedValue({
-      ok: true,
-      data: [
-        {
-          skill: {
-            frontmatter: {
-              name: 'pdf-processing',
-              description: 'Handle PDFs',
-            },
-            body: 'Use this for PDFs.',
-            raw: '',
+    const { readSkillBundlesFromRepoDir } = await import('@/lib/skills/skill-store')
+    vi.mocked(readSkillBundlesFromRepoDir).mockResolvedValue([
+      {
+        skill: {
+          frontmatter: {
+            name: 'pdf-processing',
+            description: 'Handle PDFs',
           },
-          files: [
-            {
-              path: 'SKILL.md',
-              content: new TextEncoder().encode('---\nname: pdf-processing\ndescription: Handle PDFs\n---\nUse this for PDFs.'),
-            },
-          ],
+          body: 'Use this for PDFs.',
+          raw: '',
         },
-      ],
-    })
+        files: [
+          {
+            path: 'SKILL.md',
+            content: new TextEncoder().encode('---\nname: pdf-processing\ndescription: Handle PDFs\n---\nUse this for PDFs.'),
+          },
+        ],
+      },
+    ])
 
     const { desktopWorkspaceHost } = await import('../workspace-host-desktop')
     await desktopWorkspaceHost.start('local', 'user-1')
@@ -421,26 +468,30 @@ describe('desktopWorkspaceHost', () => {
     const workspaceAgentChild = makeChildProcess()
     mockSpawn.mockReturnValueOnce(opencodeChild).mockReturnValueOnce(workspaceAgentChild)
 
-    const { readCommonWorkspaceConfig } = await import('@/lib/common-workspace-config-store')
-    vi.mocked(readCommonWorkspaceConfig).mockResolvedValue({
-      ok: true,
-      content: JSON.stringify({
-        $schema: 'https://opencode.ai/config.json',
-        default_agent: 'assistant',
-        agent: {
-          assistant: {
-            mode: 'primary',
-            tools: { task: true },
-          },
-          linear: {
-            mode: 'subagent',
-            prompt: 'Handle Linear.',
-            tools: { task: true, 'arche_*': false, 'arche_linear_admin111_*': true },
-          },
-        },
-      }),
-      hash: 'hash',
-      path: '/tmp/arche/kb-config/CommonWorkspaceConfig.json',
+    mockReadFile.mockImplementation((target: string) => {
+      if (target.endsWith('/CommonWorkspaceConfig.json')) {
+        return Promise.resolve(
+          JSON.stringify({
+            $schema: 'https://opencode.ai/config.json',
+            default_agent: 'assistant',
+            agent: {
+              assistant: {
+                mode: 'primary',
+                tools: { task: true },
+              },
+              linear: {
+                mode: 'subagent',
+                prompt: 'Handle Linear.',
+                tools: { task: true, 'arche_*': false, 'arche_linear_admin111_*': true },
+              },
+            },
+          })
+        )
+      }
+
+      const error = new Error('ENOENT') as NodeJS.ErrnoException
+      error.code = 'ENOENT'
+      return Promise.reject(error)
     })
 
     const { buildMcpConfigForSlug } = await import('@/lib/spawner/mcp-config')

--- a/apps/web/src/lib/runtime/desktop/current-vault.ts
+++ b/apps/web/src/lib/runtime/desktop/current-vault.ts
@@ -4,6 +4,7 @@ export const DESKTOP_SETTINGS_SECTIONS = [
   'providers',
   'connectors',
   'agents',
+  'skills',
   'appearance',
   'advanced',
 ] as const

--- a/apps/web/src/lib/runtime/workspace-host-desktop.ts
+++ b/apps/web/src/lib/runtime/workspace-host-desktop.ts
@@ -23,6 +23,7 @@ import {
   makeAuthHeader,
 } from '@/lib/runtime/desktop/config'
 import { getArcheOpencodeDataDir, getWorkspaceDir } from '@/lib/runtime/desktop/workspace-dirs'
+import { writeRuntimeSkills } from '@/lib/skills/runtime-skills'
 import type { WorkspaceHost, WorkspaceHostConnection, WorkspaceHostStatus } from '@/lib/runtime/types'
 import { instanceService, providerService } from '@/lib/services'
 import { getWorkspaceAgentPort } from '@/lib/spawner/config'
@@ -137,6 +138,7 @@ function getDesktopRuntimePortFromEnv(): number {
 }
 
 type DesktopRuntimeArtifacts = {
+  skills: Awaited<ReturnType<typeof buildWorkspaceRuntimeArtifacts>>['skills']
   owner: { id: string; slug: string; email: string | null } | null
   opencodeConfigContent: string
   agentsMd?: string
@@ -331,6 +333,7 @@ export const desktopWorkspaceHost: WorkspaceHost = {
     const artifacts = await buildDesktopRuntimeArtifacts(slug)
     const appliedConfigSha = hashWorkspaceRuntimeArtifacts(artifacts)
     const opencodeConfigContent = artifacts.opencodeConfigContent
+    const runtimeSkillDir = join(archeDataDir, '.config', 'opencode', 'skills')
 
     writeFileSync(
       join(workspaceDir, 'opencode.json'),
@@ -341,6 +344,8 @@ export const desktopWorkspaceHost: WorkspaceHost = {
     if (artifacts.agentsMd) {
       writeFileSync(join(workspaceDir, 'AGENTS.md'), artifacts.agentsMd, 'utf-8')
     }
+
+    await writeRuntimeSkills(runtimeSkillDir, artifacts.skills)
 
     await instanceService.upsertStarting(slug, encryptedPassword)
 

--- a/apps/web/src/lib/skills/__tests__/skill-markdown.test.ts
+++ b/apps/web/src/lib/skills/__tests__/skill-markdown.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { createSkillMarkdown, parseSkillMarkdown } from '@/lib/skills/skill-markdown'
+
+describe('skill-markdown', () => {
+  it('parses a valid SKILL.md document', () => {
+    const result = parseSkillMarkdown(`---\nname: pdf-processing\ndescription: Handle PDF workflows\nmetadata:\n  author: arche\n---\n# PDF\n`)
+
+    expect(result).toEqual({
+      ok: true,
+      skill: {
+        frontmatter: {
+          name: 'pdf-processing',
+          description: 'Handle PDF workflows',
+          metadata: {
+            author: 'arche',
+          },
+        },
+        body: '# PDF\n',
+        raw: '---\nname: pdf-processing\ndescription: Handle PDF workflows\nmetadata:\n  author: arche\n---\n# PDF\n',
+      },
+    })
+  })
+
+  it('serializes updated content while preserving existing frontmatter fields', () => {
+    const markdown = createSkillMarkdown({
+      name: 'pdf-processing',
+      description: 'Updated description',
+      body: '## Workflow\n',
+      existingFrontmatter: {
+        name: 'pdf-processing',
+        description: 'Old description',
+        compatibility: 'Requires python',
+      },
+    })
+
+    expect(markdown).toContain('name: pdf-processing')
+    expect(markdown).toContain('description: Updated description')
+    expect(markdown).toContain('compatibility: Requires python')
+    expect(markdown).toContain('## Workflow')
+  })
+})

--- a/apps/web/src/lib/skills/__tests__/skill-store.test.ts
+++ b/apps/web/src/lib/skills/__tests__/skill-store.test.ts
@@ -1,0 +1,174 @@
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getConfigRepoHashMock = vi.fn()
+const listConfigRepoFilesMock = vi.fn()
+const mutateConfigRepoMock = vi.fn()
+const readConfigRepoSnapshotMock = vi.fn()
+
+let repoDir: string | null = null
+
+async function writeRepoFile(relativePath: string, content: string): Promise<void> {
+  if (!repoDir) {
+    throw new Error('repo_not_configured')
+  }
+
+  const filePath = path.join(repoDir, relativePath)
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  await fs.writeFile(filePath, content, 'utf-8')
+}
+
+async function createSkillRepo(files: Record<string, string>): Promise<void> {
+  repoDir = await fs.mkdtemp(path.join(tmpdir(), 'skill-store-'))
+  await Promise.all(Object.entries(files).map(([relativePath, content]) => writeRepoFile(relativePath, content)))
+}
+
+function createWorkspaceConfig(skillName = 'pdf-processing'): string {
+  return JSON.stringify(
+    {
+      $schema: 'https://opencode.ai/config.json',
+      default_agent: 'assistant',
+      agent: {
+        assistant: {
+          mode: 'primary',
+          tools: {
+            skill: true,
+          },
+          permission: {
+            skill: {
+              '*': 'deny',
+              [skillName]: 'allow',
+            },
+          },
+        },
+      },
+    },
+    null,
+    2,
+  )
+}
+
+function createSkillMarkdown(skillName = 'pdf-processing'): string {
+  return [
+    '---',
+    `name: ${skillName}`,
+    'description: Handle PDF workflows',
+    '---',
+    '## Workflow',
+  ].join('\n')
+}
+
+async function loadSkillStoreModule() {
+  vi.resetModules()
+  vi.doMock('@/lib/config-repo-store', () => ({
+    getConfigRepoHash: () => getConfigRepoHashMock(),
+    listConfigRepoFiles: (...args: unknown[]) => listConfigRepoFilesMock(...args),
+    mutateConfigRepo: (...args: unknown[]) => mutateConfigRepoMock(...args),
+    readConfigRepoSnapshot: (
+      reader: (context: { repoDir: string; hash: string | null }) => Promise<unknown>
+    ) => readConfigRepoSnapshotMock(reader),
+  }))
+
+  return import('@/lib/skills/skill-store')
+}
+
+describe('skill-store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    readConfigRepoSnapshotMock.mockImplementation(
+      async (
+        reader: (context: { repoDir: string; hash: string | null }) => Promise<unknown>
+      ) => {
+        if (!repoDir) {
+          throw new Error('repo_not_configured')
+        }
+
+        const hash = 'snapshot-hash'
+        return {
+          ok: true,
+          hash,
+          data: await reader({ repoDir, hash }),
+        }
+      }
+    )
+  })
+
+  afterEach(async () => {
+    if (repoDir) {
+      await fs.rm(repoDir, { recursive: true, force: true })
+      repoDir = null
+    }
+
+    vi.unmock('@/lib/config-repo-store')
+    vi.resetModules()
+  })
+
+  it('lists skills from a single config repo snapshot', async () => {
+    await createSkillRepo({
+      'CommonWorkspaceConfig.json': createWorkspaceConfig(),
+      'skills/pdf-processing/SKILL.md': createSkillMarkdown(),
+      'skills/pdf-processing/references/guide.md': '# Guide\n',
+    })
+
+    const { listSkills } = await loadSkillStoreModule()
+    const result = await listSkills()
+
+    expect(result).toEqual({
+      ok: true,
+      hash: 'snapshot-hash',
+      data: [
+        {
+          assignedAgentIds: ['assistant'],
+          description: 'Handle PDF workflows',
+          hasResources: true,
+          name: 'pdf-processing',
+          resourcePaths: ['references/guide.md'],
+        },
+      ],
+    })
+    expect(readConfigRepoSnapshotMock).toHaveBeenCalledTimes(1)
+    expect(listConfigRepoFilesMock).not.toHaveBeenCalled()
+  })
+
+  it('reads a skill from a single config repo snapshot', async () => {
+    await createSkillRepo({
+      'CommonWorkspaceConfig.json': createWorkspaceConfig(),
+      'skills/pdf-processing/SKILL.md': createSkillMarkdown(),
+    })
+
+    const { readSkill } = await loadSkillStoreModule()
+    const result = await readSkill('pdf-processing')
+
+    expect(result).toEqual({
+      ok: true,
+      hash: 'snapshot-hash',
+      data: {
+        assignedAgentIds: ['assistant'],
+        body: '## Workflow',
+        description: 'Handle PDF workflows',
+        hasResources: false,
+        name: 'pdf-processing',
+        resourcePaths: [],
+      },
+    })
+    expect(readConfigRepoSnapshotMock).toHaveBeenCalledTimes(1)
+    expect(listConfigRepoFilesMock).not.toHaveBeenCalled()
+  })
+
+  it('fails bundle listing when a skill directory is malformed', async () => {
+    await createSkillRepo({
+      'CommonWorkspaceConfig.json': createWorkspaceConfig(),
+      'skills/pdf-processing/README.md': '# Missing skill markdown\n',
+    })
+
+    const { listSkillBundles } = await loadSkillStoreModule()
+
+    await expect(listSkillBundles()).resolves.toEqual({
+      ok: false,
+      error: 'read_failed',
+    })
+  })
+})

--- a/apps/web/src/lib/skills/__tests__/skill-zip.test.ts
+++ b/apps/web/src/lib/skills/__tests__/skill-zip.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { createSkillArchive, parseSkillArchive } from '@/lib/skills/skill-zip'
+
+describe('skill-zip', () => {
+  it('round-trips a skill bundle through zip export/import', () => {
+    const archive = createSkillArchive({
+      skill: {
+        frontmatter: {
+          name: 'pdf-processing',
+          description: 'Handle PDF workflows',
+        },
+        body: '## Workflow\n',
+        raw: '',
+      },
+      files: [
+        {
+          path: 'SKILL.md',
+          content: new TextEncoder().encode('---\nname: pdf-processing\ndescription: Handle PDF workflows\n---\n## Workflow\n'),
+        },
+        {
+          path: 'references/guide.md',
+          content: new TextEncoder().encode('# Guide\n'),
+        },
+      ],
+    })
+
+    const parsed = parseSkillArchive(archive)
+
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) {
+      return
+    }
+
+    expect(parsed.archive.skill.frontmatter.name).toBe('pdf-processing')
+    expect(parsed.archive.files.map((file) => file.path)).toEqual([
+      'SKILL.md',
+      'references/guide.md',
+    ])
+  })
+})

--- a/apps/web/src/lib/skills/__tests__/skill-zip.test.ts
+++ b/apps/web/src/lib/skills/__tests__/skill-zip.test.ts
@@ -1,7 +1,11 @@
 import { zipSync } from 'fflate'
 import { describe, expect, it } from 'vitest'
 
-import { createSkillArchive, parseSkillArchive } from '@/lib/skills/skill-zip'
+import {
+  MAX_SKILL_ARCHIVE_FILE_BYTES,
+  createSkillArchive,
+  parseSkillArchive,
+} from '@/lib/skills/skill-zip'
 
 const encoder = new TextEncoder()
 
@@ -83,5 +87,16 @@ describe('skill-zip', () => {
       'SKILL.md',
       'references/guide.md',
     ])
+  })
+
+  it('rejects archives whose extracted content exceeds the runtime limits', () => {
+    const archive = zipSync({
+      'pdf-processing/SKILL.md': encoder.encode('---\nname: pdf-processing\ndescription: Handle PDF workflows\n---\n## Workflow\n'),
+      'pdf-processing/references/huge.txt': encoder.encode('A'.repeat(MAX_SKILL_ARCHIVE_FILE_BYTES + 1024)),
+    })
+
+    const parsed = parseSkillArchive(archive)
+
+    expect(parsed).toEqual({ ok: false, error: 'archive_too_large' })
   })
 })

--- a/apps/web/src/lib/skills/__tests__/skill-zip.test.ts
+++ b/apps/web/src/lib/skills/__tests__/skill-zip.test.ts
@@ -1,6 +1,9 @@
+import { zipSync } from 'fflate'
 import { describe, expect, it } from 'vitest'
 
 import { createSkillArchive, parseSkillArchive } from '@/lib/skills/skill-zip'
+
+const encoder = new TextEncoder()
 
 describe('skill-zip', () => {
   it('round-trips a skill bundle through zip export/import', () => {
@@ -16,11 +19,11 @@ describe('skill-zip', () => {
       files: [
         {
           path: 'SKILL.md',
-          content: new TextEncoder().encode('---\nname: pdf-processing\ndescription: Handle PDF workflows\n---\n## Workflow\n'),
+          content: encoder.encode('---\nname: pdf-processing\ndescription: Handle PDF workflows\n---\n## Workflow\n'),
         },
         {
           path: 'references/guide.md',
-          content: new TextEncoder().encode('# Guide\n'),
+          content: encoder.encode('# Guide\n'),
         },
       ],
     })
@@ -33,6 +36,49 @@ describe('skill-zip', () => {
     }
 
     expect(parsed.archive.skill.frontmatter.name).toBe('pdf-processing')
+    expect(parsed.archive.files.map((file) => file.path)).toEqual([
+      'SKILL.md',
+      'references/guide.md',
+    ])
+  })
+
+  it('imports a Finder zip with __MACOSX metadata', () => {
+    const archive = zipSync({
+      'meta-ads-spain/SKILL.md': encoder.encode('---\nname: meta-ads-spain\ndescription: Meta Ads workflows\n---\n## Workflow\n'),
+      'meta-ads-spain/references/guide.md': encoder.encode('# Guide\n'),
+      '__MACOSX/._meta-ads-spain': encoder.encode('resource fork'),
+      '__MACOSX/meta-ads-spain/._SKILL.md': encoder.encode('resource fork'),
+      '__MACOSX/meta-ads-spain/references/._guide.md': encoder.encode('resource fork'),
+    })
+
+    const parsed = parseSkillArchive(archive)
+
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) {
+      return
+    }
+
+    expect(parsed.archive.skill.frontmatter.name).toBe('meta-ads-spain')
+    expect(parsed.archive.files.map((file) => file.path)).toEqual([
+      'SKILL.md',
+      'references/guide.md',
+    ])
+  })
+
+  it('uses the directory containing the skill markdown as the archive root', () => {
+    const archive = zipSync({
+      'bundle/docs/README.md': encoder.encode('# Docs\n'),
+      'bundle/skills/skill.md': encoder.encode('---\nname: pdf-processing\ndescription: Handle PDF workflows\n---\n## Workflow\n'),
+      'bundle/skills/references/guide.md': encoder.encode('# Guide\n'),
+    })
+
+    const parsed = parseSkillArchive(archive)
+
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) {
+      return
+    }
+
     expect(parsed.archive.files.map((file) => file.path)).toEqual([
       'SKILL.md',
       'references/guide.md',

--- a/apps/web/src/lib/skills/runtime-skills.ts
+++ b/apps/web/src/lib/skills/runtime-skills.ts
@@ -1,0 +1,23 @@
+import { mkdir, rm, writeFile } from 'fs/promises'
+import path from 'path'
+
+import type { SkillBundle } from '@/lib/skills/types'
+
+export async function writeRuntimeSkills(baseDir: string, skills: SkillBundle[]): Promise<void> {
+  await rm(baseDir, { recursive: true, force: true })
+
+  if (skills.length === 0) {
+    return
+  }
+
+  for (const skill of skills) {
+    const skillDir = path.join(baseDir, skill.skill.frontmatter.name)
+    await mkdir(skillDir, { recursive: true })
+
+    for (const file of skill.files) {
+      const filePath = path.join(skillDir, file.path)
+      await mkdir(path.dirname(filePath), { recursive: true })
+      await writeFile(filePath, Buffer.from(file.content))
+    }
+  }
+}

--- a/apps/web/src/lib/skills/skill-markdown.ts
+++ b/apps/web/src/lib/skills/skill-markdown.ts
@@ -1,0 +1,195 @@
+import { Document, isMap, isScalar, parseDocument } from 'yaml'
+
+import {
+  type SkillDocument,
+  type SkillFrontmatter,
+  SKILL_NAME_PATTERN,
+} from '@/lib/skills/types'
+
+type ParseSkillMarkdownResult =
+  | { ok: true; skill: SkillDocument }
+  | {
+      ok: false
+      error:
+        | 'invalid_description'
+        | 'invalid_frontmatter'
+        | 'invalid_metadata'
+        | 'invalid_name'
+        | 'invalid_yaml'
+        | 'missing_description'
+        | 'missing_frontmatter'
+        | 'missing_name'
+        | 'name_mismatch'
+    }
+
+type SplitFrontmatterResult =
+  | { ok: true; body: string; frontmatter: string }
+  | { ok: false; error: 'missing_frontmatter' }
+
+function normalizeLineEndings(value: string): string {
+  return value.replace(/\r\n?/gu, '\n')
+}
+
+function splitFrontmatter(value: string): SplitFrontmatterResult {
+  const normalized = normalizeLineEndings(value)
+  const source = normalized.startsWith('\uFEFF') ? normalized.slice(1) : normalized
+  const lines = source.split('\n')
+
+  if (lines[0] !== '---') {
+    return { ok: false, error: 'missing_frontmatter' }
+  }
+
+  for (let index = 1; index < lines.length; index += 1) {
+    if (lines[index] !== '---' && lines[index] !== '...') {
+      continue
+    }
+
+    return {
+      ok: true,
+      frontmatter: lines.slice(1, index).join('\n'),
+      body: lines.slice(index + 1).join('\n'),
+    }
+  }
+
+  return { ok: false, error: 'missing_frontmatter' }
+}
+
+function isValidSkillName(name: string): boolean {
+  return name.length >= 1 && name.length <= 64 && SKILL_NAME_PATTERN.test(name)
+}
+
+function normalizeFrontmatter(value: unknown): SkillFrontmatter | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+
+  const frontmatter = { ...(value as Record<string, unknown>) }
+
+  if (typeof frontmatter.name !== 'string') {
+    return null
+  }
+
+  if (typeof frontmatter.description !== 'string') {
+    return null
+  }
+
+  if (frontmatter.license != null && typeof frontmatter.license !== 'string') {
+    return null
+  }
+
+  if (frontmatter.compatibility != null && typeof frontmatter.compatibility !== 'string') {
+    return null
+  }
+
+  if (frontmatter.metadata != null) {
+    if (!frontmatter.metadata || typeof frontmatter.metadata !== 'object' || Array.isArray(frontmatter.metadata)) {
+      return null
+    }
+
+    const metadataEntries = Object.entries(frontmatter.metadata as Record<string, unknown>)
+    if (metadataEntries.some(([key, entry]) => !key || typeof entry !== 'string')) {
+      return null
+    }
+  }
+
+  return frontmatter as SkillFrontmatter
+}
+
+export function parseSkillMarkdown(value: string, expectedName?: string): ParseSkillMarkdownResult {
+  const split = splitFrontmatter(value)
+  if (!split.ok) {
+    return split
+  }
+
+  const document = parseDocument(split.frontmatter, {
+    prettyErrors: false,
+    strict: false,
+  })
+
+  if (document.errors.length > 0) {
+    return { ok: false, error: 'invalid_yaml' }
+  }
+
+  if (!document.contents || !isMap(document.contents)) {
+    return { ok: false, error: 'invalid_frontmatter' }
+  }
+
+  const normalized = normalizeFrontmatter(document.toJS())
+  if (!normalized) {
+    const metadataItem = document.contents.items.find((item) => {
+      if (!isScalar(item.key) || item.key.value !== 'metadata') return false
+      return true
+    })
+
+    return { ok: false, error: metadataItem ? 'invalid_metadata' : 'invalid_frontmatter' }
+  }
+
+  const name = normalized.name.trim()
+  if (!name) {
+    return { ok: false, error: 'missing_name' }
+  }
+
+  if (!isValidSkillName(name)) {
+    return { ok: false, error: 'invalid_name' }
+  }
+
+  if (expectedName && expectedName !== name) {
+    return { ok: false, error: 'name_mismatch' }
+  }
+
+  const description = normalized.description.trim()
+  if (!description) {
+    return { ok: false, error: 'missing_description' }
+  }
+
+  if (description.length > 1024) {
+    return { ok: false, error: 'invalid_description' }
+  }
+
+  if (normalized.compatibility && normalized.compatibility.length > 500) {
+    return { ok: false, error: 'invalid_frontmatter' }
+  }
+
+  return {
+    ok: true,
+    skill: {
+      frontmatter: {
+        ...normalized,
+        name,
+        description,
+      },
+      body: split.body,
+      raw: normalizeLineEndings(value),
+    },
+  }
+}
+
+export function serializeSkillMarkdown(skill: Pick<SkillDocument, 'body' | 'frontmatter'>): string {
+  const frontmatter: SkillFrontmatter = {
+    ...skill.frontmatter,
+    name: skill.frontmatter.name.trim(),
+    description: skill.frontmatter.description.trim(),
+  }
+
+  const document = new Document(frontmatter)
+  const frontmatterContent = String(document).trimEnd()
+  const body = normalizeLineEndings(skill.body)
+
+  return `---\n${frontmatterContent}\n---\n${body}`
+}
+
+export function createSkillMarkdown(input: {
+  body: string
+  description: string
+  existingFrontmatter?: SkillFrontmatter
+  name: string
+}): string {
+  return serializeSkillMarkdown({
+    body: input.body,
+    frontmatter: {
+      ...input.existingFrontmatter,
+      name: input.name,
+      description: input.description,
+    },
+  })
+}

--- a/apps/web/src/lib/skills/skill-store.ts
+++ b/apps/web/src/lib/skills/skill-store.ts
@@ -1,0 +1,511 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+import {
+  getConfigRepoHash,
+  listConfigRepoFiles,
+  mutateConfigRepo,
+  readConfigRepoFileBuffer,
+  type ConfigRepoFileEntry,
+} from '@/lib/config-repo-store'
+import {
+  createDefaultCommonWorkspaceConfig,
+  getAssignedAgentIdsForSkill,
+  parseCommonWorkspaceConfig,
+  setSkillAssignments,
+  validateCommonWorkspaceConfig,
+  type CommonWorkspaceConfig,
+} from '@/lib/workspace-config'
+import { createSkillMarkdown, parseSkillMarkdown } from '@/lib/skills/skill-markdown'
+import {
+  type SkillArchive,
+  type SkillBundle,
+  type SkillBundleFile,
+  type SkillDetail,
+  type SkillSummary,
+  SKILL_MARKDOWN_FILE_NAME,
+  SKILLS_CONFIG_DIRECTORY,
+} from '@/lib/skills/types'
+
+const COMMON_WORKSPACE_CONFIG_FILE = 'CommonWorkspaceConfig.json'
+
+type SkillStoreResult<T> =
+  | { ok: true; data: T; hash: string | null }
+  | { ok: false; error: 'invalid_config' | 'kb_unavailable' | 'not_found' | 'read_failed' }
+
+type SaveSkillDocumentInput = {
+  assignedAgentIds: string[]
+  body: string
+  description: string
+  expectedHash?: string
+  mode: 'create' | 'update'
+  name: string
+}
+
+type ImportSkillArchiveInput = {
+  archive: SkillArchive
+  assignedAgentIds: string[]
+  expectedHash?: string
+}
+
+type SaveSkillResult =
+  | { ok: true; hash: string }
+  | {
+      ok: false
+      error:
+        | 'conflict'
+        | 'invalid_config'
+        | 'kb_unavailable'
+        | 'not_found'
+        | 'skill_exists'
+        | 'unknown_agent'
+        | 'write_failed'
+    }
+
+class SkillStoreError extends Error {
+  constructor(readonly code: 'invalid_config' | 'not_found' | 'skill_exists' | 'unknown_agent') {
+    super(code)
+  }
+}
+
+function getSkillConfigDirectory(name: string): string {
+  return `${SKILLS_CONFIG_DIRECTORY}/${name}`
+}
+
+async function listFilesRecursive(rootDir: string, prefix = ''): Promise<SkillBundleFile[]> {
+  const entries = await fs.readdir(rootDir, { withFileTypes: true })
+  const files: SkillBundleFile[] = []
+
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const absolutePath = path.join(rootDir, entry.name)
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name
+
+    if (entry.isDirectory()) {
+      files.push(...await listFilesRecursive(absolutePath, relativePath))
+      continue
+    }
+
+    if (!entry.isFile()) {
+      continue
+    }
+
+    files.push({
+      path: relativePath,
+      content: new Uint8Array(await fs.readFile(absolutePath)),
+    })
+  }
+
+  return files
+}
+
+async function loadWorkspaceConfigFromRepoDir(repoDir: string): Promise<CommonWorkspaceConfig> {
+  const configPath = path.join(repoDir, COMMON_WORKSPACE_CONFIG_FILE)
+  const raw = await fs.readFile(configPath, 'utf-8').catch((error: unknown) => {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return null
+    }
+
+    throw error
+  })
+
+  if (raw == null) {
+    return createDefaultCommonWorkspaceConfig()
+  }
+
+  const parsed = parseCommonWorkspaceConfig(raw)
+  if (!parsed.ok) {
+    throw new SkillStoreError('invalid_config')
+  }
+
+  const validation = validateCommonWorkspaceConfig(parsed.config)
+  if (!validation.ok) {
+    throw new SkillStoreError('invalid_config')
+  }
+
+  return parsed.config
+}
+
+async function writeWorkspaceConfigToRepoDir(repoDir: string, config: CommonWorkspaceConfig): Promise<void> {
+  const validation = validateCommonWorkspaceConfig(config)
+  if (!validation.ok) {
+    throw new SkillStoreError('invalid_config')
+  }
+
+  await fs.writeFile(
+    path.join(repoDir, COMMON_WORKSPACE_CONFIG_FILE),
+    JSON.stringify(config, null, 2),
+    'utf-8'
+  )
+}
+
+async function readSkillBundleFromRepoDir(repoDir: string, name: string): Promise<SkillBundle | null> {
+  const skillDir = path.join(repoDir, getSkillConfigDirectory(name))
+  const stats = await fs.stat(skillDir).catch(() => null)
+  if (!stats?.isDirectory()) {
+    return null
+  }
+
+  const files = await listFilesRecursive(skillDir)
+  const skillMarkdown = files.find((file) => file.path === SKILL_MARKDOWN_FILE_NAME)
+  if (!skillMarkdown) {
+    return null
+  }
+
+  const parsed = parseSkillMarkdown(Buffer.from(skillMarkdown.content).toString('utf-8'), name)
+  if (!parsed.ok) {
+    return null
+  }
+
+  return {
+    files,
+    skill: parsed.skill,
+  }
+}
+
+async function writeSkillBundleToRepoDir(repoDir: string, name: string, files: SkillBundleFile[]): Promise<void> {
+  const skillDir = path.join(repoDir, getSkillConfigDirectory(name))
+  await fs.rm(skillDir, { recursive: true, force: true })
+  await fs.mkdir(skillDir, { recursive: true })
+
+  for (const file of files) {
+    const filePath = path.join(skillDir, file.path)
+    await fs.mkdir(path.dirname(filePath), { recursive: true })
+    await fs.writeFile(filePath, Buffer.from(file.content))
+  }
+}
+
+function groupSkillFiles(files: ConfigRepoFileEntry[]): Map<string, SkillBundleFile[]> {
+  const grouped = new Map<string, SkillBundleFile[]>()
+
+  for (const file of files) {
+    const relativePath = file.path.slice(SKILLS_CONFIG_DIRECTORY.length + 1)
+    const separatorIndex = relativePath.indexOf('/')
+    if (separatorIndex <= 0) {
+      continue
+    }
+
+    const skillName = relativePath.slice(0, separatorIndex)
+    const skillRelativePath = relativePath.slice(separatorIndex + 1)
+    const current = grouped.get(skillName) ?? []
+    current.push({ path: skillRelativePath, content: new Uint8Array(file.content) })
+    grouped.set(skillName, current)
+  }
+
+  return grouped
+}
+
+function createSkillSummary(bundle: SkillBundle, assignedAgentIds: string[]): SkillSummary {
+  const resourcePaths = bundle.files
+    .map((file) => file.path)
+    .filter((filePath) => filePath !== SKILL_MARKDOWN_FILE_NAME)
+    .sort((left, right) => left.localeCompare(right))
+
+  return {
+    assignedAgentIds,
+    description: bundle.skill.frontmatter.description,
+    hasResources: resourcePaths.length > 0,
+    name: bundle.skill.frontmatter.name,
+    resourcePaths,
+  }
+}
+
+async function loadWorkspaceConfigForRead(): Promise<SkillStoreResult<CommonWorkspaceConfig>> {
+  const result = await readConfigRepoFileBuffer(COMMON_WORKSPACE_CONFIG_FILE)
+  if (!result.ok) {
+    if (result.error === 'not_found') {
+      return { ok: true, data: createDefaultCommonWorkspaceConfig(), hash: null }
+    }
+
+    return { ok: false, error: result.error }
+  }
+
+  const parsed = parseCommonWorkspaceConfig(result.content.toString('utf-8'))
+  if (!parsed.ok) {
+    return { ok: false, error: 'invalid_config' }
+  }
+
+  const validation = validateCommonWorkspaceConfig(parsed.config)
+  if (!validation.ok) {
+    return { ok: false, error: 'invalid_config' }
+  }
+
+  return { ok: true, data: parsed.config, hash: result.hash }
+}
+
+export async function listSkills(): Promise<SkillStoreResult<SkillSummary[]>> {
+  const [skillsResult, configResult] = await Promise.all([
+    listConfigRepoFiles(SKILLS_CONFIG_DIRECTORY),
+    loadWorkspaceConfigForRead(),
+  ])
+
+  if (!skillsResult.ok) {
+    return { ok: false, error: skillsResult.error }
+  }
+
+  if (!configResult.ok) {
+    return configResult
+  }
+
+  const groupedFiles = groupSkillFiles(skillsResult.files)
+  const skills: SkillSummary[] = []
+
+  for (const [name, files] of groupedFiles) {
+    const skillMarkdown = files.find((file) => file.path === SKILL_MARKDOWN_FILE_NAME)
+    if (!skillMarkdown) {
+      continue
+    }
+
+    const parsed = parseSkillMarkdown(Buffer.from(skillMarkdown.content).toString('utf-8'), name)
+    if (!parsed.ok) {
+      continue
+    }
+
+    skills.push(
+      createSkillSummary(
+        { files, skill: parsed.skill },
+        getAssignedAgentIdsForSkill(configResult.data, parsed.skill.frontmatter.name)
+      )
+    )
+  }
+
+  skills.sort((left, right) => left.name.localeCompare(right.name))
+  return { ok: true, data: skills, hash: skillsResult.hash }
+}
+
+export async function listSkillBundles(): Promise<SkillStoreResult<SkillBundle[]>> {
+  const skillsResult = await listConfigRepoFiles(SKILLS_CONFIG_DIRECTORY)
+  if (!skillsResult.ok) {
+    return { ok: false, error: skillsResult.error }
+  }
+
+  const groupedFiles = groupSkillFiles(skillsResult.files)
+  const bundles: SkillBundle[] = []
+
+  for (const [name, files] of groupedFiles) {
+    const skillMarkdown = files.find((file) => file.path === SKILL_MARKDOWN_FILE_NAME)
+    if (!skillMarkdown) {
+      continue
+    }
+
+    const parsed = parseSkillMarkdown(Buffer.from(skillMarkdown.content).toString('utf-8'), name)
+    if (!parsed.ok) {
+      continue
+    }
+
+    bundles.push({ files, skill: parsed.skill })
+  }
+
+  bundles.sort((left, right) => left.skill.frontmatter.name.localeCompare(right.skill.frontmatter.name))
+  return { ok: true, data: bundles, hash: skillsResult.hash }
+}
+
+export async function readSkill(name: string): Promise<SkillStoreResult<SkillDetail>> {
+  const [bundleResult, configResult] = await Promise.all([
+    listConfigRepoFiles(getSkillConfigDirectory(name)),
+    loadWorkspaceConfigForRead(),
+  ])
+
+  if (!bundleResult.ok) {
+    return { ok: false, error: bundleResult.error }
+  }
+
+  if (!configResult.ok) {
+    return configResult
+  }
+
+  const skillMarkdown = bundleResult.files.find((file) => file.path === `${getSkillConfigDirectory(name)}/${SKILL_MARKDOWN_FILE_NAME}`)
+  if (!skillMarkdown) {
+    return { ok: false, error: 'not_found' }
+  }
+
+  const files = bundleResult.files.map((file) => ({
+    path: file.path.slice(getSkillConfigDirectory(name).length + 1),
+    content: new Uint8Array(file.content),
+  }))
+  const parsed = parseSkillMarkdown(skillMarkdown.content.toString('utf-8'), name)
+  if (!parsed.ok) {
+    return { ok: false, error: 'read_failed' }
+  }
+
+  const summary = createSkillSummary(
+    { files, skill: parsed.skill },
+    getAssignedAgentIdsForSkill(configResult.data, parsed.skill.frontmatter.name)
+  )
+
+  return {
+    ok: true,
+    data: {
+      ...summary,
+      body: parsed.skill.body,
+    },
+    hash: bundleResult.hash,
+  }
+}
+
+export async function readSkillBundle(name: string): Promise<SkillStoreResult<SkillBundle>> {
+  const bundleResult = await listConfigRepoFiles(getSkillConfigDirectory(name))
+  if (!bundleResult.ok) {
+    return { ok: false, error: bundleResult.error }
+  }
+
+  const skillMarkdown = bundleResult.files.find((file) => file.path === `${getSkillConfigDirectory(name)}/${SKILL_MARKDOWN_FILE_NAME}`)
+  if (!skillMarkdown) {
+    return { ok: false, error: 'not_found' }
+  }
+
+  const files = bundleResult.files.map((file) => ({
+    path: file.path.slice(getSkillConfigDirectory(name).length + 1),
+    content: new Uint8Array(file.content),
+  }))
+  const parsed = parseSkillMarkdown(skillMarkdown.content.toString('utf-8'), name)
+  if (!parsed.ok) {
+    return { ok: false, error: 'read_failed' }
+  }
+
+  return {
+    ok: true,
+    data: {
+      files,
+      skill: parsed.skill,
+    },
+    hash: bundleResult.hash,
+  }
+}
+
+function normalizeAssignedAgentIds(config: CommonWorkspaceConfig, assignedAgentIds: string[]): string[] {
+  const existingAgents = new Set(Object.keys(config.agent ?? {}))
+  const uniqueAgentIds = Array.from(new Set(assignedAgentIds)).sort((left, right) => left.localeCompare(right))
+
+  if (uniqueAgentIds.some((agentId) => !existingAgents.has(agentId))) {
+    throw new SkillStoreError('unknown_agent')
+  }
+
+  return uniqueAgentIds
+}
+
+function mapSkillMutationError(error: unknown): SaveSkillResult {
+  if (error instanceof SkillStoreError) {
+    return { ok: false, error: error.code }
+  }
+
+  return { ok: false, error: 'write_failed' }
+}
+
+export async function saveSkillDocument(input: SaveSkillDocumentInput): Promise<SaveSkillResult> {
+  try {
+    const result = await mutateConfigRepo({
+      expectedHash: input.expectedHash,
+      commitMessage: input.mode === 'create'
+        ? `Add skill ${input.name}`
+        : `Update skill ${input.name}`,
+      mutate: async ({ repoDir }) => {
+        const config = await loadWorkspaceConfigFromRepoDir(repoDir)
+        const assignedAgentIds = normalizeAssignedAgentIds(config, input.assignedAgentIds)
+        const existingBundle = await readSkillBundleFromRepoDir(repoDir, input.name)
+
+        if (input.mode === 'create' && existingBundle) {
+          throw new SkillStoreError('skill_exists')
+        }
+
+        if (input.mode === 'update' && !existingBundle) {
+          throw new SkillStoreError('not_found')
+        }
+
+        const skillMarkdown = createSkillMarkdown({
+          name: input.name,
+          description: input.description,
+          body: input.body,
+          existingFrontmatter: existingBundle?.skill.frontmatter,
+        })
+        const preservedFiles = existingBundle?.files.filter((file) => file.path !== SKILL_MARKDOWN_FILE_NAME) ?? []
+        const nextFiles: SkillBundleFile[] = [
+          { path: SKILL_MARKDOWN_FILE_NAME, content: new TextEncoder().encode(skillMarkdown) },
+          ...preservedFiles,
+        ]
+
+        await writeSkillBundleToRepoDir(repoDir, input.name, nextFiles)
+
+        const nextConfig = setSkillAssignments(config, input.name, assignedAgentIds)
+        await writeWorkspaceConfigToRepoDir(repoDir, nextConfig)
+
+        return [COMMON_WORKSPACE_CONFIG_FILE, getSkillConfigDirectory(input.name)]
+      },
+    })
+
+    if (!result.ok) {
+      return result
+    }
+
+    return { ok: true, hash: result.hash }
+  } catch (error) {
+    return mapSkillMutationError(error)
+  }
+}
+
+export async function importSkillArchive(input: ImportSkillArchiveInput): Promise<SaveSkillResult> {
+  const { archive } = input
+
+  try {
+    const result = await mutateConfigRepo({
+      expectedHash: input.expectedHash,
+      commitMessage: `Import skill ${archive.skill.frontmatter.name}`,
+      mutate: async ({ repoDir }) => {
+        const config = await loadWorkspaceConfigFromRepoDir(repoDir)
+        const assignedAgentIds = normalizeAssignedAgentIds(config, input.assignedAgentIds)
+
+        await writeSkillBundleToRepoDir(repoDir, archive.skill.frontmatter.name, archive.files)
+
+        const nextConfig = setSkillAssignments(config, archive.skill.frontmatter.name, assignedAgentIds)
+        await writeWorkspaceConfigToRepoDir(repoDir, nextConfig)
+
+        return [COMMON_WORKSPACE_CONFIG_FILE, getSkillConfigDirectory(archive.skill.frontmatter.name)]
+      },
+    })
+
+    if (!result.ok) {
+      return result
+    }
+
+    return { ok: true, hash: result.hash }
+  } catch (error) {
+    return mapSkillMutationError(error)
+  }
+}
+
+export async function deleteSkill(name: string, expectedHash?: string): Promise<SaveSkillResult> {
+  try {
+    const result = await mutateConfigRepo({
+      expectedHash,
+      commitMessage: `Delete skill ${name}`,
+      mutate: async ({ repoDir }) => {
+        const config = await loadWorkspaceConfigFromRepoDir(repoDir)
+        const existingBundle = await readSkillBundleFromRepoDir(repoDir, name)
+        if (!existingBundle) {
+          throw new SkillStoreError('not_found')
+        }
+
+        await fs.rm(path.join(repoDir, getSkillConfigDirectory(name)), { recursive: true, force: true })
+
+        const nextConfig = setSkillAssignments(config, name, [])
+        await writeWorkspaceConfigToRepoDir(repoDir, nextConfig)
+
+        return [COMMON_WORKSPACE_CONFIG_FILE, getSkillConfigDirectory(name)]
+      },
+    })
+
+    if (!result.ok) {
+      return result
+    }
+
+    return { ok: true, hash: result.hash }
+  } catch (error) {
+    return mapSkillMutationError(error)
+  }
+}
+
+export async function getSkillsConfigHash(): Promise<
+  | { ok: true; hash: string | null }
+  | { ok: false; error: 'kb_unavailable' | 'read_failed' }
+> {
+  return getConfigRepoHash()
+}

--- a/apps/web/src/lib/skills/skill-store.ts
+++ b/apps/web/src/lib/skills/skill-store.ts
@@ -3,10 +3,9 @@ import path from 'path'
 
 import {
   getConfigRepoHash,
-  listConfigRepoFiles,
   mutateConfigRepo,
-  readConfigRepoFileBuffer,
-  type ConfigRepoFileEntry,
+  listConfigRepoFiles,
+  readConfigRepoSnapshot,
 } from '@/lib/config-repo-store'
 import {
   createDefaultCommonWorkspaceConfig,
@@ -64,6 +63,14 @@ type SaveSkillResult =
 
 class SkillStoreError extends Error {
   constructor(readonly code: 'invalid_config' | 'not_found' | 'skill_exists' | 'unknown_agent') {
+    super(code)
+  }
+}
+
+type SkillStoreReadErrorCode = 'invalid_config' | 'kb_unavailable' | 'not_found' | 'read_failed'
+
+class SkillStoreReadError extends Error {
+  constructor(readonly code: SkillStoreReadErrorCode) {
     super(code)
   }
 }
@@ -138,28 +145,39 @@ async function writeWorkspaceConfigToRepoDir(repoDir: string, config: CommonWork
   )
 }
 
-async function readSkillBundleFromRepoDir(repoDir: string, name: string): Promise<SkillBundle | null> {
+async function loadSkillBundleFromRepoDir(repoDir: string, name: string): Promise<
+  | { ok: true; bundle: SkillBundle }
+  | { ok: false; error: 'not_found' | 'read_failed' }
+> {
   const skillDir = path.join(repoDir, getSkillConfigDirectory(name))
   const stats = await fs.stat(skillDir).catch(() => null)
   if (!stats?.isDirectory()) {
-    return null
+    return { ok: false, error: 'not_found' }
   }
 
   const files = await listFilesRecursive(skillDir)
   const skillMarkdown = files.find((file) => file.path === SKILL_MARKDOWN_FILE_NAME)
   if (!skillMarkdown) {
-    return null
+    return { ok: false, error: 'read_failed' }
   }
 
   const parsed = parseSkillMarkdown(Buffer.from(skillMarkdown.content).toString('utf-8'), name)
   if (!parsed.ok) {
-    return null
+    return { ok: false, error: 'read_failed' }
   }
 
   return {
-    files,
-    skill: parsed.skill,
+    ok: true,
+    bundle: {
+      files,
+      skill: parsed.skill,
+    },
   }
+}
+
+async function readSkillBundleFromRepoDir(repoDir: string, name: string): Promise<SkillBundle | null> {
+  const result = await loadSkillBundleFromRepoDir(repoDir, name)
+  return result.ok ? result.bundle : null
 }
 
 async function writeSkillBundleToRepoDir(repoDir: string, name: string, files: SkillBundleFile[]): Promise<void> {
@@ -172,26 +190,6 @@ async function writeSkillBundleToRepoDir(repoDir: string, name: string, files: S
     await fs.mkdir(path.dirname(filePath), { recursive: true })
     await fs.writeFile(filePath, Buffer.from(file.content))
   }
-}
-
-function groupSkillFiles(files: ConfigRepoFileEntry[]): Map<string, SkillBundleFile[]> {
-  const grouped = new Map<string, SkillBundleFile[]>()
-
-  for (const file of files) {
-    const relativePath = file.path.slice(SKILLS_CONFIG_DIRECTORY.length + 1)
-    const separatorIndex = relativePath.indexOf('/')
-    if (separatorIndex <= 0) {
-      continue
-    }
-
-    const skillName = relativePath.slice(0, separatorIndex)
-    const skillRelativePath = relativePath.slice(separatorIndex + 1)
-    const current = grouped.get(skillName) ?? []
-    current.push({ path: skillRelativePath, content: new Uint8Array(file.content) })
-    grouped.set(skillName, current)
-  }
-
-  return grouped
 }
 
 function createSkillSummary(bundle: SkillBundle, assignedAgentIds: string[]): SkillSummary {
@@ -209,136 +207,135 @@ function createSkillSummary(bundle: SkillBundle, assignedAgentIds: string[]): Sk
   }
 }
 
-async function loadWorkspaceConfigForRead(): Promise<SkillStoreResult<CommonWorkspaceConfig>> {
-  const result = await readConfigRepoFileBuffer(COMMON_WORKSPACE_CONFIG_FILE)
-  if (!result.ok) {
-    if (result.error === 'not_found') {
-      return { ok: true, data: createDefaultCommonWorkspaceConfig(), hash: null }
+async function listSkillNamesFromRepoDir(repoDir: string): Promise<string[]> {
+  const skillsDir = path.join(repoDir, SKILLS_CONFIG_DIRECTORY)
+  const entries = await fs.readdir(skillsDir, { withFileTypes: true }).catch((error: unknown) => {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return null
     }
 
-    return { ok: false, error: result.error }
+    throw error
+  })
+
+  if (!entries) {
+    return []
   }
 
-  const parsed = parseCommonWorkspaceConfig(result.content.toString('utf-8'))
-  if (!parsed.ok) {
-    return { ok: false, error: 'invalid_config' }
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right))
+}
+
+export async function readSkillBundlesFromRepoDir(
+  repoDir: string,
+  options: { strict?: boolean } = {}
+): Promise<SkillBundle[]> {
+  const skillNames = await listSkillNamesFromRepoDir(repoDir)
+  const bundles: SkillBundle[] = []
+
+  for (const name of skillNames) {
+    const result = await loadSkillBundleFromRepoDir(repoDir, name)
+    if (!result.ok) {
+      if (options.strict) {
+        throw new SkillStoreReadError(result.error === 'not_found' ? 'read_failed' : result.error)
+      }
+
+      continue
+    }
+
+    bundles.push(result.bundle)
   }
 
-  const validation = validateCommonWorkspaceConfig(parsed.config)
-  if (!validation.ok) {
-    return { ok: false, error: 'invalid_config' }
+  return bundles
+}
+
+function mapSkillStoreReadError(error: unknown): SkillStoreReadErrorCode {
+  if (error instanceof SkillStoreError && error.code === 'invalid_config') {
+    return 'invalid_config'
   }
 
-  return { ok: true, data: parsed.config, hash: result.hash }
+  if (error instanceof SkillStoreReadError) {
+    return error.code
+  }
+
+  return 'read_failed'
+}
+
+async function readSkillStoreSnapshot<T>(
+  reader: (repoDir: string) => Promise<T>
+): Promise<{ ok: true; data: T; hash: string | null } | { ok: false; error: SkillStoreReadErrorCode }> {
+  try {
+    const snapshot = await readConfigRepoSnapshot(async ({ repoDir }) => reader(repoDir))
+    if (!snapshot.ok) {
+      return { ok: false, error: snapshot.error }
+    }
+
+    return snapshot
+  } catch (error) {
+    return { ok: false, error: mapSkillStoreReadError(error) }
+  }
 }
 
 export async function listSkills(): Promise<SkillStoreResult<SkillSummary[]>> {
-  const [skillsResult, configResult] = await Promise.all([
-    listConfigRepoFiles(SKILLS_CONFIG_DIRECTORY),
-    loadWorkspaceConfigForRead(),
-  ])
+  const snapshot = await readSkillStoreSnapshot(async (repoDir) => {
+    const config = await loadWorkspaceConfigFromRepoDir(repoDir)
+    const bundles = await readSkillBundlesFromRepoDir(repoDir, { strict: true })
 
-  if (!skillsResult.ok) {
-    return { ok: false, error: skillsResult.error }
-  }
-
-  if (!configResult.ok) {
-    return configResult
-  }
-
-  const groupedFiles = groupSkillFiles(skillsResult.files)
-  const skills: SkillSummary[] = []
-
-  for (const [name, files] of groupedFiles) {
-    const skillMarkdown = files.find((file) => file.path === SKILL_MARKDOWN_FILE_NAME)
-    if (!skillMarkdown) {
-      continue
-    }
-
-    const parsed = parseSkillMarkdown(Buffer.from(skillMarkdown.content).toString('utf-8'), name)
-    if (!parsed.ok) {
-      continue
-    }
-
-    skills.push(
+    return bundles.map((bundle) =>
       createSkillSummary(
-        { files, skill: parsed.skill },
-        getAssignedAgentIdsForSkill(configResult.data, parsed.skill.frontmatter.name)
+        bundle,
+        getAssignedAgentIdsForSkill(config, bundle.skill.frontmatter.name)
       )
     )
+  })
+
+  if (!snapshot.ok) {
+    return snapshot
   }
 
-  skills.sort((left, right) => left.name.localeCompare(right.name))
-  return { ok: true, data: skills, hash: skillsResult.hash }
+  return { ok: true, data: snapshot.data, hash: snapshot.hash }
 }
 
 export async function listSkillBundles(): Promise<SkillStoreResult<SkillBundle[]>> {
-  const skillsResult = await listConfigRepoFiles(SKILLS_CONFIG_DIRECTORY)
-  if (!skillsResult.ok) {
-    return { ok: false, error: skillsResult.error }
+  const snapshot = await readSkillStoreSnapshot(async (repoDir) =>
+    readSkillBundlesFromRepoDir(repoDir, { strict: true })
+  )
+
+  if (!snapshot.ok) {
+    return snapshot
   }
 
-  const groupedFiles = groupSkillFiles(skillsResult.files)
-  const bundles: SkillBundle[] = []
-
-  for (const [name, files] of groupedFiles) {
-    const skillMarkdown = files.find((file) => file.path === SKILL_MARKDOWN_FILE_NAME)
-    if (!skillMarkdown) {
-      continue
-    }
-
-    const parsed = parseSkillMarkdown(Buffer.from(skillMarkdown.content).toString('utf-8'), name)
-    if (!parsed.ok) {
-      continue
-    }
-
-    bundles.push({ files, skill: parsed.skill })
-  }
-
-  bundles.sort((left, right) => left.skill.frontmatter.name.localeCompare(right.skill.frontmatter.name))
-  return { ok: true, data: bundles, hash: skillsResult.hash }
+  return { ok: true, data: snapshot.data, hash: snapshot.hash }
 }
 
 export async function readSkill(name: string): Promise<SkillStoreResult<SkillDetail>> {
-  const [bundleResult, configResult] = await Promise.all([
-    listConfigRepoFiles(getSkillConfigDirectory(name)),
-    loadWorkspaceConfigForRead(),
-  ])
+  const snapshot = await readSkillStoreSnapshot(async (repoDir) => {
+    const config = await loadWorkspaceConfigFromRepoDir(repoDir)
+    const bundleResult = await loadSkillBundleFromRepoDir(repoDir, name)
+    if (!bundleResult.ok) {
+      throw new SkillStoreReadError(bundleResult.error)
+    }
 
-  if (!bundleResult.ok) {
-    return { ok: false, error: bundleResult.error }
+    const summary = createSkillSummary(
+      bundleResult.bundle,
+      getAssignedAgentIdsForSkill(config, bundleResult.bundle.skill.frontmatter.name)
+    )
+
+    return {
+      ...summary,
+      body: bundleResult.bundle.skill.body,
+    }
+  })
+
+  if (!snapshot.ok) {
+    return snapshot
   }
-
-  if (!configResult.ok) {
-    return configResult
-  }
-
-  const skillMarkdown = bundleResult.files.find((file) => file.path === `${getSkillConfigDirectory(name)}/${SKILL_MARKDOWN_FILE_NAME}`)
-  if (!skillMarkdown) {
-    return { ok: false, error: 'not_found' }
-  }
-
-  const files = bundleResult.files.map((file) => ({
-    path: file.path.slice(getSkillConfigDirectory(name).length + 1),
-    content: new Uint8Array(file.content),
-  }))
-  const parsed = parseSkillMarkdown(skillMarkdown.content.toString('utf-8'), name)
-  if (!parsed.ok) {
-    return { ok: false, error: 'read_failed' }
-  }
-
-  const summary = createSkillSummary(
-    { files, skill: parsed.skill },
-    getAssignedAgentIdsForSkill(configResult.data, parsed.skill.frontmatter.name)
-  )
 
   return {
     ok: true,
-    data: {
-      ...summary,
-      body: parsed.skill.body,
-    },
-    hash: bundleResult.hash,
+    data: snapshot.data,
+    hash: snapshot.hash,
   }
 }
 

--- a/apps/web/src/lib/skills/skill-zip.ts
+++ b/apps/web/src/lib/skills/skill-zip.ts
@@ -9,6 +9,9 @@ import {
 } from '@/lib/skills/types'
 
 export const MAX_SKILL_ARCHIVE_BYTES = 5 * 1024 * 1024
+export const MAX_SKILL_ARCHIVE_ENTRIES = 100
+export const MAX_SKILL_ARCHIVE_EXTRACTED_BYTES = 20 * 1024 * 1024
+export const MAX_SKILL_ARCHIVE_FILE_BYTES = 5 * 1024 * 1024
 
 type ParseSkillArchiveResult =
   | { ok: true; archive: SkillArchive }
@@ -126,10 +129,43 @@ export function parseSkillArchive(buffer: Uint8Array): ParseSkillArchiveResult {
   }
 
   let extracted: Record<string, Uint8Array>
+  let extractedBytes = 0
+  let extractedEntryCount = 0
+  let archiveTooLarge = false
+
   try {
-    extracted = unzipSync(buffer)
+    extracted = unzipSync(buffer, {
+      filter: (file) => {
+        if (file.name.endsWith('/')) {
+          return false
+        }
+
+        extractedEntryCount += 1
+        if (extractedEntryCount > MAX_SKILL_ARCHIVE_ENTRIES) {
+          archiveTooLarge = true
+          return false
+        }
+
+        if (file.originalSize > MAX_SKILL_ARCHIVE_FILE_BYTES) {
+          archiveTooLarge = true
+          return false
+        }
+
+        if (extractedBytes + file.originalSize > MAX_SKILL_ARCHIVE_EXTRACTED_BYTES) {
+          archiveTooLarge = true
+          return false
+        }
+
+        extractedBytes += file.originalSize
+        return true
+      },
+    })
   } catch {
     return { ok: false, error: 'invalid_archive' }
+  }
+
+  if (archiveTooLarge) {
+    return { ok: false, error: 'archive_too_large' }
   }
 
   const files: SkillBundleFile[] = []

--- a/apps/web/src/lib/skills/skill-zip.ts
+++ b/apps/web/src/lib/skills/skill-zip.ts
@@ -1,0 +1,116 @@
+import { strFromU8, unzipSync, zipSync } from 'fflate'
+
+import { parseSkillMarkdown } from '@/lib/skills/skill-markdown'
+import {
+  type SkillArchive,
+  type SkillBundle,
+  type SkillBundleFile,
+  SKILL_MARKDOWN_FILE_NAME,
+} from '@/lib/skills/types'
+
+export const MAX_SKILL_ARCHIVE_BYTES = 5 * 1024 * 1024
+
+type ParseSkillArchiveResult =
+  | { ok: true; archive: SkillArchive }
+  | {
+      ok: false
+      error:
+        | 'archive_too_large'
+        | 'invalid_archive'
+        | 'invalid_archive_path'
+        | 'invalid_skill_markdown'
+        | 'missing_skill_markdown'
+    }
+
+function normalizeArchivePath(input: string): string | null {
+  const normalized = input
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/+/g, '/')
+
+  const segments = normalized
+    .split('/')
+    .filter((segment) => segment.length > 0 && segment !== '.')
+
+  if (segments.length === 0 || segments.some((segment) => segment === '..')) {
+    return null
+  }
+
+  return segments.join('/')
+}
+
+function stripCommonRoot(files: SkillBundleFile[]): SkillBundleFile[] {
+  const firstSegments = Array.from(new Set(files.map((file) => file.path.split('/')[0])))
+  if (firstSegments.length !== 1) {
+    return files
+  }
+
+  const [rootSegment] = firstSegments
+  const skillMarkdownPath = `${rootSegment}/${SKILL_MARKDOWN_FILE_NAME}`
+  if (!files.some((file) => file.path === skillMarkdownPath)) {
+    return files
+  }
+
+  return files.map((file) => ({
+    ...file,
+    path: file.path.slice(rootSegment.length + 1),
+  }))
+}
+
+export function parseSkillArchive(buffer: Uint8Array): ParseSkillArchiveResult {
+  if (buffer.byteLength > MAX_SKILL_ARCHIVE_BYTES) {
+    return { ok: false, error: 'archive_too_large' }
+  }
+
+  let extracted: Record<string, Uint8Array>
+  try {
+    extracted = unzipSync(buffer)
+  } catch {
+    return { ok: false, error: 'invalid_archive' }
+  }
+
+  const files: SkillBundleFile[] = []
+  for (const [entryPath, content] of Object.entries(extracted)) {
+    if (entryPath.endsWith('/')) {
+      continue
+    }
+
+    const normalizedPath = normalizeArchivePath(entryPath)
+    if (!normalizedPath) {
+      return { ok: false, error: 'invalid_archive_path' }
+    }
+
+    files.push({ path: normalizedPath, content })
+  }
+
+  const normalizedFiles = stripCommonRoot(files)
+  const skillMarkdown = normalizedFiles.find((file) => file.path === SKILL_MARKDOWN_FILE_NAME)
+  if (!skillMarkdown) {
+    return { ok: false, error: 'missing_skill_markdown' }
+  }
+
+  const parsed = parseSkillMarkdown(strFromU8(skillMarkdown.content))
+  if (!parsed.ok) {
+    return { ok: false, error: 'invalid_skill_markdown' }
+  }
+
+  return {
+    ok: true,
+    archive: {
+      files: normalizedFiles,
+      skill: parsed.skill,
+    },
+  }
+}
+
+export function createSkillArchive(bundle: SkillBundle): Uint8Array {
+  const rootDirectory = bundle.skill.frontmatter.name
+  const archiveEntries: Record<string, Uint8Array> = {}
+
+  for (const file of bundle.files) {
+    archiveEntries[`${rootDirectory}/${file.path}`] = file.content
+  }
+
+  return zipSync(archiveEntries, { level: 0 })
+}

--- a/apps/web/src/lib/skills/skill-zip.ts
+++ b/apps/web/src/lib/skills/skill-zip.ts
@@ -40,22 +40,84 @@ function normalizeArchivePath(input: string): string | null {
   return segments.join('/')
 }
 
-function stripCommonRoot(files: SkillBundleFile[]): SkillBundleFile[] {
-  const firstSegments = Array.from(new Set(files.map((file) => file.path.split('/')[0])))
-  if (firstSegments.length !== 1) {
-    return files
+function shouldIgnoreArchivePath(path: string): boolean {
+  const segments = path.split('/')
+  const fileName = segments[segments.length - 1] ?? ''
+
+  return segments.includes('__MACOSX') || fileName === '.DS_Store' || fileName.startsWith('._')
+}
+
+type SkillRoot = {
+  directoryPath: string
+  markdownPath: string
+}
+
+function getSkillRoot(files: SkillBundleFile[]): SkillRoot | null {
+  const candidates = files
+    .filter((file) => {
+      const segments = file.path.split('/')
+      const fileName = segments[segments.length - 1] ?? ''
+      return fileName.toLowerCase() === SKILL_MARKDOWN_FILE_NAME.toLowerCase()
+    })
+    .map((file) => {
+      const separatorIndex = file.path.lastIndexOf('/')
+      const directoryPath = separatorIndex === -1 ? '' : file.path.slice(0, separatorIndex)
+      const fileName = separatorIndex === -1 ? file.path : file.path.slice(separatorIndex + 1)
+
+      return {
+        directoryPath,
+        fileName,
+        markdownPath: file.path,
+        depth: directoryPath ? directoryPath.split('/').length : 0,
+      }
+    })
+    .sort((left, right) => {
+      if (left.depth !== right.depth) {
+        return left.depth - right.depth
+      }
+
+      if (left.fileName !== right.fileName) {
+        if (left.fileName === SKILL_MARKDOWN_FILE_NAME) {
+          return -1
+        }
+
+        if (right.fileName === SKILL_MARKDOWN_FILE_NAME) {
+          return 1
+        }
+      }
+
+      return left.markdownPath.localeCompare(right.markdownPath)
+    })
+
+  const selected = candidates[0]
+  if (!selected) {
+    return null
   }
 
-  const [rootSegment] = firstSegments
-  const skillMarkdownPath = `${rootSegment}/${SKILL_MARKDOWN_FILE_NAME}`
-  if (!files.some((file) => file.path === skillMarkdownPath)) {
-    return files
+  return {
+    directoryPath: selected.directoryPath,
+    markdownPath: selected.markdownPath,
+  }
+}
+
+function normalizeSkillFiles(files: SkillBundleFile[]): SkillBundleFile[] | null {
+  const skillRoot = getSkillRoot(files)
+  if (!skillRoot) {
+    return null
   }
 
-  return files.map((file) => ({
-    ...file,
-    path: file.path.slice(rootSegment.length + 1),
-  }))
+  const rootPrefix = skillRoot.directoryPath ? `${skillRoot.directoryPath}/` : ''
+
+  return files
+    .filter((file) => !rootPrefix || file.path.startsWith(rootPrefix))
+    .map((file) => {
+      const relativePath = rootPrefix ? file.path.slice(rootPrefix.length) : file.path
+
+      return {
+        ...file,
+        path: file.path === skillRoot.markdownPath ? SKILL_MARKDOWN_FILE_NAME : relativePath,
+      }
+    })
 }
 
 export function parseSkillArchive(buffer: Uint8Array): ParseSkillArchiveResult {
@@ -81,10 +143,18 @@ export function parseSkillArchive(buffer: Uint8Array): ParseSkillArchiveResult {
       return { ok: false, error: 'invalid_archive_path' }
     }
 
+    if (shouldIgnoreArchivePath(normalizedPath)) {
+      continue
+    }
+
     files.push({ path: normalizedPath, content })
   }
 
-  const normalizedFiles = stripCommonRoot(files)
+  const normalizedFiles = normalizeSkillFiles(files)
+  if (!normalizedFiles) {
+    return { ok: false, error: 'missing_skill_markdown' }
+  }
+
   const skillMarkdown = normalizedFiles.find((file) => file.path === SKILL_MARKDOWN_FILE_NAME)
   if (!skillMarkdown) {
     return { ok: false, error: 'missing_skill_markdown' }

--- a/apps/web/src/lib/skills/types.ts
+++ b/apps/web/src/lib/skills/types.ts
@@ -1,0 +1,45 @@
+export const SKILL_NAME_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/
+export const SKILLS_CONFIG_DIRECTORY = 'skills'
+export const SKILL_MARKDOWN_FILE_NAME = 'SKILL.md'
+
+export type SkillFrontmatter = {
+  compatibility?: string
+  description: string
+  license?: string
+  metadata?: Record<string, string>
+  name: string
+  [key: string]: unknown
+}
+
+export type SkillDocument = {
+  body: string
+  frontmatter: SkillFrontmatter
+  raw: string
+}
+
+export type SkillBundleFile = {
+  content: Uint8Array
+  path: string
+}
+
+export type SkillBundle = {
+  files: SkillBundleFile[]
+  skill: SkillDocument
+}
+
+export type SkillSummary = {
+  assignedAgentIds: string[]
+  description: string
+  hasResources: boolean
+  name: string
+  resourcePaths: string[]
+}
+
+export type SkillDetail = SkillSummary & {
+  body: string
+}
+
+export type SkillArchive = {
+  files: SkillBundleFile[]
+  skill: SkillDocument
+}

--- a/apps/web/src/lib/spawner/__tests__/core.test.ts
+++ b/apps/web/src/lib/spawner/__tests__/core.test.ts
@@ -64,6 +64,10 @@ vi.mock('@/lib/common-workspace-config-store', () => ({
   }),
 }))
 
+vi.mock('@/lib/skills/skill-store', () => ({
+  listSkillBundles: vi.fn().mockResolvedValue({ ok: true, data: [] }),
+}))
+
 // Mock docker
 vi.mock('../docker', () => ({
   createContainer: vi.fn(),
@@ -141,12 +145,13 @@ describe('startInstance', () => {
     const result = await startInstance('alice', 'user-1')
 
     expect(result).toEqual({ ok: true, status: 'running' })
-    const [slug, password, configContent, agentsMd, gitAuthor] = mockDocker.createContainer.mock.calls[0] ?? []
+    const [slug, password, configContent, agentsMd, skills, gitAuthor] = mockDocker.createContainer.mock.calls[0] ?? []
     expect(slug).toBe('alice')
     expect(password).toBe('test-password-123')
     expect(typeof configContent).toBe('string')
     expect(configContent).toContain('"$schema":"https://opencode.ai/config.json"')
     expect(typeof agentsMd).toBe('string')
+    expect(skills).toEqual([])
     expect(gitAuthor).toEqual({ name: 'alice', email: 'alice@example.com' })
     expect(mockDocker.startContainer).toHaveBeenCalledWith('container-123')
     expect(mockSync).toHaveBeenCalledWith({

--- a/apps/web/src/lib/spawner/__tests__/core.test.ts
+++ b/apps/web/src/lib/spawner/__tests__/core.test.ts
@@ -1,4 +1,21 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockReadConfigRepoSnapshot = vi.fn()
+let snapshotRepoDir: string | null = null
+
+async function writeSnapshotRepoFile(relativePath: string, content: string): Promise<void> {
+  if (!snapshotRepoDir) {
+    throw new Error('snapshot_repo_not_configured')
+  }
+
+  const filePath = path.join(snapshotRepoDir, relativePath)
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  await fs.writeFile(filePath, content, 'utf-8')
+}
 
 // Mock services (used directly by core.ts and transitively by runtime-config-hash.ts, mcp-config.ts)
 vi.mock('@/lib/services', () => ({
@@ -64,8 +81,14 @@ vi.mock('@/lib/common-workspace-config-store', () => ({
   }),
 }))
 
+vi.mock('@/lib/config-repo-store', () => ({
+  readConfigRepoSnapshot: (
+    reader: (context: { repoDir: string; hash: string | null }) => Promise<unknown>
+  ) => mockReadConfigRepoSnapshot(reader),
+}))
+
 vi.mock('@/lib/skills/skill-store', () => ({
-  listSkillBundles: vi.fn().mockResolvedValue({ ok: true, data: [] }),
+  readSkillBundlesFromRepoDir: vi.fn().mockResolvedValue([]),
 }))
 
 // Mock docker
@@ -89,7 +112,6 @@ vi.mock('../crypto', () => ({
   decryptPassword: vi.fn(() => 'test-password-123'),
 }))
 
-import { readCommonWorkspaceConfig } from '@/lib/common-workspace-config-store'
 import { isInstanceHealthyWithPassword } from '@/lib/opencode/client'
 import { syncProviderAccessForInstance } from '@/lib/opencode/providers'
 import { auditService, instanceService, userService } from '@/lib/services'
@@ -104,12 +126,44 @@ const mockDocker = vi.mocked(docker)
 const mockBuildMcpConfigForSlug = vi.mocked(buildMcpConfigForSlug)
 const mockHealth = vi.mocked(isInstanceHealthyWithPassword)
 const mockSync = vi.mocked(syncProviderAccessForInstance)
-const mockReadCommonWorkspaceConfig = vi.mocked(readCommonWorkspaceConfig)
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.clearAllMocks()
+  if (snapshotRepoDir) {
+    await fs.rm(snapshotRepoDir, { recursive: true, force: true })
+  }
+
+  snapshotRepoDir = await fs.mkdtemp(path.join(tmpdir(), 'core-runtime-repo-'))
+  await Promise.all([
+    writeSnapshotRepoFile(
+      'CommonWorkspaceConfig.json',
+      JSON.stringify({
+        $schema: 'https://opencode.ai/config.json',
+        default_agent: 'assistant',
+        agent: {},
+      })
+    ),
+    writeSnapshotRepoFile('AGENTS.md', '# AGENTS.md'),
+  ])
+
+  mockReadConfigRepoSnapshot.mockImplementation(
+    async (
+      reader: (context: { repoDir: string; hash: string | null }) => Promise<unknown>
+    ) => ({
+      ok: true,
+      hash: 'snapshot-hash',
+      data: await reader({ repoDir: snapshotRepoDir!, hash: 'snapshot-hash' }),
+    })
+  )
   mockHealth.mockResolvedValue(true)
   mockBuildMcpConfigForSlug.mockResolvedValue(null)
+})
+
+afterEach(async () => {
+  if (snapshotRepoDir) {
+    await fs.rm(snapshotRepoDir, { recursive: true, force: true })
+    snapshotRepoDir = null
+  }
 })
 
 describe('startInstance', () => {
@@ -338,9 +392,9 @@ describe('isSlowStart', () => {
 
 describe('startInstance - agent config transforms', () => {
   it('remaps connector IDs and injects self-delegation guards', async () => {
-    mockReadCommonWorkspaceConfig.mockResolvedValue({
-      ok: true,
-      content: JSON.stringify({
+    await writeSnapshotRepoFile(
+      'CommonWorkspaceConfig.json',
+      JSON.stringify({
         $schema: 'https://opencode.ai/config.json',
         default_agent: 'assistant',
         agent: {
@@ -355,10 +409,8 @@ describe('startInstance - agent config transforms', () => {
             tools: { task: true, 'arche_*': false, 'arche_linear_admin111_*': true },
           },
         },
-      }),
-      hash: 'hash',
-      path: '/kb-config/CommonWorkspaceConfig.json',
-    } as never)
+      })
+    )
 
     mockBuildMcpConfigForSlug.mockResolvedValue({
       $schema: 'https://opencode.ai/config.json',

--- a/apps/web/src/lib/spawner/__tests__/docker.test.ts
+++ b/apps/web/src/lib/spawner/__tests__/docker.test.ts
@@ -22,7 +22,11 @@ vi.mock('dockerode', () => ({
 
 const mockWriteFile = vi.fn().mockResolvedValue(undefined)
 const mockChmod = vi.fn().mockResolvedValue(undefined)
+const mockMkdir = vi.fn().mockResolvedValue(undefined)
+const mockRm = vi.fn().mockResolvedValue(undefined)
 vi.mock('fs/promises', () => ({
+  mkdir: (...args: unknown[]) => mockMkdir(...args),
+  rm: (...args: unknown[]) => mockRm(...args),
   writeFile: (...args: unknown[]) => mockWriteFile(...args),
   chmod: (...args: unknown[]) => mockChmod(...args),
 }))
@@ -128,6 +132,7 @@ describe('docker', () => {
           'OPENCODE_CONFIG_DIR=/opt/arche/opencode-config',
           'HOME=/home/workspace',
           'XDG_DATA_HOME=/home/workspace/.local/share',
+          'XDG_CONFIG_HOME=/home/workspace/.config',
           'XDG_STATE_HOME=/home/workspace/.local/state',
           'WORKSPACE_AGENT_PORT=4097',
           'WORKSPACE_GIT_AUTHOR_NAME=user-slug',
@@ -141,7 +146,7 @@ describe('docker', () => {
             'arche-opencode-share-user-slug:/home/workspace/.local/share/opencode',
             'arche-opencode-state-user-slug:/home/workspace/.local/state/opencode',
             '/opt/arche/kb-content:/kb-content',
-            '/opt/arche/users/user-slug/opencode-config.json:/tmp/arche-user-data/opencode-config.json:ro',
+            '/opt/arche/users/user-slug:/tmp/arche-user-data:ro',
           ],
         },
         Labels: {
@@ -205,8 +210,7 @@ describe('docker', () => {
         expect.objectContaining({
           HostConfig: expect.objectContaining({
             Binds: expect.arrayContaining([
-              '/opt/arche/users/user-slug/opencode-config.json:/tmp/arche-user-data/opencode-config.json:ro',
-              '/opt/arche/users/user-slug/AGENTS.md:/tmp/arche-user-data/AGENTS.md:ro',
+              '/opt/arche/users/user-slug:/tmp/arche-user-data:ro',
             ]),
           }),
         })
@@ -222,13 +226,39 @@ describe('docker', () => {
       expect(agentsCalls).toHaveLength(0)
     })
 
+    it('writes runtime skills to the user-data directory when provided', async () => {
+      await createContainer('user-slug', 'secret-password', undefined, undefined, [
+        {
+          skill: {
+            frontmatter: {
+              name: 'pdf-processing',
+              description: 'Handle PDFs',
+            },
+            body: 'Use this for PDFs.',
+            raw: '',
+          },
+          files: [
+            {
+              path: 'SKILL.md',
+              content: new TextEncoder().encode('---\nname: pdf-processing\ndescription: Handle PDFs\n---\nUse this for PDFs.'),
+            },
+          ],
+        },
+      ])
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        '/opt/arche/users/user-slug/skills/pdf-processing/SKILL.md',
+        expect.any(Buffer)
+      )
+    })
+
     it('returns the created container', async () => {
       const container = await createContainer('slug', 'pass')
       expect(container.id).toBe('container-123')
     })
 
     it('uses provided git author identity when passed', async () => {
-      await createContainer('user-slug', 'secret-password', undefined, undefined, {
+      await createContainer('user-slug', 'secret-password', undefined, undefined, undefined, {
         name: 'alice',
         email: 'alice@example.com',
       })

--- a/apps/web/src/lib/spawner/__tests__/runtime-artifacts.test.ts
+++ b/apps/web/src/lib/spawner/__tests__/runtime-artifacts.test.ts
@@ -1,69 +1,117 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
 
-vi.mock('@/lib/common-workspace-config-store', () => ({
-  readCommonWorkspaceConfig: vi.fn().mockResolvedValue({
-    ok: true,
-    content: JSON.stringify({
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const buildMcpConfigForSlugMock = vi.fn()
+const readConfigRepoSnapshotMock = vi.fn()
+const findIdentityBySlugMock = vi.fn()
+
+let repoDir: string | null = null
+
+async function writeRepoFile(relativePath: string, content: string): Promise<void> {
+  if (!repoDir) {
+    throw new Error('repo_not_configured')
+  }
+
+  const filePath = path.join(repoDir, relativePath)
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  await fs.writeFile(filePath, content, 'utf-8')
+}
+
+async function createRuntimeRepo(files: Record<string, string>): Promise<void> {
+  repoDir = await fs.mkdtemp(path.join(tmpdir(), 'runtime-artifacts-'))
+  await Promise.all(Object.entries(files).map(([relativePath, content]) => writeRepoFile(relativePath, content)))
+}
+
+function createWorkspaceConfig(): string {
+  return JSON.stringify(
+    {
       $schema: 'https://opencode.ai/config.json',
       agent: {},
-    }),
-  }),
-  readConfigRepoFile: vi.fn().mockResolvedValue({
-    ok: true,
-    content: '# Base instructions',
-  }),
-}))
+    },
+    null,
+    2,
+  )
+}
 
-vi.mock('@/lib/services', () => ({
-  userService: {
-    findIdentityBySlug: vi.fn().mockResolvedValue({
-      id: 'user-1',
-      slug: 'alice',
-      email: 'alice@example.com',
-    }),
-  },
-}))
+async function loadRuntimeArtifactsModule() {
+  vi.resetModules()
+  vi.doMock('@/lib/config-repo-store', () => ({
+    readConfigRepoSnapshot: (
+      reader: (context: { repoDir: string; hash: string | null }) => Promise<unknown>
+    ) => readConfigRepoSnapshotMock(reader),
+  }))
+  vi.doMock('@/lib/services', () => ({
+    userService: {
+      findIdentityBySlug: (...args: unknown[]) => findIdentityBySlugMock(...args),
+    },
+  }))
+  vi.doMock('@/lib/spawner/mcp-config', () => ({
+    buildMcpConfigForSlug: (...args: unknown[]) => buildMcpConfigForSlugMock(...args),
+  }))
 
-vi.mock('@/lib/skills/skill-store', () => ({
-  listSkillBundles: vi.fn().mockResolvedValue({
-    ok: true,
-    data: [
-      {
-        skill: {
-          frontmatter: {
-            name: 'pdf-processing',
-            description: 'Handle PDF files',
-          },
-          body: 'Use this for PDFs.',
-          raw: '---\nname: pdf-processing\ndescription: Handle PDF files\n---\nUse this for PDFs.',
-        },
-        files: [
-          {
-            path: 'SKILL.md',
-            content: new TextEncoder().encode('---\nname: pdf-processing\ndescription: Handle PDF files\n---\nUse this for PDFs.'),
-          },
-        ],
-      },
-    ],
-  }),
-}))
-
-vi.mock('../mcp-config', () => ({
-  buildMcpConfigForSlug: vi.fn().mockResolvedValue(null),
-}))
-
-import {
-  buildWorkspaceRuntimeArtifacts,
-  getWebProviderGatewayConfig,
-  hashWorkspaceRuntimeArtifacts,
-} from '../runtime-artifacts'
+  return import('../runtime-artifacts')
+}
 
 describe('runtime artifacts', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    buildMcpConfigForSlugMock.mockResolvedValue(null)
+    findIdentityBySlugMock.mockResolvedValue({
+      id: 'user-1',
+      slug: 'alice',
+      email: 'alice@example.com',
+    })
+    readConfigRepoSnapshotMock.mockImplementation(
+      async (
+        reader: (context: { repoDir: string; hash: string | null }) => Promise<unknown>
+      ) => {
+        if (!repoDir) {
+          throw new Error('repo_not_configured')
+        }
+
+        const hash = 'config-snapshot-hash'
+        return {
+          ok: true,
+          hash,
+          data: await reader({ repoDir, hash }),
+        }
+      }
+    )
   })
 
-  it('builds the final runtime config and injected AGENTS instructions', async () => {
+  afterEach(async () => {
+    if (repoDir) {
+      await fs.rm(repoDir, { recursive: true, force: true })
+      repoDir = null
+    }
+
+    vi.unmock('@/lib/config-repo-store')
+    vi.unmock('@/lib/services')
+    vi.unmock('@/lib/spawner/mcp-config')
+    vi.resetModules()
+  })
+
+  it('builds the final runtime config and injected AGENTS instructions from one repo snapshot', async () => {
+    await createRuntimeRepo({
+      'AGENTS.md': '# Base instructions\nSlug: {{slug}}\nEmail: {{email}}\n',
+      'CommonWorkspaceConfig.json': createWorkspaceConfig(),
+      'skills/pdf-processing/SKILL.md': [
+        '---',
+        'name: pdf-processing',
+        'description: Handle PDF files',
+        '---',
+        'Use this for PDFs.',
+      ].join('\n'),
+    })
+
+    const {
+      buildWorkspaceRuntimeArtifacts,
+      getWebProviderGatewayConfig,
+    } = await loadRuntimeArtifactsModule()
+
     const artifacts = await buildWorkspaceRuntimeArtifacts('alice', getWebProviderGatewayConfig())
     const config = JSON.parse(artifacts.opencodeConfigContent) as {
       permission?: {
@@ -75,6 +123,7 @@ describe('runtime artifacts', () => {
       }
     }
 
+    expect(readConfigRepoSnapshotMock).toHaveBeenCalledTimes(1)
     expect(config.permission?.edit?.['opencode.json']).toBe('deny')
     expect(config.provider?.fireworks?.options?.baseURL).toBe(
       'http://web:3000/api/internal/providers/fireworks'
@@ -88,7 +137,38 @@ describe('runtime artifacts', () => {
     expect(artifacts.skills[0]?.skill.frontmatter.name).toBe('pdf-processing')
   })
 
-  it('changes the runtime hash when the generated config or AGENTS content changes', () => {
+  it('fails when the snapshot contains a malformed skill bundle', async () => {
+    await createRuntimeRepo({
+      'CommonWorkspaceConfig.json': createWorkspaceConfig(),
+      'skills/pdf-processing/README.md': '# Missing SKILL.md\n',
+    })
+
+    const {
+      buildWorkspaceRuntimeArtifacts,
+      getWebProviderGatewayConfig,
+    } = await loadRuntimeArtifactsModule()
+
+    await expect(
+      buildWorkspaceRuntimeArtifacts('alice', getWebProviderGatewayConfig())
+    ).rejects.toThrow('read_failed')
+  })
+
+  it('fails when the config repo snapshot cannot be read', async () => {
+    readConfigRepoSnapshotMock.mockResolvedValueOnce({ ok: false, error: 'read_failed' })
+
+    const {
+      buildWorkspaceRuntimeArtifacts,
+      getWebProviderGatewayConfig,
+    } = await loadRuntimeArtifactsModule()
+
+    await expect(
+      buildWorkspaceRuntimeArtifacts('alice', getWebProviderGatewayConfig())
+    ).rejects.toThrow('read_failed')
+  })
+
+  it('changes the runtime hash when the generated config or AGENTS content changes', async () => {
+    const { hashWorkspaceRuntimeArtifacts } = await loadRuntimeArtifactsModule()
+
     const baseHash = hashWorkspaceRuntimeArtifacts({
       opencodeConfigContent: '{"provider":{"fireworks":{}}}',
       agentsMd: '# Base instructions',
@@ -126,7 +206,9 @@ describe('runtime artifacts', () => {
     ).not.toBe(baseHash)
   })
 
-  it('ignores connector gateway token rotation when hashing runtime artifacts', () => {
+  it('ignores connector gateway token rotation when hashing runtime artifacts', async () => {
+    const { hashWorkspaceRuntimeArtifacts } = await loadRuntimeArtifactsModule()
+
     const baseConfig = {
       $schema: 'https://opencode.ai/config.json',
       mcp: {
@@ -165,7 +247,9 @@ describe('runtime artifacts', () => {
     )
   })
 
-  it('keeps external MCP authorization changes in the runtime hash', () => {
+  it('keeps external MCP authorization changes in the runtime hash', async () => {
+    const { hashWorkspaceRuntimeArtifacts } = await loadRuntimeArtifactsModule()
+
     const baseConfig = {
       $schema: 'https://opencode.ai/config.json',
       mcp: {

--- a/apps/web/src/lib/spawner/__tests__/runtime-artifacts.test.ts
+++ b/apps/web/src/lib/spawner/__tests__/runtime-artifacts.test.ts
@@ -24,6 +24,30 @@ vi.mock('@/lib/services', () => ({
   },
 }))
 
+vi.mock('@/lib/skills/skill-store', () => ({
+  listSkillBundles: vi.fn().mockResolvedValue({
+    ok: true,
+    data: [
+      {
+        skill: {
+          frontmatter: {
+            name: 'pdf-processing',
+            description: 'Handle PDF files',
+          },
+          body: 'Use this for PDFs.',
+          raw: '---\nname: pdf-processing\ndescription: Handle PDF files\n---\nUse this for PDFs.',
+        },
+        files: [
+          {
+            path: 'SKILL.md',
+            content: new TextEncoder().encode('---\nname: pdf-processing\ndescription: Handle PDF files\n---\nUse this for PDFs.'),
+          },
+        ],
+      },
+    ],
+  }),
+}))
+
 vi.mock('../mcp-config', () => ({
   buildMcpConfigForSlug: vi.fn().mockResolvedValue(null),
 }))
@@ -60,6 +84,8 @@ describe('runtime artifacts', () => {
     )
     expect(artifacts.agentsMd).toContain('Slug: alice')
     expect(artifacts.agentsMd).toContain('Email: alice@example.com')
+    expect(artifacts.skills).toHaveLength(1)
+    expect(artifacts.skills[0]?.skill.frontmatter.name).toBe('pdf-processing')
   })
 
   it('changes the runtime hash when the generated config or AGENTS content changes', () => {
@@ -79,6 +105,23 @@ describe('runtime artifacts', () => {
       hashWorkspaceRuntimeArtifacts({
         opencodeConfigContent: '{"provider":{"fireworks":{}}}',
         agentsMd: '# Updated instructions',
+      })
+    ).not.toBe(baseHash)
+
+    expect(
+      hashWorkspaceRuntimeArtifacts({
+        opencodeConfigContent: '{"provider":{"fireworks":{}}}',
+        agentsMd: '# Base instructions',
+        skills: [
+          {
+            skill: {
+              frontmatter: { name: 'pdf-processing', description: 'Handle PDFs' },
+              body: 'v2',
+              raw: '',
+            },
+            files: [{ path: 'SKILL.md', content: new TextEncoder().encode('v2') }],
+          },
+        ],
       })
     ).not.toBe(baseHash)
   })

--- a/apps/web/src/lib/spawner/core.ts
+++ b/apps/web/src/lib/spawner/core.ts
@@ -46,9 +46,9 @@ export async function startInstance(slug: string, userId: string): Promise<Start
   try {
     const artifacts = await buildWorkspaceRuntimeArtifacts(slug, getWebProviderGatewayConfig())
     const appliedConfigSha = hashWorkspaceRuntimeArtifacts(artifacts)
-    const { owner, opencodeConfigContent, agentsMd } = artifacts
+    const { owner, opencodeConfigContent, agentsMd, skills } = artifacts
 
-    const container = await docker.createContainer(slug, password, opencodeConfigContent, agentsMd, {
+    const container = await docker.createContainer(slug, password, opencodeConfigContent, agentsMd, skills, {
       name: owner?.slug ?? slug,
       email: owner?.email ?? undefined,
     })

--- a/apps/web/src/lib/spawner/docker.ts
+++ b/apps/web/src/lib/spawner/docker.ts
@@ -1,4 +1,5 @@
 import { getUserDataHostPath, ensureUserDirectory } from "@/lib/user-data";
+import type { SkillBundle } from '@/lib/skills/types'
 import {
   getContainerSocketPath,
   getContainerProxyUrl,
@@ -54,6 +55,7 @@ export async function createContainer(
   password: string,
   opencodeConfigContent?: string,
   agentsMd?: string,
+  skills?: SkillBundle[],
   gitAuthor?: { name: string; email?: string }
 ) {
   const docker = await getContainerClient();
@@ -96,7 +98,7 @@ export async function createContainer(
   // Persist runtime files in host user-data directory.
   // We mount files individually into /tmp inside the container so the workspace
   // can remain empty during init-workspace git bootstrap.
-  const { chmod, writeFile } = await importRuntimeModule<typeof import("fs/promises")>("fs/promises");
+  const { chmod, mkdir, rm, writeFile } = await importRuntimeModule<typeof import("fs/promises")>("fs/promises");
   const { join } = await importRuntimeModule<typeof import("path")>("path");
   const userDataPath = getUserDataHostPath(slug);
   await ensureUserDirectory(slug);
@@ -110,14 +112,28 @@ export async function createContainer(
     "utf-8"
   );
   await chmod(opencodeConfigPath, 0o644);
-  binds.push(`${opencodeConfigPath}:/tmp/arche-user-data/opencode-config.json:ro`);
 
+  const agentsPath = join(userDataPath, 'AGENTS.md')
   if (agentsMd) {
-    const agentsPath = join(userDataPath, "AGENTS.md");
     await writeFile(agentsPath, agentsMd, "utf-8");
     await chmod(agentsPath, 0o644);
-    binds.push(`${agentsPath}:/tmp/arche-user-data/AGENTS.md:ro`);
+  } else {
+    await rm(agentsPath, { force: true }).catch(() => {})
   }
+
+  const skillsDir = join(userDataPath, 'skills')
+  await rm(skillsDir, { recursive: true, force: true }).catch(() => {})
+  for (const skill of skills ?? []) {
+    const skillDir = join(skillsDir, skill.skill.frontmatter.name)
+    await mkdir(skillDir, { recursive: true })
+    for (const file of skill.files) {
+      const filePath = join(skillDir, file.path)
+      await mkdir(join(skillDir, file.path.split('/').slice(0, -1).join('/')), { recursive: true })
+      await writeFile(filePath, Buffer.from(file.content))
+    }
+  }
+
+  binds.push(`${userDataPath}:/tmp/arche-user-data:ro`);
 
   const env = [
     `OPENCODE_SERVER_PASSWORD=${password}`,
@@ -127,6 +143,7 @@ export async function createContainer(
     // Force HOME/XDG to mounted /home/workspace paths so session data persists.
     `HOME=/home/workspace`,
     `XDG_DATA_HOME=/home/workspace/.local/share`,
+    `XDG_CONFIG_HOME=/home/workspace/.config`,
     `XDG_STATE_HOME=/home/workspace/.local/state`,
     `WORKSPACE_AGENT_PORT=${getWorkspaceAgentPort()}`,
     `WORKSPACE_GIT_AUTHOR_NAME=${gitAuthor?.name ?? slug}`,

--- a/apps/web/src/lib/spawner/runtime-artifacts.ts
+++ b/apps/web/src/lib/spawner/runtime-artifacts.ts
@@ -2,6 +2,8 @@ import { createHash } from 'node:crypto'
 
 import { readCommonWorkspaceConfig, readConfigRepoFile } from '@/lib/common-workspace-config-store'
 import { getConnectorGatewayBaseUrl } from '@/lib/connectors/gateway-config'
+import { listSkillBundles } from '@/lib/skills/skill-store'
+import type { SkillBundle } from '@/lib/skills/types'
 import { userService } from '@/lib/services'
 import {
   injectAlwaysOnAgentTools,
@@ -32,6 +34,7 @@ type WorkspaceOwner = {
 } | null
 
 export type WorkspaceRuntimeArtifacts = {
+  skills: SkillBundle[]
   owner: WorkspaceOwner
   opencodeConfigContent: string
   agentsMd?: string
@@ -160,8 +163,11 @@ export async function buildWorkspaceRuntimeArtifacts(
   const owner = await getWorkspaceOwner(slug)
   const config = await buildWorkspaceRuntimeConfig(slug, providerGatewayConfig)
   const agentsMd = await buildWorkspaceAgentsMd(slug, owner)
+  const skillsResult = await listSkillBundles().catch(() => null)
+  const skills = skillsResult?.ok ? skillsResult.data : []
 
   return {
+    skills,
     owner,
     opencodeConfigContent: serializeRuntimeConfig(config),
     ...(agentsMd ? { agentsMd } : {}),
@@ -169,6 +175,7 @@ export async function buildWorkspaceRuntimeArtifacts(
 }
 
 export function hashWorkspaceRuntimeArtifacts(input: {
+  skills?: SkillBundle[]
   opencodeConfigContent: string
   agentsMd?: string
 }): string {
@@ -177,6 +184,13 @@ export function hashWorkspaceRuntimeArtifacts(input: {
       JSON.stringify({
         opencodeConfigContent: normalizeRuntimeConfigForHash(input.opencodeConfigContent),
         agentsMd: input.agentsMd ?? null,
+        skills: (input.skills ?? []).map((skill) => ({
+          name: skill.skill.frontmatter.name,
+          files: skill.files.map((file) => ({
+            path: file.path,
+            content: Buffer.from(file.content).toString('base64'),
+          })),
+        })),
       })
     )
     .digest('hex')

--- a/apps/web/src/lib/spawner/runtime-artifacts.ts
+++ b/apps/web/src/lib/spawner/runtime-artifacts.ts
@@ -1,8 +1,11 @@
 import { createHash } from 'node:crypto'
+import { promises as fs } from 'fs'
+import path from 'path'
 
+import { readConfigRepoSnapshot } from '@/lib/config-repo-store'
 import { readCommonWorkspaceConfig, readConfigRepoFile } from '@/lib/common-workspace-config-store'
 import { getConnectorGatewayBaseUrl } from '@/lib/connectors/gateway-config'
-import { listSkillBundles } from '@/lib/skills/skill-store'
+import { readSkillBundlesFromRepoDir } from '@/lib/skills/skill-store'
 import type { SkillBundle } from '@/lib/skills/types'
 import { userService } from '@/lib/services'
 import {
@@ -39,6 +42,8 @@ export type WorkspaceRuntimeArtifacts = {
   opencodeConfigContent: string
   agentsMd?: string
 }
+
+const COMMON_WORKSPACE_CONFIG_FILE = 'CommonWorkspaceConfig.json'
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
@@ -99,10 +104,54 @@ async function getWorkspaceOwner(slug: string): Promise<WorkspaceOwner> {
   return userService.findIdentityBySlug(slug).catch(() => null)
 }
 
-async function buildBaseWorkspaceConfig(slug: string): Promise<Record<string, unknown>> {
+async function readOptionalRepoTextFile(repoDir: string, filePath: string): Promise<string | null> {
+  return fs.readFile(path.join(repoDir, filePath), 'utf-8').catch((error: unknown) => {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return null
+    }
+
+    throw error
+  })
+}
+
+async function readRuntimeRepoSnapshot(): Promise<{
+  agentsMdContent: string | null
+  commonConfigContent: string | null
+  skills: SkillBundle[]
+}> {
+  const snapshot = await readConfigRepoSnapshot(async ({ repoDir }) => {
+    const [agentsMdContent, commonConfigContent, skills] = await Promise.all([
+      readOptionalRepoTextFile(repoDir, 'AGENTS.md'),
+      readOptionalRepoTextFile(repoDir, COMMON_WORKSPACE_CONFIG_FILE),
+      readSkillBundlesFromRepoDir(repoDir, { strict: true }),
+    ])
+
+    return {
+      agentsMdContent,
+      commonConfigContent,
+      skills,
+    }
+  })
+
+  if (!snapshot.ok) {
+    throw new Error(snapshot.error)
+  }
+
+  return snapshot.data
+}
+
+async function buildBaseWorkspaceConfig(
+  slug: string,
+  commonConfigContent?: string | null
+): Promise<Record<string, unknown>> {
   let baseConfig: Record<string, unknown> = {}
 
-  const commonConfigResult = await readCommonWorkspaceConfig().catch(() => null)
+  const commonConfigResult = typeof commonConfigContent === 'undefined'
+    ? await readCommonWorkspaceConfig().catch(() => null)
+    : commonConfigContent == null
+      ? null
+      : { ok: true as const, content: commonConfigContent }
+
   if (commonConfigResult?.ok) {
     try {
       baseConfig = parseRuntimeConfigContent(commonConfigResult.content)
@@ -131,9 +180,10 @@ async function buildBaseWorkspaceConfig(slug: string): Promise<Record<string, un
 
 export async function buildWorkspaceRuntimeConfig(
   slug: string,
-  providerGatewayConfig: Record<string, unknown>
+  providerGatewayConfig: Record<string, unknown>,
+  commonConfigContent?: string | null
 ): Promise<Record<string, unknown>> {
-  const baseConfig = await buildBaseWorkspaceConfig(slug)
+  const baseConfig = await buildBaseWorkspaceConfig(slug, commonConfigContent)
   return withWorkspacePermissionGuards({
     ...baseConfig,
     ...providerGatewayConfig,
@@ -142,9 +192,15 @@ export async function buildWorkspaceRuntimeConfig(
 
 export async function buildWorkspaceAgentsMd(
   slug: string,
-  owner?: WorkspaceOwner
+  owner?: WorkspaceOwner,
+  agentsMdContent?: string | null
 ): Promise<string | undefined> {
-  const agentsResult = await readConfigRepoFile('AGENTS.md').catch(() => null)
+  const agentsResult = typeof agentsMdContent === 'undefined'
+    ? await readConfigRepoFile('AGENTS.md').catch(() => null)
+    : agentsMdContent == null
+      ? null
+      : { ok: true as const, content: agentsMdContent }
+
   if (!agentsResult?.ok) {
     return undefined
   }
@@ -161,13 +217,16 @@ export async function buildWorkspaceRuntimeArtifacts(
   providerGatewayConfig: Record<string, unknown>
 ): Promise<WorkspaceRuntimeArtifacts> {
   const owner = await getWorkspaceOwner(slug)
-  const config = await buildWorkspaceRuntimeConfig(slug, providerGatewayConfig)
-  const agentsMd = await buildWorkspaceAgentsMd(slug, owner)
-  const skillsResult = await listSkillBundles().catch(() => null)
-  const skills = skillsResult?.ok ? skillsResult.data : []
+  const repoSnapshot = await readRuntimeRepoSnapshot()
+  const config = await buildWorkspaceRuntimeConfig(
+    slug,
+    providerGatewayConfig,
+    repoSnapshot.commonConfigContent
+  )
+  const agentsMd = await buildWorkspaceAgentsMd(slug, owner, repoSnapshot.agentsMdContent)
 
   return {
-    skills,
+    skills: repoSnapshot.skills,
     owner,
     opencodeConfigContent: serializeRuntimeConfig(config),
     ...(agentsMd ? { agentsMd } : {}),

--- a/apps/web/src/lib/workspace-config.ts
+++ b/apps/web/src/lib/workspace-config.ts
@@ -1,10 +1,15 @@
-import { extractAgentCapabilitiesFromTools, type AgentCapabilities } from '@/lib/agent-capabilities'
+import {
+  buildAgentPermissionConfigFromCapabilities,
+  extractAgentCapabilitiesFromTools,
+  type AgentCapabilities,
+} from '@/lib/agent-capabilities'
 
 export type CommonAgentConfig = {
   description?: string
   display_name?: string
   mode?: 'primary' | 'subagent' | 'all'
   model?: string
+  permission?: Record<string, unknown>
   temperature?: number
   prompt?: string
   tools?: Record<string, boolean>
@@ -146,8 +151,74 @@ export function getAgentSummaries(config: CommonWorkspaceConfig): CommonAgentSum
     prompt: typeof agent?.prompt === 'string' ? agent.prompt : undefined,
     mode: typeof agent?.mode === 'string' ? agent.mode : undefined,
     isPrimary: defaultAgent === id || agent?.mode === 'primary',
-    capabilities: extractAgentCapabilitiesFromTools(agent?.tools)
+    capabilities: extractAgentCapabilitiesFromTools(agent?.tools, agent?.permission)
   }))
+}
+
+function isToolMap(value: unknown): value is Record<string, boolean> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function setAgentSkillIds(agent: CommonAgentConfig, skillIds: string[]): CommonAgentConfig {
+  const capabilities = extractAgentCapabilitiesFromTools(agent.tools, agent.permission)
+  const nextSkillIds = Array.from(new Set(skillIds)).sort((left, right) => left.localeCompare(right))
+  const nextTools = isToolMap(agent.tools) ? { ...agent.tools } : {}
+
+  if (nextSkillIds.length > 0) {
+    nextTools.skill = true
+  } else {
+    delete nextTools.skill
+  }
+
+  const nextPermission = buildAgentPermissionConfigFromCapabilities(
+    { ...capabilities, skillIds: nextSkillIds },
+    agent.permission,
+  )
+
+  const nextAgent: CommonAgentConfig = {
+    ...agent,
+    tools: Object.keys(nextTools).length > 0 ? nextTools : undefined,
+  }
+
+  if (nextPermission) {
+    nextAgent.permission = nextPermission
+  } else {
+    delete nextAgent.permission
+  }
+
+  return nextAgent
+}
+
+export function getAssignedAgentIdsForSkill(config: CommonWorkspaceConfig, skillId: string): string[] {
+  const agents = config.agent ?? {}
+
+  return Object.entries(agents)
+    .filter(([, agent]) => extractAgentCapabilitiesFromTools(agent?.tools, agent?.permission).skillIds.includes(skillId))
+    .map(([id]) => id)
+    .sort((left, right) => left.localeCompare(right))
+}
+
+export function setSkillAssignments(
+  config: CommonWorkspaceConfig,
+  skillId: string,
+  assignedAgentIds: string[],
+): CommonWorkspaceConfig {
+  const targetAgentIds = new Set(assignedAgentIds)
+  const agents = config.agent ?? {}
+
+  return {
+    ...config,
+    agent: Object.fromEntries(
+      Object.entries(agents).map(([id, agent]) => {
+        const capabilities = extractAgentCapabilitiesFromTools(agent?.tools, agent?.permission)
+        const nextSkillIds = targetAgentIds.has(id)
+          ? [...capabilities.skillIds, skillId]
+          : capabilities.skillIds.filter((entry) => entry !== skillId)
+
+        return [id, setAgentSkillIds(agent, nextSkillIds)]
+      })
+    ),
+  }
 }
 
 export function generateAgentId(displayName: string, existingIds: string[]): string {

--- a/apps/web/src/lib/workspace-panel-state.ts
+++ b/apps/web/src/lib/workspace-panel-state.ts
@@ -3,6 +3,10 @@ const LAYOUT_COOKIE_NAME_PREFIX = 'arche-workspace-layout'
 const LEFT_PANEL_COOKIE_NAME_PREFIX = 'arche-workspace-left-panel'
 const COOKIE_MAX_AGE_SECONDS = 31536000
 
+export const LEFT_PANEL_SECTION_IDS = ['chats', 'knowledge', 'experts', 'skills'] as const
+
+export type LeftPanelSectionId = (typeof LEFT_PANEL_SECTION_IDS)[number]
+
 export type StoredLayoutState = {
   leftWidth?: number
   rightWidth?: number
@@ -11,35 +15,76 @@ export type StoredLayoutState = {
   rightTab?: 'preview' | 'review'
 }
 
-export type StoredLeftPanelState = {
-  topRatio?: number
+type LegacyStoredLeftPanelState = {
+  bottomCollapsed?: boolean
+  midCollapsed?: boolean
   midRatio?: number
   topCollapsed?: boolean
-  midCollapsed?: boolean
-  bottomCollapsed?: boolean
+  topRatio?: number
 }
+
+export type StoredLeftPanelState = {
+  collapsed?: Partial<Record<LeftPanelSectionId, boolean>>
+  ratios?: Partial<Record<LeftPanelSectionId, number>>
+} & LegacyStoredLeftPanelState
 
 export type NormalizedLeftPanelState = {
-  topRatio: number
-  midRatio: number
-  topCollapsed: boolean
-  midCollapsed: boolean
-  bottomCollapsed: boolean
+  collapsed: Record<LeftPanelSectionId, boolean>
+  ratios: Record<LeftPanelSectionId, number>
 }
 
-const DEFAULT_TOP_RATIO = 3 / 8
-const DEFAULT_MID_RATIO = 3 / 8
+const DEFAULT_LEFT_PANEL_RATIOS: Record<LeftPanelSectionId, number> = {
+  chats: 0.32,
+  knowledge: 0.32,
+  experts: 0.18,
+  skills: 0.18,
+}
+
+const DEFAULT_LEFT_PANEL_COLLAPSED: Record<LeftPanelSectionId, boolean> = {
+  chats: false,
+  knowledge: false,
+  experts: false,
+  skills: false,
+}
 
 export const DEFAULT_LEFT_PANEL_STATE: NormalizedLeftPanelState = {
-  topRatio: DEFAULT_TOP_RATIO,
-  midRatio: DEFAULT_MID_RATIO,
-  topCollapsed: false,
-  midCollapsed: false,
-  bottomCollapsed: false,
+  ratios: DEFAULT_LEFT_PANEL_RATIOS,
+  collapsed: DEFAULT_LEFT_PANEL_COLLAPSED,
 }
 
 function isValidRatio(value: unknown): value is number {
   return typeof value === 'number' && isFinite(value) && value > 0 && value < 1
+}
+
+function isSectionId(value: string): value is LeftPanelSectionId {
+  return LEFT_PANEL_SECTION_IDS.includes(value as LeftPanelSectionId)
+}
+
+function normalizeRatios(partial: Partial<Record<LeftPanelSectionId, number>>): Record<LeftPanelSectionId, number> {
+  const rawRatios = Object.fromEntries(
+    LEFT_PANEL_SECTION_IDS.map((sectionId) => [
+      sectionId,
+      isValidRatio(partial[sectionId]) ? partial[sectionId] : DEFAULT_LEFT_PANEL_RATIOS[sectionId],
+    ])
+  ) as Record<LeftPanelSectionId, number>
+
+  const total = Object.values(rawRatios).reduce((sum, value) => sum + value, 0)
+  if (!isFinite(total) || total <= 0) {
+    return { ...DEFAULT_LEFT_PANEL_RATIOS }
+  }
+
+  return Object.fromEntries(
+    LEFT_PANEL_SECTION_IDS.map((sectionId) => [sectionId, rawRatios[sectionId] / total])
+  ) as Record<LeftPanelSectionId, number>
+}
+
+function normalizeCollapsed(partial: Partial<Record<LeftPanelSectionId, boolean>>): Record<LeftPanelSectionId, boolean> {
+  return Object.fromEntries(
+    LEFT_PANEL_SECTION_IDS.map((sectionId) => [
+      sectionId,
+      typeof partial[sectionId] === 'boolean' ? partial[sectionId] : DEFAULT_LEFT_PANEL_COLLAPSED[sectionId],
+    ])
+  ) as Record<LeftPanelSectionId, boolean>
 }
 
 function readLocalStorageValue(storageKey: string): string | null {
@@ -84,6 +129,27 @@ function writeCookieValue(cookieName: string, value: string): void {
   document.cookie = `${cookieName}=${encodeURIComponent(value)}; Path=/; Max-Age=${COOKIE_MAX_AGE_SECONDS}; SameSite=Lax${secure}`
 }
 
+function normalizeLegacyState(state: LegacyStoredLeftPanelState): NormalizedLeftPanelState {
+  const topRatio = isValidRatio(state.topRatio) ? state.topRatio : DEFAULT_LEFT_PANEL_RATIOS.chats
+  const midRatio = isValidRatio(state.midRatio) ? state.midRatio : DEFAULT_LEFT_PANEL_RATIOS.knowledge
+  const bottomShare = Math.max(0.1, 1 - topRatio - midRatio) / 2
+
+  return {
+    ratios: normalizeRatios({
+      chats: topRatio,
+      knowledge: midRatio,
+      experts: bottomShare,
+      skills: bottomShare,
+    }),
+    collapsed: normalizeCollapsed({
+      chats: typeof state.topCollapsed === 'boolean' ? state.topCollapsed : false,
+      knowledge: typeof state.midCollapsed === 'boolean' ? state.midCollapsed : false,
+      experts: typeof state.bottomCollapsed === 'boolean' ? state.bottomCollapsed : false,
+      skills: typeof state.bottomCollapsed === 'boolean' ? state.bottomCollapsed : false,
+    }),
+  }
+}
+
 export function getWorkspaceLayoutStorageKey(scope: string): string {
   return `${STORAGE_KEY_PREFIX}.${scope}.layout`
 }
@@ -121,13 +187,25 @@ export function normalizeLeftPanelState(
 ): NormalizedLeftPanelState {
   if (!state) return DEFAULT_LEFT_PANEL_STATE
 
-  return {
-    topRatio: isValidRatio(state.topRatio) ? state.topRatio : DEFAULT_TOP_RATIO,
-    midRatio: isValidRatio(state.midRatio) ? state.midRatio : DEFAULT_MID_RATIO,
-    topCollapsed: typeof state.topCollapsed === 'boolean' ? state.topCollapsed : false,
-    midCollapsed: typeof state.midCollapsed === 'boolean' ? state.midCollapsed : false,
-    bottomCollapsed: typeof state.bottomCollapsed === 'boolean' ? state.bottomCollapsed : false,
+  if ('ratios' in state || 'collapsed' in state) {
+    const ratios = state.ratios && typeof state.ratios === 'object' && !Array.isArray(state.ratios)
+      ? Object.fromEntries(
+          Object.entries(state.ratios).filter(([key]) => isSectionId(key))
+        ) as Partial<Record<LeftPanelSectionId, number>>
+      : {}
+    const collapsed = state.collapsed && typeof state.collapsed === 'object' && !Array.isArray(state.collapsed)
+      ? Object.fromEntries(
+          Object.entries(state.collapsed).filter(([key]) => isSectionId(key))
+        ) as Partial<Record<LeftPanelSectionId, boolean>>
+      : {}
+
+    return {
+      ratios: normalizeRatios(ratios),
+      collapsed: normalizeCollapsed(collapsed),
+    }
   }
+
+  return normalizeLegacyState(state)
 }
 
 export function readWorkspacePanelState<T>(

--- a/infra/workspace-image/entrypoint.sh
+++ b/infra/workspace-image/entrypoint.sh
@@ -36,6 +36,12 @@ if [ -f "/tmp/arche-user-data/AGENTS.md" ]; then
   cp /tmp/arche-user-data/AGENTS.md /workspace/AGENTS.md
 fi
 
+mkdir -p /home/workspace/.config/opencode
+rm -rf /home/workspace/.config/opencode/skills
+if [ -d "/tmp/arche-user-data/skills" ]; then
+  cp -R /tmp/arche-user-data/skills /home/workspace/.config/opencode/skills
+fi
+
 # Start workspace-agent if available
 # Logs go to stdout/stderr (captured by container runtime)
 if command -v workspace-agent >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add full skills management across web and desktop, including create, edit, import, export, and sidebar/settings navigation
- let admins assign skills to agents and map those assignments to OpenCode skill permissions and runtime tool access
- materialize skill bundles into the OpenCode runtime and include them in restart detection so workspace config stays in sync

## Verification
- pnpm test
- pnpm lint
- pnpm build
- podman build -f web/Containerfile -t arche-web:latest .
- podman build --build-arg OPENCODE_VERSION=\"$(cat /Users/inakitajes/Documents/_personal_github/arche.feat-add-skills-support/versions/opencode.version)\" -t arche-workspace:latest .