### PR TITLE
fix(workspace): stabilize provider auth sync in desktop

### DIFF
--- a/apps/web/src/app/api/u/[slug]/providers/[provider]/route.ts
+++ b/apps/web/src/app/api/u/[slug]/providers/[provider]/route.ts
@@ -7,6 +7,7 @@ import { replaceApiCredential } from '@/lib/providers/store'
 import { PROVIDERS, type ProviderId } from '@/lib/providers/types'
 import { withAuth } from '@/lib/runtime/with-auth'
 import { instanceService, providerService, userService } from '@/lib/services'
+import { decryptPassword } from '@/lib/spawner/crypto'
 
 export interface CreateProviderCredentialRequest {
   apiKey: string
@@ -44,10 +45,12 @@ async function syncProviderAccessBestEffort(slug: string, userId: string): Promi
       return false
     }
 
+    const password = decryptPassword(instance.serverPassword)
+
     const result = await syncProviderAccessForInstance({
       instance: {
         baseUrl: getInstanceUrl(slug),
-        authHeader: `Basic ${Buffer.from(`opencode:${instance.serverPassword}`).toString('base64')}`,
+        authHeader: `Basic ${Buffer.from(`opencode:${password}`).toString('base64')}`,
       },
       slug,
       userId,

--- a/apps/web/src/lib/runtime/__tests__/workspace-host-desktop.test.ts
+++ b/apps/web/src/lib/runtime/__tests__/workspace-host-desktop.test.ts
@@ -747,6 +747,29 @@ describe('desktopWorkspaceHost', () => {
     })
   })
 
+  it('retries provider sync before marking restart as required', async () => {
+    const opencodeChild = makeChildProcess()
+    const workspaceAgentChild = makeChildProcess()
+    mockSpawn.mockReturnValueOnce(opencodeChild).mockReturnValueOnce(workspaceAgentChild)
+    process.env.ARCHE_DESKTOP_START_INTERVAL_MS = '1'
+    process.env.ARCHE_DESKTOP_START_TIMEOUT_MS = '20'
+
+    const { desktopWorkspaceHost } = await import('../workspace-host-desktop')
+    const { syncProviderAccessForInstance } = await import('@/lib/opencode/providers')
+    const { providerService } = await import('@/lib/services')
+
+    vi.mocked(syncProviderAccessForInstance)
+      .mockResolvedValueOnce({ ok: false, error: 'sync_failed' })
+      .mockResolvedValueOnce({ ok: true })
+
+    const result = await desktopWorkspaceHost.start('local', 'user-1')
+
+    expect(result).toEqual({ ok: true, status: 'started' })
+    expect(syncProviderAccessForInstance).toHaveBeenCalledTimes(2)
+    expect(providerService.clearWorkspaceRestartRequired).toHaveBeenCalledWith('local')
+    expect(providerService.markWorkspaceRestartRequired).not.toHaveBeenCalled()
+  })
+
   it('stores encrypted credentials in DB on start', async () => {
     const opencodeChild = makeChildProcess()
     const workspaceAgentChild = makeChildProcess()

--- a/apps/web/src/lib/runtime/__tests__/workspace-host-desktop.test.ts
+++ b/apps/web/src/lib/runtime/__tests__/workspace-host-desktop.test.ts
@@ -770,6 +770,35 @@ describe('desktopWorkspaceHost', () => {
     expect(providerService.markWorkspaceRestartRequired).not.toHaveBeenCalled()
   })
 
+  it('marks restart required when provider sync retries are exhausted', async () => {
+    const opencodeChild = makeChildProcess()
+    const workspaceAgentChild = makeChildProcess()
+    mockSpawn.mockReturnValueOnce(opencodeChild).mockReturnValueOnce(workspaceAgentChild)
+    process.env.ARCHE_DESKTOP_START_INTERVAL_MS = '1'
+    process.env.ARCHE_DESKTOP_START_TIMEOUT_MS = '5'
+
+    const { desktopWorkspaceHost } = await import('../workspace-host-desktop')
+    const { syncProviderAccessForInstance } = await import('@/lib/opencode/providers')
+    const { providerService } = await import('@/lib/services')
+
+    const syncMock = vi.mocked(syncProviderAccessForInstance)
+    syncMock.mockResolvedValue({ ok: false, error: 'sync_failed' })
+
+    try {
+      const result = await desktopWorkspaceHost.start('local', 'user-1')
+
+      expect(result).toEqual({ ok: true, status: 'started' })
+      expect(syncMock.mock.calls.length).toBeGreaterThanOrEqual(1)
+      expect(providerService.markWorkspaceRestartRequired).toHaveBeenCalledWith('local')
+      expect(providerService.clearWorkspaceRestartRequired).not.toHaveBeenCalled()
+    } finally {
+      // Reset to the default resolved value so subsequent tests are not
+      // affected by the persistent failure mock (beforeEach uses
+      // clearAllMocks which does not restore mock implementations).
+      syncMock.mockResolvedValue({ ok: true })
+    }
+  })
+
   it('stores encrypted credentials in DB on start', async () => {
     const opencodeChild = makeChildProcess()
     const workspaceAgentChild = makeChildProcess()

--- a/apps/web/src/lib/runtime/workspace-host-desktop.ts
+++ b/apps/web/src/lib/runtime/workspace-host-desktop.ts
@@ -101,6 +101,43 @@ function logDesktopRuntime(
   console.log(`[desktop-runtime] ${JSON.stringify(payload)}`)
 }
 
+async function syncProvidersWithRetry(input: {
+  authHeader: string
+  intervalMs: number
+  port: number
+  slug: string
+  timeoutMs: number
+  userId: string
+}): Promise<Awaited<ReturnType<typeof syncProviderAccessForInstance>>> {
+  const deadline = Date.now() + input.timeoutMs
+  let attempt = 1
+
+  while (true) {
+    const result = await syncProviderAccessForInstance({
+      instance: {
+        baseUrl: `http://${LOOPBACK_HOST}:${input.port}`,
+        authHeader: input.authHeader,
+      },
+      slug: input.slug,
+      userId: input.userId,
+    })
+
+    if (result.ok || Date.now() >= deadline) {
+      return result
+    }
+
+    logDesktopRuntime(
+      input.slug,
+      'providers',
+      'sync_retry',
+      `attempt=${String(attempt)} error=${result.error}`,
+    )
+    attempt += 1
+
+    await new Promise((resolve) => setTimeout(resolve, input.intervalMs))
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Port env sync
 // ---------------------------------------------------------------------------
@@ -449,12 +486,12 @@ export const desktopWorkspaceHost: WorkspaceHost = {
       }
 
       const syncUserId = artifacts.owner?.id ?? userId
-      const syncResult = await syncProviderAccessForInstance({
-        instance: {
-          baseUrl: `http://${LOOPBACK_HOST}:${port}`,
-          authHeader,
-        },
+      const syncResult = await syncProvidersWithRetry({
+        authHeader,
+        intervalMs,
+        port,
         slug,
+        timeoutMs,
         userId: syncUserId,
       })
       if (!syncResult.ok) {

--- a/apps/web/tests/providers-routes.test.ts
+++ b/apps/web/tests/providers-routes.test.ts
@@ -17,6 +17,13 @@ vi.mock('@/lib/opencode/client', () => ({
   getInstanceUrl: (...args: unknown[]) => mockGetInstanceUrl(...args),
 }))
 
+const mockDecryptPassword = vi.fn((value: string) => value.replace(/^enc:/, ''))
+const mockEncryptPassword = vi.fn((value: string) => `enc:${value}`)
+vi.mock('@/lib/spawner/crypto', () => ({
+  decryptPassword: (...args: unknown[]) => mockDecryptPassword(...args),
+  encryptPassword: (...args: unknown[]) => mockEncryptPassword(...args),
+}))
+
 const mockFindUnique = vi.fn()
 const mockFindFirst = vi.fn()
 const mockFindMany = vi.fn()
@@ -101,6 +108,8 @@ describe('GET /api/u/[slug]/providers', () => {
     vi.clearAllMocks()
     vi.resetModules()
     mockSyncProviderAccessForInstance.mockResolvedValue({ ok: true })
+    mockDecryptPassword.mockImplementation((value: string) => value.replace(/^enc:/, ''))
+    mockEncryptPassword.mockImplementation((value: string) => `enc:${value}`)
     mockTransaction.mockImplementation(async (callback: (tx: ReturnType<typeof createProviderTransactionClient>) => unknown) =>
       callback(createProviderTransactionClient())
     )
@@ -153,6 +162,8 @@ describe('POST /api/u/[slug]/providers/[provider]', () => {
     vi.clearAllMocks()
     vi.resetModules()
     mockSyncProviderAccessForInstance.mockResolvedValue({ ok: true })
+    mockDecryptPassword.mockImplementation((value: string) => value.replace(/^enc:/, ''))
+    mockEncryptPassword.mockImplementation((value: string) => `enc:${value}`)
     mockTransaction.mockImplementation(async (callback: (tx: ReturnType<typeof createProviderTransactionClient>) => unknown) =>
       callback(createProviderTransactionClient())
     )
@@ -212,7 +223,7 @@ describe('POST /api/u/[slug]/providers/[provider]', () => {
   it('creates new credential and audits creation', async () => {
     mockGetAuthenticatedUser.mockResolvedValue(session('admin', 'ADMIN'))
     mockFindUnique.mockResolvedValueOnce({ id: 'user-1' })
-    mockFindUnique.mockResolvedValueOnce({ serverPassword: 'secret', status: 'running' })
+    mockFindUnique.mockResolvedValueOnce({ serverPassword: 'enc:secret', status: 'running' })
     mockFindFirst.mockResolvedValue({ version: 2 })
     mockUpdateMany.mockResolvedValue({ count: 1 })
     mockCreate.mockResolvedValue({
@@ -256,7 +267,7 @@ describe('POST /api/u/[slug]/providers/[provider]', () => {
   it('returns restartRequired when live provider sync fails', async () => {
     mockGetAuthenticatedUser.mockResolvedValue(session('admin', 'ADMIN'))
     mockFindUnique.mockResolvedValueOnce({ id: 'user-1' })
-    mockFindUnique.mockResolvedValueOnce({ serverPassword: 'secret', status: 'running' })
+    mockFindUnique.mockResolvedValueOnce({ serverPassword: 'enc:secret', status: 'running' })
     mockFindFirst.mockResolvedValue({ version: 0 })
     mockUpdateMany.mockResolvedValue({ count: 1 })
     mockCreate.mockResolvedValue({
@@ -299,7 +310,7 @@ describe('DELETE /api/u/[slug]/providers/[provider]', () => {
   it('disables provider credential and syncs running instance', async () => {
     mockGetAuthenticatedUser.mockResolvedValue(session('admin', 'ADMIN'))
     mockFindUnique.mockResolvedValueOnce({ id: 'user-1' })
-    mockFindUnique.mockResolvedValueOnce({ serverPassword: 'secret', status: 'running' })
+    mockFindUnique.mockResolvedValueOnce({ serverPassword: 'enc:secret', status: 'running' })
     mockUpdateMany.mockResolvedValue({ count: 1 })
 
     const { status, body } = await callDeleteProvider('alice', 'openai')


### PR DESCRIPTION
## Summary
- retry desktop provider sync during workspace startup so transient OpenCode readiness does not leave provider changes stuck as pending after restart
- decrypt stored instance passwords before live provider sync so running workspaces can refresh provider auth without forcing a restart
- add regression coverage for the desktop retry path and the encrypted-password provider route path

## Verification
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `podman compose -f \"infra/compose/compose.yaml\" build` (`No services to build` is expected for this compose file)
- `podman build --build-arg GIT_SHA=\"local-check\" -t arche-web:verify -f \"apps/web/Containerfile\" apps`
- `podman build --build-arg OPENCODE_VERSION=\"$(tr -d '[:space:]' < \"versions/opencode.version\")\" -t arche-workspace:verify -f \"infra/workspace-image/Containerfile\" infra/workspace-image`