### PR TITLE
fix(workspace): resolve desktop attachment paths locally

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -329,10 +329,10 @@ function createWindow(): void {
   const isLauncher = currentVault === null
 
   mainWindow = new BrowserWindow({
-    width: isLauncher ? 720 : 1280,
-    height: isLauncher ? 560 : 800,
-    minWidth: isLauncher ? 600 : 800,
-    minHeight: isLauncher ? 480 : 600,
+    width: isLauncher ? 680 : 1280,
+    height: isLauncher ? 680 : 800,
+    minWidth: isLauncher ? 560 : 800,
+    minHeight: isLauncher ? 560 : 600,
     title: getCurrentVaultTitle(),
     backgroundColor: '#f7f4ef',
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : undefined,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -326,11 +326,13 @@ function installTokenHeaderInjection(): void {
 }
 
 function createWindow(): void {
+  const isLauncher = currentVault === null
+
   mainWindow = new BrowserWindow({
-    width: 1280,
-    height: 800,
-    minWidth: 800,
-    minHeight: 600,
+    width: isLauncher ? 720 : 1280,
+    height: isLauncher ? 560 : 800,
+    minWidth: isLauncher ? 600 : 800,
+    minHeight: isLauncher ? 480 : 600,
     title: getCurrentVaultTitle(),
     backgroundColor: '#f7f4ef',
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : undefined,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -24,6 +24,7 @@ import {
   getDesktopRuntimeDataDir,
   getDesktopSecretsDir,
   getDesktopUserDataDir,
+  getDesktopWorkspaceAttachmentsDir,
   getDesktopWorkspaceDir,
 } from './vault-layout'
 import { LOCAL_DESKTOP_USER_SLUG } from './vault-layout-constants'
@@ -473,6 +474,24 @@ function quitLauncherProcess(): DesktopApiResult {
   return { ok: true }
 }
 
+async function revealAttachmentsDirectory(): Promise<DesktopApiResult> {
+  if (!currentVault) {
+    return { ok: false, error: 'vault_not_open' }
+  }
+
+  const attachmentsDir = getDesktopWorkspaceAttachmentsDir(currentVault.path)
+  if (!existsSync(attachmentsDir)) {
+    mkdirSync(attachmentsDir, { recursive: true })
+  }
+
+  const error = await shell.openPath(attachmentsDir)
+  if (error) {
+    return { ok: false, error: 'reveal_attachments_failed' }
+  }
+
+  return { ok: true }
+}
+
 async function pickDirectory(options: {
   title: string
   defaultPath?: string | null
@@ -530,6 +549,7 @@ function registerDesktopIpcHandlers(): void {
   ipcMain.handle('desktop:open-vault', async (_event, vaultPath: string) => launchVaultProcess(vaultPath))
   ipcMain.handle('desktop:open-vault-launcher', async () => openVaultLauncherProcess())
   ipcMain.handle('desktop:quit-launcher-process', async () => quitLauncherProcess())
+  ipcMain.handle('desktop:reveal-attachments-directory', async () => revealAttachmentsDirectory())
 }
 
 function resolveStartupVault(): DesktopVault | null {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -22,5 +22,7 @@ contextBridge.exposeInMainWorld('arche', {
       ipcRenderer.invoke('desktop:pick-vault-parent-directory') as Promise<string | null>,
     quitLauncherProcess: () =>
       ipcRenderer.invoke('desktop:quit-launcher-process') as Promise<DesktopApiResult>,
+    revealAttachmentsDirectory: () =>
+      ipcRenderer.invoke('desktop:reveal-attachments-directory') as Promise<DesktopApiResult>,
   },
 })

--- a/apps/desktop/src/vault-layout.ts
+++ b/apps/desktop/src/vault-layout.ts
@@ -33,6 +33,10 @@ export function getDesktopWorkspaceDir(vaultPath: string): string {
   return join(vaultPath, DESKTOP_WORKSPACE_DIR_NAME)
 }
 
+export function getDesktopWorkspaceAttachmentsDir(vaultPath: string): string {
+  return join(getDesktopWorkspaceDir(vaultPath), '.arche', 'attachments')
+}
+
 export function getDesktopSecretsDir(vaultPath: string): string {
   return join(vaultPath, DESKTOP_SECRETS_DIR_NAME)
 }

--- a/apps/desktop/tests/vault-layout.test.js
+++ b/apps/desktop/tests/vault-layout.test.js
@@ -11,6 +11,7 @@ const {
   getDesktopRuntimeDir,
   getDesktopSecretsDir,
   getDesktopUsersDir,
+  getDesktopWorkspaceAttachmentsDir,
 } = require('../dist/vault-layout.js')
 
 function withTempDir(run) {
@@ -32,5 +33,6 @@ test('returns hidden desktop vault paths', () => {
     assert.equal(getDesktopRuntimeDir(vaultPath), join(vaultPath, '.runtime'))
     assert.equal(getDesktopSecretsDir(vaultPath), join(vaultPath, '.secrets'))
     assert.equal(getDesktopUsersDir(vaultPath), join(vaultPath, '.users'))
+    assert.equal(getDesktopWorkspaceAttachmentsDir(vaultPath), join(vaultPath, 'workspace', '.arche', 'attachments'))
   })
 })

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/status-reader.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/status-reader.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createUpstreamSessionStatusReader } from '@/app/api/w/[slug]/chat/stream/status-reader'
+
+describe('createUpstreamSessionStatusReader', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('reuses a recent upstream status within the cache window', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          'session-1': { type: 'busy' },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const readStatus = createUpstreamSessionStatusReader({
+      baseUrl: 'http://127.0.0.1:4096',
+      authHeader: 'Basic token',
+      sessionId: 'session-1',
+    })
+
+    await expect(readStatus()).resolves.toBe('busy')
+    await vi.advanceTimersByTimeAsync(1_500)
+    await expect(readStatus()).resolves.toBe('busy')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs and returns null when the upstream status request fails', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('socket hang up'))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const readStatus = createUpstreamSessionStatusReader({
+      baseUrl: 'http://127.0.0.1:4096',
+      authHeader: 'Basic token',
+      sessionId: 'session-1',
+    })
+
+    await expect(readStatus()).resolves.toBeNull()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[chat-stream] Failed to read upstream session status',
+      expect.objectContaining({
+        baseUrl: 'http://127.0.0.1:4096',
+        sessionId: 'session-1',
+        error: 'socket hang up',
+      }),
+    )
+  })
+})

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/watchdog.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/watchdog.test.ts
@@ -47,17 +47,50 @@ describe('chat stream watchdog helpers', () => {
 
   describe('getSilentStreamOutcome', () => {
     it('keeps waiting while upstream remains busy', () => {
-      expect(getSilentStreamOutcome('busy')).toBe('keep_waiting')
-      expect(getSilentStreamOutcome('retry')).toBe('keep_waiting')
+      expect(getSilentStreamOutcome({
+        upstreamStatus: 'busy',
+        silentForMs: 19_999,
+        relevantEventTimeoutMs: 20_000,
+      })).toBe('keep_waiting')
+      expect(getSilentStreamOutcome({
+        upstreamStatus: 'retry',
+        silentForMs: 35_999,
+        relevantEventTimeoutMs: 12_000,
+      })).toBe('keep_waiting')
+    })
+
+    it('times out after extended silence even when upstream stays busy', () => {
+      expect(getSilentStreamOutcome({
+        upstreamStatus: 'busy',
+        silentForMs: 60_000,
+        relevantEventTimeoutMs: 20_000,
+      })).toBe('stream_timeout')
+      expect(getSilentStreamOutcome({
+        upstreamStatus: 'retry',
+        silentForMs: 36_000,
+        relevantEventTimeoutMs: 12_000,
+      })).toBe('stream_timeout')
     })
 
     it('finalizes when upstream has idled', () => {
-      expect(getSilentStreamOutcome('idle')).toBe('finalize_idle')
+      expect(getSilentStreamOutcome({
+        upstreamStatus: 'idle',
+        silentForMs: 20_000,
+        relevantEventTimeoutMs: 20_000,
+      })).toBe('finalize_idle')
     })
 
     it('falls back to stream timeout for unknown or missing upstream status', () => {
-      expect(getSilentStreamOutcome(null)).toBe('stream_timeout')
-      expect(getSilentStreamOutcome('complete')).toBe('stream_timeout')
+      expect(getSilentStreamOutcome({
+        upstreamStatus: null,
+        silentForMs: 20_000,
+        relevantEventTimeoutMs: 20_000,
+      })).toBe('stream_timeout')
+      expect(getSilentStreamOutcome({
+        upstreamStatus: 'complete',
+        silentForMs: 20_000,
+        relevantEventTimeoutMs: 20_000,
+      })).toBe('stream_timeout')
     })
   })
 })

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/watchdog.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/watchdog.test.ts
@@ -4,12 +4,22 @@ import { getIdleFinalizationOutcome, getSilentStreamOutcome } from '@/app/api/w/
 
 describe('chat stream watchdog helpers', () => {
   describe('getIdleFinalizationOutcome', () => {
-    it('returns complete for resume streams', () => {
+    it('returns resume_incomplete for silent resume streams', () => {
       expect(
         getIdleFinalizationOutcome({
           resume: true,
           assistantMessageSeen: false,
           assistantPartSeen: false,
+        }),
+      ).toBe('resume_incomplete')
+    })
+
+    it('returns complete for resume streams once assistant parts arrive', () => {
+      expect(
+        getIdleFinalizationOutcome({
+          resume: true,
+          assistantMessageSeen: true,
+          assistantPartSeen: true,
         }),
       ).toBe('complete')
     })

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/watchdog.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/watchdog.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { getIdleFinalizationOutcome, getSilentStreamOutcome } from '@/app/api/w/[slug]/chat/stream/watchdog'
+
+describe('chat stream watchdog helpers', () => {
+  describe('getIdleFinalizationOutcome', () => {
+    it('returns complete for resume streams', () => {
+      expect(
+        getIdleFinalizationOutcome({
+          resume: true,
+          assistantMessageSeen: false,
+          assistantPartSeen: false,
+        }),
+      ).toBe('complete')
+    })
+
+    it('requires an assistant message for send streams', () => {
+      expect(
+        getIdleFinalizationOutcome({
+          resume: false,
+          assistantMessageSeen: false,
+          assistantPartSeen: false,
+        }),
+      ).toBe('stream_no_assistant_message')
+    })
+
+    it('requires an assistant part once the message exists', () => {
+      expect(
+        getIdleFinalizationOutcome({
+          resume: false,
+          assistantMessageSeen: true,
+          assistantPartSeen: false,
+        }),
+      ).toBe('stream_incomplete')
+    })
+
+    it('completes when send streams have assistant parts', () => {
+      expect(
+        getIdleFinalizationOutcome({
+          resume: false,
+          assistantMessageSeen: true,
+          assistantPartSeen: true,
+        }),
+      ).toBe('complete')
+    })
+  })
+
+  describe('getSilentStreamOutcome', () => {
+    it('keeps waiting while upstream remains busy', () => {
+      expect(getSilentStreamOutcome('busy')).toBe('keep_waiting')
+      expect(getSilentStreamOutcome('retry')).toBe('keep_waiting')
+    })
+
+    it('finalizes when upstream has idled', () => {
+      expect(getSilentStreamOutcome('idle')).toBe('finalize_idle')
+    })
+
+    it('falls back to stream timeout for unknown or missing upstream status', () => {
+      expect(getSilentStreamOutcome(null)).toBe('stream_timeout')
+      expect(getSilentStreamOutcome('complete')).toBe('stream_timeout')
+    })
+  })
+})

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -1,8 +1,13 @@
+import { join } from 'path'
+import { pathToFileURL } from 'url'
+
 import { NextRequest, NextResponse } from 'next/server'
 
 import { extractPdfText, isPdfMime } from '@/lib/attachments/pdf-text-extractor'
 import { getInstanceUrl } from '@/lib/opencode/client'
 import { normalizeProviderId, resolveRuntimeProviderId } from '@/lib/providers/catalog'
+import { DESKTOP_WORKSPACE_DIR_NAME } from '@/lib/runtime/desktop/vault-layout-constants'
+import { isDesktop } from '@/lib/runtime/mode'
 import { withAuth } from '@/lib/runtime/with-auth'
 import { instanceService } from '@/lib/services'
 import { INITIAL_SSE_PARSE_STATE, parseSseChunk } from '@/lib/sse-parser'
@@ -126,6 +131,14 @@ async function readWorkspaceImageAttachment(
 
 function toWorkspaceFileUrl(path: string): string {
   const normalized = normalizeAttachmentPath(path)
+
+  if (isDesktop()) {
+    const vaultRoot = process.env.ARCHE_DATA_DIR?.trim()
+    if (vaultRoot) {
+      return pathToFileURL(join(vaultRoot, DESKTOP_WORKSPACE_DIR_NAME, ...normalized.split('/'))).toString()
+    }
+  }
+
   const encodedPath = normalized
     .split('/')
     .map((segment) => encodeURIComponent(segment))
@@ -133,10 +146,15 @@ function toWorkspaceFileUrl(path: string): string {
   return `file:///workspace/${encodedPath}`
 }
 
+function toAttachmentPromptPath(path: string): string {
+  const normalized = normalizeAttachmentPath(path)
+  return isDesktop() ? normalized : `/workspace/${normalized}`
+}
+
 function toAttachmentHintText(paths: string[]): string {
   const lines = [
     'Attached workspace files:',
-    ...paths.map((path) => `- /workspace/${path}`),
+    ...paths.map((path) => `- ${toAttachmentPromptPath(path)}`),
     'If direct file parsing is unavailable, inspect these paths with available tools.',
   ]
   return lines.join('\n')
@@ -148,7 +166,7 @@ function toPdfExtractedTextPart(path: string, text: string, truncated: boolean):
     : ''
 
   return [
-    `Extracted text from attached PDF: /workspace/${path}`,
+    `Extracted text from attached PDF: ${toAttachmentPromptPath(path)}`,
     text,
     truncationNote,
   ]
@@ -158,14 +176,14 @@ function toPdfExtractedTextPart(path: string, text: string, truncated: boolean):
 
 function toPdfExtractionFailureText(path: string): string {
   return [
-    `Attached PDF could not be extracted automatically: /workspace/${path}`,
+    `Attached PDF could not be extracted automatically: ${toAttachmentPromptPath(path)}`,
     'Continue by using available tools on this path, or ask the user for an OCR-friendly/text PDF if the file is scanned.',
   ].join('\n')
 }
 
 function toSpreadsheetToolHintText(path: string): string {
   return [
-    `Attached spreadsheet file: /workspace/${path}`,
+    `Attached spreadsheet file: ${toAttachmentPromptPath(path)}`,
     'You must use spreadsheet_inspect first to detect sheets and columns, then use spreadsheet_sample/spreadsheet_query/spreadsheet_stats for focused analysis and calculations.',
   ].join('\n')
 }

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -3,6 +3,7 @@ import { pathToFileURL } from 'url'
 
 import { NextRequest, NextResponse } from 'next/server'
 
+import { getIdleFinalizationOutcome, getSilentStreamOutcome } from '@/app/api/w/[slug]/chat/stream/watchdog'
 import { extractPdfText, isPdfMime } from '@/lib/attachments/pdf-text-extractor'
 import { getInstanceUrl } from '@/lib/opencode/client'
 import { normalizeProviderId, resolveRuntimeProviderId } from '@/lib/providers/catalog'
@@ -572,16 +573,15 @@ export const POST = withAuth(
         const finalizeFromIdle = () => {
           if (aborted) return
 
-          if (!resume && !assistantMessageSeen) {
-            emitStatus('error', undefined, 'stream_no_assistant_message')
-            sendEvent('error', { error: 'stream_no_assistant_message' })
-            aborted = true
-            return
-          }
+          const outcome = getIdleFinalizationOutcome({
+            resume,
+            assistantMessageSeen,
+            assistantPartSeen,
+          })
 
-          if (!resume && !assistantPartSeen) {
-            emitStatus('error', undefined, 'stream_incomplete')
-            sendEvent('error', { error: 'stream_incomplete' })
+          if (outcome !== 'complete') {
+            emitStatus('error', undefined, outcome)
+            sendEvent('error', { error: outcome })
             aborted = true
             return
           }
@@ -605,14 +605,16 @@ export const POST = withAuth(
 
             if (readResult.type === 'tick') {
               if (Date.now() - lastRelevantEventAt > relevantEventTimeoutMs) {
-                const upstreamStatus = await readUpstreamSessionStatus(baseUrl, authHeader, sessionId)
+                const watchdogOutcome = getSilentStreamOutcome(
+                  await readUpstreamSessionStatus(baseUrl, authHeader, sessionId),
+                )
 
-                if (upstreamStatus === 'busy' || upstreamStatus === 'retry') {
+                if (watchdogOutcome === 'keep_waiting') {
                   markRelevantEvent()
                   continue
                 }
 
-                if (upstreamStatus === 'idle') {
+                if (watchdogOutcome === 'finalize_idle') {
                   markRelevantEvent()
                   finalizeFromIdle()
                   continue

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -554,11 +554,18 @@ export const POST = withAuth(
         let assistantMessageSeen = typeof assistantMessageId === 'string'
         let assistantPartSeen = false
         let lastRelevantEventAt = Date.now()
+        let lastStreamActivityAt = lastRelevantEventAt
         const relevantEventTimeoutMs = resume
           ? RESUME_STREAM_RELEVANT_EVENT_TIMEOUT_MS
           : SEND_STREAM_RELEVANT_EVENT_TIMEOUT_MS
 
         const markRelevantEvent = () => {
+          const now = Date.now()
+          lastRelevantEventAt = now
+          lastStreamActivityAt = now
+        }
+
+        const markWatchdogCheck = () => {
           lastRelevantEventAt = Date.now()
         }
 
@@ -606,16 +613,20 @@ export const POST = withAuth(
             if (readResult.type === 'tick') {
               if (Date.now() - lastRelevantEventAt > relevantEventTimeoutMs) {
                 const watchdogOutcome = getSilentStreamOutcome(
-                  await readUpstreamSessionStatus(baseUrl, authHeader, sessionId),
+                  {
+                    upstreamStatus: await readUpstreamSessionStatus(baseUrl, authHeader, sessionId),
+                    silentForMs: Date.now() - lastStreamActivityAt,
+                    relevantEventTimeoutMs,
+                  },
                 )
 
                 if (watchdogOutcome === 'keep_waiting') {
-                  markRelevantEvent()
+                  markWatchdogCheck()
                   continue
                 }
 
                 if (watchdogOutcome === 'finalize_idle') {
-                  markRelevantEvent()
+                  markWatchdogCheck()
                   finalizeFromIdle()
                   continue
                 }

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -42,6 +42,8 @@ type WorkspaceAgentReadResponse = {
   error?: string
 }
 
+type UpstreamSessionStatusResponse = Record<string, { type?: string } | undefined>
+
 const MAX_PDF_BYTES_FOR_EXTRACTION = 8 * 1024 * 1024
 const MAX_IMAGE_BYTES_FOR_INLINE = 8 * 1024 * 1024
 const MAX_PDF_TEXT_CHARS = 24_000
@@ -204,6 +206,34 @@ function decodeWorkspaceAgentFileContent(data: WorkspaceAgentReadResponse): Buff
   }
 
   return null
+}
+
+async function readUpstreamSessionStatus(
+  baseUrl: string,
+  authHeader: string,
+  sessionId: string,
+): Promise<string | null> {
+  try {
+    const response = await fetch(`${baseUrl}/session/status`, {
+      method: 'GET',
+      headers: {
+        Authorization: authHeader,
+        Accept: 'application/json',
+      },
+      cache: 'no-store',
+      signal: AbortSignal.timeout(3_000),
+    })
+
+    if (!response.ok) {
+      return null
+    }
+
+    const data = await response.json().catch(() => null) as UpstreamSessionStatusResponse | null
+    const status = data?.[sessionId]
+    return typeof status?.type === 'string' ? status.type : null
+  } catch {
+    return null
+  }
 }
 
 async function readWorkspaceAttachment(
@@ -575,6 +605,19 @@ export const POST = withAuth(
 
             if (readResult.type === 'tick') {
               if (Date.now() - lastRelevantEventAt > relevantEventTimeoutMs) {
+                const upstreamStatus = await readUpstreamSessionStatus(baseUrl, authHeader, sessionId)
+
+                if (upstreamStatus === 'busy' || upstreamStatus === 'retry') {
+                  markRelevantEvent()
+                  continue
+                }
+
+                if (upstreamStatus === 'idle') {
+                  markRelevantEvent()
+                  finalizeFromIdle()
+                  continue
+                }
+
                 emitStatus('error', undefined, 'stream_timeout')
                 sendEvent('error', { error: 'stream_timeout' })
                 aborted = true

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from 'url'
 import { NextRequest, NextResponse } from 'next/server'
 
 import { getIdleFinalizationOutcome, getSilentStreamOutcome } from '@/app/api/w/[slug]/chat/stream/watchdog'
+import { createUpstreamSessionStatusReader } from '@/app/api/w/[slug]/chat/stream/status-reader'
 import { extractPdfText, isPdfMime } from '@/lib/attachments/pdf-text-extractor'
 import { getInstanceUrl } from '@/lib/opencode/client'
 import { normalizeProviderId, resolveRuntimeProviderId } from '@/lib/providers/catalog'
@@ -42,8 +43,6 @@ type WorkspaceAgentReadResponse = {
   encoding?: 'utf-8' | 'base64'
   error?: string
 }
-
-type UpstreamSessionStatusResponse = Record<string, { type?: string } | undefined>
 
 const MAX_PDF_BYTES_FOR_EXTRACTION = 8 * 1024 * 1024
 const MAX_IMAGE_BYTES_FOR_INLINE = 8 * 1024 * 1024
@@ -209,34 +208,6 @@ function decodeWorkspaceAgentFileContent(data: WorkspaceAgentReadResponse): Buff
   return null
 }
 
-async function readUpstreamSessionStatus(
-  baseUrl: string,
-  authHeader: string,
-  sessionId: string,
-): Promise<string | null> {
-  try {
-    const response = await fetch(`${baseUrl}/session/status`, {
-      method: 'GET',
-      headers: {
-        Authorization: authHeader,
-        Accept: 'application/json',
-      },
-      cache: 'no-store',
-      signal: AbortSignal.timeout(3_000),
-    })
-
-    if (!response.ok) {
-      return null
-    }
-
-    const data = await response.json().catch(() => null) as UpstreamSessionStatusResponse | null
-    const status = data?.[sessionId]
-    return typeof status?.type === 'string' ? status.type : null
-  } catch {
-    return null
-  }
-}
-
 async function readWorkspaceAttachment(
   agent: { baseUrl: string; authHeader: string },
   path: string,
@@ -345,11 +316,16 @@ export const POST = withAuth(
         }
       }
 
-      try {
-        sendEvent('status', { status: 'connecting' })
+        try {
+          sendEvent('status', { status: 'connecting' })
+          const readUpstreamSessionStatus = createUpstreamSessionStatusReader({
+            baseUrl,
+            authHeader,
+            sessionId,
+          })
 
-        // Subscribe first so we don't miss fast session events.
-        const eventsUrl = `${baseUrl}/event`
+          // Subscribe first so we don't miss fast session events.
+          const eventsUrl = `${baseUrl}/event`
 
         const eventsResponse = await fetch(eventsUrl, {
           method: 'GET',
@@ -614,7 +590,7 @@ export const POST = withAuth(
               if (Date.now() - lastRelevantEventAt > relevantEventTimeoutMs) {
                 const watchdogOutcome = getSilentStreamOutcome(
                   {
-                    upstreamStatus: await readUpstreamSessionStatus(baseUrl, authHeader, sessionId),
+                    upstreamStatus: await readUpstreamSessionStatus(),
                     silentForMs: Date.now() - lastStreamActivityAt,
                     relevantEventTimeoutMs,
                   },

--- a/apps/web/src/app/api/w/[slug]/chat/stream/status-reader.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/status-reader.ts
@@ -1,0 +1,65 @@
+type UpstreamSessionStatusEntry = {
+  type?: string
+}
+
+type UpstreamSessionStatusResponse = Record<string, UpstreamSessionStatusEntry | undefined>
+
+type UpstreamSessionStatusReaderOptions = {
+  baseUrl: string
+  authHeader: string
+  sessionId: string
+}
+
+const UPSTREAM_STATUS_CACHE_WINDOW_MS = 2_000
+const UPSTREAM_STATUS_TIMEOUT_MS = 3_000
+
+export function createUpstreamSessionStatusReader({
+  baseUrl,
+  authHeader,
+  sessionId,
+}: UpstreamSessionStatusReaderOptions): () => Promise<string | null> {
+  let cache: { expiresAt: number; status: string | null } | null = null
+
+  return async () => {
+    const now = Date.now()
+    if (cache && now < cache.expiresAt) {
+      return cache.status
+    }
+
+    try {
+      const response = await fetch(`${baseUrl}/session/status`, {
+        method: 'GET',
+        headers: {
+          Authorization: authHeader,
+          Accept: 'application/json',
+        },
+        cache: 'no-store',
+        signal: AbortSignal.timeout(UPSTREAM_STATUS_TIMEOUT_MS),
+      })
+
+      if (!response.ok) {
+        console.warn('[chat-stream] Upstream session status request failed', {
+          baseUrl,
+          sessionId,
+          status: response.status,
+        })
+        cache = { expiresAt: now + UPSTREAM_STATUS_CACHE_WINDOW_MS, status: null }
+        return null
+      }
+
+      const data = await response.json().catch(() => null) as UpstreamSessionStatusResponse | null
+      const sessionStatus = data?.[sessionId]
+      const status = typeof sessionStatus?.type === 'string' ? sessionStatus.type : null
+      cache = { expiresAt: now + UPSTREAM_STATUS_CACHE_WINDOW_MS, status }
+      return status
+    } catch (error) {
+      console.warn('[chat-stream] Failed to read upstream session status', {
+        baseUrl,
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      cache = { expiresAt: now + UPSTREAM_STATUS_CACHE_WINDOW_MS, status: null }
+      return null
+    }
+  }
+}

--- a/apps/web/src/app/api/w/[slug]/chat/stream/watchdog.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/watchdog.ts
@@ -1,4 +1,8 @@
-export type IdleFinalizationOutcome = 'complete' | 'stream_incomplete' | 'stream_no_assistant_message'
+export type IdleFinalizationOutcome =
+  | 'complete'
+  | 'resume_incomplete'
+  | 'stream_incomplete'
+  | 'stream_no_assistant_message'
 
 export type SilentStreamOutcome = 'finalize_idle' | 'keep_waiting' | 'stream_timeout'
 
@@ -22,7 +26,7 @@ export function getIdleFinalizationOutcome({
   assistantPartSeen,
 }: IdleFinalizationInput): IdleFinalizationOutcome {
   if (resume) {
-    return 'complete'
+    return assistantPartSeen ? 'complete' : 'resume_incomplete'
   }
 
   if (!assistantMessageSeen) {

--- a/apps/web/src/app/api/w/[slug]/chat/stream/watchdog.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/watchdog.ts
@@ -1,0 +1,41 @@
+export type IdleFinalizationOutcome = 'complete' | 'stream_incomplete' | 'stream_no_assistant_message'
+
+export type SilentStreamOutcome = 'finalize_idle' | 'keep_waiting' | 'stream_timeout'
+
+type IdleFinalizationInput = {
+  resume: boolean
+  assistantMessageSeen: boolean
+  assistantPartSeen: boolean
+}
+
+export function getIdleFinalizationOutcome({
+  resume,
+  assistantMessageSeen,
+  assistantPartSeen,
+}: IdleFinalizationInput): IdleFinalizationOutcome {
+  if (resume) {
+    return 'complete'
+  }
+
+  if (!assistantMessageSeen) {
+    return 'stream_no_assistant_message'
+  }
+
+  if (!assistantPartSeen) {
+    return 'stream_incomplete'
+  }
+
+  return 'complete'
+}
+
+export function getSilentStreamOutcome(upstreamStatus: string | null): SilentStreamOutcome {
+  if (upstreamStatus === 'busy' || upstreamStatus === 'retry') {
+    return 'keep_waiting'
+  }
+
+  if (upstreamStatus === 'idle') {
+    return 'finalize_idle'
+  }
+
+  return 'stream_timeout'
+}

--- a/apps/web/src/app/api/w/[slug]/chat/stream/watchdog.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/watchdog.ts
@@ -2,10 +2,18 @@ export type IdleFinalizationOutcome = 'complete' | 'stream_incomplete' | 'stream
 
 export type SilentStreamOutcome = 'finalize_idle' | 'keep_waiting' | 'stream_timeout'
 
+const SILENT_STREAM_TIMEOUT_MULTIPLIER = 3
+
 type IdleFinalizationInput = {
   resume: boolean
   assistantMessageSeen: boolean
   assistantPartSeen: boolean
+}
+
+type SilentStreamInput = {
+  upstreamStatus: string | null
+  silentForMs: number
+  relevantEventTimeoutMs: number
 }
 
 export function getIdleFinalizationOutcome({
@@ -28,9 +36,15 @@ export function getIdleFinalizationOutcome({
   return 'complete'
 }
 
-export function getSilentStreamOutcome(upstreamStatus: string | null): SilentStreamOutcome {
+export function getSilentStreamOutcome({
+  upstreamStatus,
+  silentForMs,
+  relevantEventTimeoutMs,
+}: SilentStreamInput): SilentStreamOutcome {
   if (upstreamStatus === 'busy' || upstreamStatus === 'retry') {
-    return 'keep_waiting'
+    return silentForMs < relevantEventTimeoutMs * SILENT_STREAM_TIMEOUT_MULTIPLIER
+      ? 'keep_waiting'
+      : 'stream_timeout'
   }
 
   if (upstreamStatus === 'idle') {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -24,6 +24,8 @@
   --color-accent-foreground: hsl(var(--accent-foreground));
   --color-destructive: hsl(var(--destructive));
   --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-warning: hsl(var(--warning));
+  --color-warning-foreground: hsl(var(--warning-foreground));
   --color-border: hsl(var(--border));
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));
@@ -94,6 +96,8 @@
   --accent-foreground: 20 18% 16%;
   --destructive: 0 70% 50%;
   --destructive-foreground: 0 0% 100%;
+  --warning: 38 92% 50%;
+  --warning-foreground: 32 81% 29%;
   /* Tinted borders */
   --border: 30 12% 78%;
   --input: 30 12% 78%;
@@ -136,6 +140,8 @@
   --accent-foreground: 0 0% 92%;
   --destructive: 0 60% 45%;
   --destructive-foreground: 0 0% 100%;
+  --warning: 38 80% 56%;
+  --warning-foreground: 40 90% 86%;
   --border: 0 0% 20%;
   --input: 0 0% 20%;
   --ring: 24 78% 60%;
@@ -167,6 +173,8 @@
   --muted: 30 10% 91%;
   --accent: 30 34% 87%;
   --accent-foreground: 20 18% 16%;
+  --warning: 36 90% 50%;
+  --warning-foreground: 30 75% 28%;
   --border: 30 10% 84%;
   --input: 30 10% 84%;
   --ring: 24 90% 55%;
@@ -199,6 +207,8 @@
   --accent-foreground: 198 14% 22%;
   --destructive: 0 70% 50%;
   --destructive-foreground: 0 0% 100%;
+  --warning: 40 85% 52%;
+  --warning-foreground: 35 70% 30%;
   --border: 198 8% 80%;
   --input: 198 8% 80%;
   --ring: 195 22% 50%;
@@ -237,6 +247,8 @@
   --accent-foreground: 154 12% 22%;
   --destructive: 0 70% 50%;
   --destructive-foreground: 0 0% 100%;
+  --warning: 42 82% 50%;
+  --warning-foreground: 38 68% 28%;
   --border: 150 6% 80%;
   --input: 150 6% 80%;
   --ring: 152 20% 46%;
@@ -275,6 +287,8 @@
   --accent-foreground: 274 12% 24%;
   --destructive: 0 70% 50%;
   --destructive-foreground: 0 0% 100%;
+  --warning: 40 78% 52%;
+  --warning-foreground: 36 65% 30%;
   --border: 272 6% 81%;
   --input: 272 6% 81%;
   --ring: 272 20% 58%;
@@ -313,6 +327,8 @@
   --accent-foreground: 348 14% 24%;
   --destructive: 0 70% 50%;
   --destructive-foreground: 0 0% 100%;
+  --warning: 35 85% 52%;
+  --warning-foreground: 30 72% 28%;
   --border: 348 5% 81%;
   --input: 348 5% 81%;
   --ring: 348 26% 56%;
@@ -345,6 +361,8 @@
   --muted: 0 0% 15%;
   --accent: 30 34% 24%;
   --accent-foreground: 0 0% 92%;
+  --warning: 36 85% 58%;
+  --warning-foreground: 38 88% 88%;
   --border: 0 0% 20%;
   --input: 0 0% 20%;
   --ring: 24 90% 55%;
@@ -377,6 +395,8 @@
   --accent-foreground: 200 5% 92%;
   --destructive: 0 60% 45%;
   --destructive-foreground: 0 0% 100%;
+  --warning: 40 75% 58%;
+  --warning-foreground: 42 82% 88%;
   --border: 200 6% 20%;
   --input: 200 6% 20%;
   --ring: 195 28% 50%;
@@ -415,6 +435,8 @@
   --accent-foreground: 150 5% 92%;
   --destructive: 0 60% 45%;
   --destructive-foreground: 0 0% 100%;
+  --warning: 42 72% 56%;
+  --warning-foreground: 44 78% 86%;
   --border: 150 5% 20%;
   --input: 150 5% 20%;
   --ring: 152 24% 46%;
@@ -453,6 +475,8 @@
   --accent-foreground: 272 5% 92%;
   --destructive: 0 60% 45%;
   --destructive-foreground: 0 0% 100%;
+  --warning: 40 70% 58%;
+  --warning-foreground: 42 76% 88%;
   --border: 272 5% 20%;
   --input: 272 5% 20%;
   --ring: 272 22% 56%;
@@ -491,6 +515,8 @@
   --accent-foreground: 348 5% 92%;
   --destructive: 0 60% 45%;
   --destructive-foreground: 0 0% 100%;
+  --warning: 35 78% 58%;
+  --warning-foreground: 38 84% 88%;
   --border: 348 5% 20%;
   --input: 348 5% 20%;
   --ring: 348 26% 54%;

--- a/apps/web/src/app/u/[slug]/page.tsx
+++ b/apps/web/src/app/u/[slug]/page.tsx
@@ -110,13 +110,13 @@ export default async function WorkspacePage({
             </p>
 
             {setupNotice && (
-              <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-900">
+              <div className="rounded-xl border border-warning/30 bg-warning/10 px-4 py-3 text-sm text-warning-foreground">
                 {setupNotice.text}
               </div>
             )}
 
             {kickstartStatus === 'setup_in_progress' && (
-              <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-900">
+              <div className="rounded-xl border border-warning/30 bg-warning/10 px-4 py-3 text-sm text-warning-foreground">
                 Setup is currently running. You can open the wizard to monitor progress,
                 but apply may be temporarily locked.
               </div>
@@ -167,7 +167,7 @@ export default async function WorkspacePage({
           className={
             setupNotice.tone === 'success'
               ? 'mb-6 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-800'
-              : 'mb-6 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-900'
+              : 'mb-6 rounded-xl border border-warning/30 bg-warning/10 px-4 py-3 text-sm text-warning-foreground'
           }
         >
           {setupNotice.text}

--- a/apps/web/src/components/desktop/desktop-vault-launcher.tsx
+++ b/apps/web/src/components/desktop/desktop-vault-launcher.tsx
@@ -293,9 +293,9 @@ export function DesktopVaultLauncher() {
   }
 
   return (
-    <main className="scrollbar-custom relative flex h-screen flex-col overflow-y-auto px-10 pb-8 pt-14">
-      <div className="desktop-titlebar-drag absolute inset-x-0 top-0 z-50 h-8" />
-      <div className="flex flex-1 flex-col space-y-8">
+    <main className="scrollbar-custom relative flex h-screen flex-col overflow-y-auto pb-8">
+      <div className="desktop-titlebar-drag sticky inset-x-0 top-0 z-50 h-10 shrink-0" />
+      <div className="flex flex-1 flex-col space-y-8 px-10 pt-2">
         <div className="space-y-6">
           <div className="space-y-3">
             <p className="text-xs uppercase tracking-[0.18em] text-primary/80">Welcome to Arche</p>

--- a/apps/web/src/components/desktop/desktop-vault-launcher.tsx
+++ b/apps/web/src/components/desktop/desktop-vault-launcher.tsx
@@ -273,7 +273,8 @@ export function DesktopVaultLauncher() {
 
   if (status) {
     return (
-      <main className="mx-auto flex min-h-screen max-w-5xl items-center justify-center px-6 py-10">
+      <main className="relative mx-auto flex min-h-screen max-w-5xl items-center justify-center px-6 py-10">
+        <div className="desktop-titlebar-drag absolute inset-x-0 top-0 z-50 h-8" />
         <section className="w-full max-w-2xl rounded-3xl border border-border/60 bg-card/70 p-10 text-center shadow-sm backdrop-blur">
           <div className="space-y-5">
             <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10">
@@ -295,7 +296,8 @@ export function DesktopVaultLauncher() {
   }
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-5xl items-center justify-center px-6 py-10">
+    <main className="relative mx-auto flex min-h-screen max-w-5xl items-center justify-center px-6 py-10">
+      <div className="desktop-titlebar-drag absolute inset-x-0 top-0 z-50 h-8" />
       <div className={mode === 'create'
         ? 'w-full'
         : 'grid w-full gap-8 lg:grid-cols-[minmax(0,1.3fr)_minmax(300px,380px)]'

--- a/apps/web/src/components/desktop/desktop-vault-launcher.tsx
+++ b/apps/web/src/components/desktop/desktop-vault-launcher.tsx
@@ -273,7 +273,7 @@ export function DesktopVaultLauncher() {
 
   if (status) {
     return (
-      <main className="mx-auto flex min-h-screen max-w-4xl items-center justify-center px-6 py-10">
+      <main className="mx-auto flex min-h-screen max-w-5xl items-center justify-center px-6 py-10">
         <section className="w-full max-w-2xl rounded-3xl border border-border/60 bg-card/70 p-10 text-center shadow-sm backdrop-blur">
           <div className="space-y-5">
             <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10">
@@ -295,19 +295,19 @@ export function DesktopVaultLauncher() {
   }
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-6xl items-center px-6 py-10">
+    <main className="mx-auto flex min-h-screen max-w-5xl items-center justify-center px-6 py-10">
       <div className={mode === 'create'
         ? 'w-full'
-        : 'grid w-full gap-8 lg:grid-cols-[minmax(0,1.3fr)_minmax(320px,420px)]'
+        : 'grid w-full gap-8 lg:grid-cols-[minmax(0,1.3fr)_minmax(300px,380px)]'
       }>
         <section className="rounded-3xl border border-border/60 bg-card/60 p-8 shadow-sm backdrop-blur">
-          <div className="max-w-2xl space-y-6">
+          <div className="space-y-6">
             <div className="space-y-3">
               <p className="text-xs uppercase tracking-[0.18em] text-primary/80">Welcome to Arche</p>
               <h1 className="type-display text-3xl leading-tight text-foreground sm:text-4xl">
                 Set up your workspace
               </h1>
-              <p className="max-w-xl text-sm text-muted-foreground sm:text-base">
+              <p className="text-sm text-muted-foreground sm:text-base">
                 A vault is a self-contained workspace where Arche keeps your repos, agents,
                 and knowledge base organized.
               </p>

--- a/apps/web/src/components/desktop/desktop-vault-launcher.tsx
+++ b/apps/web/src/components/desktop/desktop-vault-launcher.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
-  ClockCounterClockwise,
   FolderOpen,
   Plus,
   SpinnerGap,
@@ -273,182 +272,159 @@ export function DesktopVaultLauncher() {
 
   if (status) {
     return (
-      <main className="relative mx-auto flex min-h-screen max-w-5xl items-center justify-center px-6 py-10">
+      <main className="relative flex h-screen flex-col items-center justify-center px-10 py-10">
         <div className="desktop-titlebar-drag absolute inset-x-0 top-0 z-50 h-8" />
-        <section className="w-full max-w-2xl rounded-3xl border border-border/60 bg-card/70 p-10 text-center shadow-sm backdrop-blur">
-          <div className="space-y-5">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10">
-              <SpinnerGap size={24} className="animate-spin text-primary" />
-            </div>
-            <h1 className="type-display text-3xl leading-tight text-foreground">
-              {status.title}
-            </h1>
-            <p className="mx-auto max-w-md text-sm text-muted-foreground sm:text-base">
-              {status.description}
-            </p>
-            <div className="mx-auto h-1.5 w-48 overflow-hidden rounded-full bg-muted/40">
-              <div className="h-full animate-[progress-sweep_1.8s_ease-in-out_infinite] rounded-full bg-primary" />
-            </div>
+        <div className="w-full max-w-md space-y-6 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10">
+            <SpinnerGap size={24} className="animate-spin text-primary" />
           </div>
-        </section>
+          <h1 className="type-display text-3xl leading-tight text-foreground">
+            {status.title}
+          </h1>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            {status.description}
+          </p>
+          <div className="mx-auto h-1.5 w-48 overflow-hidden rounded-full bg-muted/40">
+            <div className="h-full animate-[progress-sweep_1.8s_ease-in-out_infinite] rounded-full bg-primary" />
+          </div>
+        </div>
       </main>
     )
   }
 
   return (
-    <main className="relative mx-auto flex min-h-screen max-w-5xl items-center justify-center px-6 py-10">
+    <main className="scrollbar-custom relative flex h-screen flex-col overflow-y-auto px-10 pb-8 pt-14">
       <div className="desktop-titlebar-drag absolute inset-x-0 top-0 z-50 h-8" />
-      <div className={mode === 'create'
-        ? 'w-full'
-        : 'grid w-full gap-8 lg:grid-cols-[minmax(0,1.3fr)_minmax(300px,380px)]'
-      }>
-        <section className="rounded-3xl border border-border/60 bg-card/60 p-8 shadow-sm backdrop-blur">
-          <div className="space-y-6">
-            <div className="space-y-3">
-              <p className="text-xs uppercase tracking-[0.18em] text-primary/80">Welcome to Arche</p>
-              <h1 className="type-display text-3xl leading-tight text-foreground sm:text-4xl">
-                Set up your workspace
-              </h1>
-              <p className="text-sm text-muted-foreground sm:text-base">
-                A vault is a self-contained workspace where Arche keeps your repos, agents,
-                and knowledge base organized.
-              </p>
-            </div>
-
-            {!mode && (
-              <div className="grid gap-4 sm:grid-cols-2">
-                <button
-                  type="button"
-                  onClick={() => setMode('create')}
-                  className="group rounded-2xl border border-border/60 bg-background/60 p-5 text-left transition-all hover:border-primary/40 hover:bg-primary/5 hover:shadow-subtle"
-                >
-                  <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
-                    <Plus size={20} weight="bold" />
-                  </div>
-                  <p className="font-medium text-foreground">Create new vault</p>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    Pick a template, configure agents, and get started.
-                  </p>
-                </button>
-
-                <button
-                  type="button"
-                  onClick={handleOpenExistingVault}
-                  className="group rounded-2xl border border-border/60 bg-background/60 p-5 text-left transition-all hover:border-primary/40 hover:bg-primary/5 hover:shadow-subtle"
-                >
-                  <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
-                    <FolderOpen size={20} weight="bold" />
-                  </div>
-                  <p className="font-medium text-foreground">Open existing vault</p>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    Browse your filesystem for an existing Arche vault.
-                  </p>
-                </button>
-              </div>
-            )}
-
-            {mode === 'create' && (
-              <KickstartWizard
-                embedded
-                loadCatalog={loadDesktopKickstartCatalog}
-                onBack={() => setMode(null)}
-                onSubmit={handleCreateVault}
-                renderStepOneExtras={(
-                  <>
-                    <div className="space-y-2">
-                      <Label htmlFor="desktop-vault-name">Vault name</Label>
-                      <Input
-                        id="desktop-vault-name"
-                        value={vaultName}
-                        onChange={(event) => setVaultName(event.target.value)}
-                        placeholder={DEFAULT_NEW_VAULT_NAME}
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label>Location</Label>
-                      <div className="flex flex-col gap-3 sm:flex-row">
-                        <Input
-                          value={parentPath}
-                          readOnly
-                          placeholder="Choose a parent folder"
-                          className="flex-1"
-                        />
-                        <button
-                          type="button"
-                          onClick={handleChooseLocation}
-                          className="inline-flex items-center justify-center rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/50"
-                        >
-                          Choose location
-                        </button>
-                      </div>
-                    </div>
-
-                    <div className="rounded-xl border border-dashed border-border/60 bg-muted/20 px-4 py-3">
-                      <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-                        Vault path
-                      </p>
-                      <p className="mt-1 break-all font-mono text-sm text-foreground/80">
-                        {previewPath || (
-                          <span className="italic text-muted-foreground">Choose a location above</span>
-                        )}
-                      </p>
-                    </div>
-                  </>
-                )}
-                stepOneReadyOverride={stepOneReady}
-                submitLabel="Create vault"
-                submittingLabel="Creating vault"
-              />
-            )}
-
-            {error ? (
-              <div className="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-                {error}
-              </div>
-            ) : null}
+      <div className="flex flex-1 flex-col space-y-8">
+        <div className="space-y-6">
+          <div className="space-y-3">
+            <p className="text-xs uppercase tracking-[0.18em] text-primary/80">Welcome to Arche</p>
+            <h1 className="type-display text-4xl leading-tight text-foreground">
+              Set up your workspace
+            </h1>
+            <p className="text-sm text-muted-foreground sm:text-base">
+              A vault is a self-contained workspace where Arche keeps your repos, agents,
+              and knowledge base organized.
+            </p>
           </div>
-        </section>
 
-        {!mode && <aside className="rounded-3xl border border-border/60 bg-card/60 p-6 shadow-sm backdrop-blur">
-          <div className="space-y-4">
-            <div>
-              <h2 className="text-lg font-semibold text-foreground">Recent vaults</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Reopen a recent vault in its own window.
-              </p>
-            </div>
-
-            {recentVaults.length === 0 ? (
-              <div className="flex flex-col items-center rounded-2xl border border-dashed border-border/60 px-4 py-8 text-center">
-                <ClockCounterClockwise size={24} className="mb-2 text-muted-foreground/50" />
-                <p className="text-sm text-muted-foreground">No recent vaults yet.</p>
-                <p className="mt-1 text-xs text-muted-foreground/70">
-                  Vaults you open will appear here.
+          {!mode && (
+            <div className="grid gap-4 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={() => setMode('create')}
+                className="group rounded-2xl border border-border/60 bg-background/60 p-5 text-left transition-all hover:border-primary/40 hover:bg-primary/5 hover:shadow-subtle"
+              >
+                <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
+                  <Plus size={20} weight="bold" />
+                </div>
+                <p className="font-medium text-foreground">Create new vault</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Pick a template, configure agents, and get started.
                 </p>
-              </div>
-            ) : (
-              <div className="space-y-3">
-                {recentVaults.map((vault) => (
-                  <button
-                    key={vault.path}
-                    type="button"
-                    onClick={() => handleOpenRecentVault(vault.path)}
-                    className="flex w-full items-center gap-3 rounded-2xl border border-border/60 bg-background/60 px-4 py-3 text-left transition-all hover:border-primary/30 hover:bg-background hover:shadow-subtle"
-                  >
-                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-muted/40 text-muted-foreground">
-                      <Vault size={18} />
+              </button>
+
+              <button
+                type="button"
+                onClick={handleOpenExistingVault}
+                className="group rounded-2xl border border-border/60 bg-background/60 p-5 text-left transition-all hover:border-primary/40 hover:bg-primary/5 hover:shadow-subtle"
+              >
+                <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
+                  <FolderOpen size={20} weight="bold" />
+                </div>
+                <p className="font-medium text-foreground">Open existing vault</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Browse your filesystem for an existing Arche vault.
+                </p>
+              </button>
+            </div>
+          )}
+
+          {mode === 'create' && (
+            <KickstartWizard
+              embedded
+              loadCatalog={loadDesktopKickstartCatalog}
+              onBack={() => setMode(null)}
+              onSubmit={handleCreateVault}
+              renderStepOneExtras={(
+                <>
+                  <div className="space-y-2">
+                    <Label htmlFor="desktop-vault-name">Vault name</Label>
+                    <Input
+                      id="desktop-vault-name"
+                      value={vaultName}
+                      onChange={(event) => setVaultName(event.target.value)}
+                      placeholder={DEFAULT_NEW_VAULT_NAME}
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label>Location</Label>
+                    <div className="flex flex-col gap-3 sm:flex-row">
+                      <Input
+                        value={parentPath}
+                        readOnly
+                        placeholder="Choose a parent folder"
+                        className="flex-1"
+                      />
+                      <button
+                        type="button"
+                        onClick={handleChooseLocation}
+                        className="inline-flex items-center justify-center rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/50"
+                      >
+                        Choose location
+                      </button>
                     </div>
-                    <div className="min-w-0">
-                      <span className="block truncate text-sm font-medium text-foreground">{vault.name}</span>
-                      <span className="block truncate text-xs text-muted-foreground">{vault.path}</span>
-                    </div>
-                  </button>
-                ))}
-              </div>
-            )}
+                  </div>
+
+                  <div className="rounded-xl border border-dashed border-border/60 bg-muted/20 px-4 py-3">
+                    <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                      Vault path
+                    </p>
+                    <p className="mt-1 break-all font-mono text-sm text-foreground/80">
+                      {previewPath || (
+                        <span className="italic text-muted-foreground">Choose a location above</span>
+                      )}
+                    </p>
+                  </div>
+                </>
+              )}
+              stepOneReadyOverride={stepOneReady}
+              submitLabel="Create vault"
+              submittingLabel="Creating vault"
+            />
+          )}
+
+          {error ? (
+            <div className="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              {error}
+            </div>
+          ) : null}
+        </div>
+
+        {!mode && recentVaults.length > 0 && (
+          <div className="space-y-3 border-t border-border/40 pt-6">
+            <h2 className="text-sm font-medium text-muted-foreground">Recent vaults</h2>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {recentVaults.map((vault) => (
+                <button
+                  key={vault.path}
+                  type="button"
+                  onClick={() => handleOpenRecentVault(vault.path)}
+                  className="flex w-full items-center gap-3 rounded-2xl border border-border/60 bg-background/60 px-4 py-3 text-left transition-all hover:border-primary/30 hover:bg-background hover:shadow-subtle"
+                >
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-muted/40 text-muted-foreground">
+                    <Vault size={18} />
+                  </div>
+                  <div className="min-w-0">
+                    <span className="block truncate text-sm font-medium text-foreground">{vault.name}</span>
+                    <span className="block truncate text-xs text-muted-foreground">{vault.path}</span>
+                  </div>
+                </button>
+              ))}
+            </div>
           </div>
-        </aside>}
+        )}
       </div>
     </main>
   )

--- a/apps/web/src/components/kickstart/kickstart-wizard.tsx
+++ b/apps/web/src/components/kickstart/kickstart-wizard.tsx
@@ -357,9 +357,16 @@ export function KickstartWizard({
 
   useEffect(() => {
     const scroller = wizardTopRef.current?.closest('main')
-    if (scroller) {
-      scroller.scrollTo({ top: 0, behavior: 'smooth' })
+    if (!(scroller instanceof HTMLElement)) {
+      return
     }
+
+    if (typeof scroller.scrollTo === 'function') {
+      scroller.scrollTo({ top: 0, behavior: 'smooth' })
+      return
+    }
+
+    scroller.scrollTop = 0
   }, [step])
 
   const selectedTemplate = useMemo(() => {

--- a/apps/web/src/components/kickstart/kickstart-wizard.tsx
+++ b/apps/web/src/components/kickstart/kickstart-wizard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type ChangeEvent, type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+import { type ChangeEvent, Fragment, type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import {
   CaretRight,
   CheckCircle,
@@ -283,6 +283,7 @@ export function KickstartWizard({
   submittingLabel = 'Applying',
 }: KickstartWizardProps) {
   const [step, setStep] = useState(1)
+  const wizardTopRef = useRef<HTMLDivElement>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isApplying, setIsApplying] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
@@ -353,6 +354,10 @@ export function KickstartWizard({
       cancelled = true
     }
   }, [initialTemplateId, loadCatalog])
+
+  useEffect(() => {
+    wizardTopRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }, [step])
 
   const selectedTemplate = useMemo(() => {
     if (selectedTemplateId === IMPORT_TEMPLATE_ID) {
@@ -595,14 +600,14 @@ export function KickstartWizard({
   }
 
   return (
-    <div className="space-y-6">
+    <div ref={wizardTopRef} className="space-y-6">
       {initialStatus === 'setup_in_progress' && (
         <div className="glass-panel rounded-2xl border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-900">
           Another setup operation is currently running. You can still review this wizard, but apply may return a conflict until the current run finishes.
         </div>
       )}
 
-      <section className={cn('rounded-3xl p-6 sm:p-8', !embedded && 'glass-panel')}>
+      <section className={cn(!embedded && 'rounded-3xl p-6 sm:p-8 glass-panel')}>
         <div className="mb-8 flex items-start">
           {STEPS.map((label, index) => {
             const itemStep = index + 1
@@ -610,8 +615,20 @@ export function KickstartWizard({
             const active = step === itemStep
 
             return (
-              <div key={label} className="flex flex-1 items-start">
-                <div className="flex flex-col items-center">
+              <Fragment key={label}>
+                {index > 0 && (
+                  <div
+                    className={cn(
+                      'mt-4 h-px flex-1',
+                      step > itemStep
+                        ? 'bg-emerald-500/30'
+                        : step > index
+                          ? 'bg-primary/30'
+                          : 'bg-border/60'
+                    )}
+                  />
+                )}
+                <div className="flex w-20 shrink-0 flex-col items-center">
                   <div
                     className={cn(
                       'flex h-8 w-8 items-center justify-center rounded-full text-xs font-medium transition-colors',
@@ -635,17 +652,7 @@ export function KickstartWizard({
                     {label}
                   </p>
                 </div>
-                {index < STEPS.length - 1 && (
-                  <div className={cn(
-                    'mt-4 mx-2 h-px flex-1',
-                    step > itemStep + 1
-                      ? 'bg-emerald-500/30'
-                      : step > itemStep
-                        ? 'bg-primary/30'
-                        : 'bg-border/60'
-                  )} />
-                )}
-              </div>
+              </Fragment>
             )
           })}
         </div>

--- a/apps/web/src/components/kickstart/kickstart-wizard.tsx
+++ b/apps/web/src/components/kickstart/kickstart-wizard.tsx
@@ -356,7 +356,10 @@ export function KickstartWizard({
   }, [initialTemplateId, loadCatalog])
 
   useEffect(() => {
-    wizardTopRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    const scroller = wizardTopRef.current?.closest('main')
+    if (scroller) {
+      scroller.scrollTo({ top: 0, behavior: 'smooth' })
+    }
   }, [step])
 
   const selectedTemplate = useMemo(() => {
@@ -607,7 +610,7 @@ export function KickstartWizard({
         </div>
       )}
 
-      <section className={cn(!embedded && 'rounded-3xl p-6 sm:p-8 glass-panel')}>
+      <section className={cn(embedded ? 'py-6' : 'rounded-3xl p-6 sm:p-8 glass-panel')}>
         <div className="mb-8 flex items-start">
           {STEPS.map((label, index) => {
             const itemStep = index + 1

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -12,7 +12,7 @@ const badgeVariants = cva(
         secondary: "bg-muted text-muted-foreground",
         outline: "border border-border text-muted-foreground",
         success: "bg-emerald-500/10 text-emerald-600",
-        warning: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+        warning: "bg-warning/10 text-warning-foreground",
       },
     },
     defaultVariants: {

--- a/apps/web/src/components/workspace/__tests__/chat-panel-textarea.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/chat-panel-textarea.test.tsx
@@ -82,6 +82,7 @@ function createClipboardImageData(file: File) {
 
 afterEach(() => {
   cleanup();
+  delete (window as Window & { arche?: unknown }).arche;
   vi.unstubAllGlobals();
 });
 
@@ -293,6 +294,36 @@ describe("ChatPanel textarea", () => {
         contextPaths: [],
       }
     );
+  });
+
+  it("shows a desktop-only reveal attachments action in the manage dialog", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ attachments: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const revealAttachmentsDirectory = vi.fn().mockResolvedValue({ ok: true });
+    (window as Window & { arche?: unknown }).arche = {
+      isDesktop: true,
+      platform: "darwin",
+      desktop: {
+        revealAttachmentsDirectory,
+      },
+    };
+
+    renderChatPanel();
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Manage attachments" }));
+    await screen.findByText("Upload file");
+    fireEvent.click(screen.getByText("Manage attachments"));
+
+    const revealButton = await screen.findByRole("button", { name: "Reveal in Finder" });
+    fireEvent.click(revealButton);
+
+    await waitFor(() => {
+      expect(revealAttachmentsDirectory).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("does not trigger uploads when pasted clipboard data has no images", async () => {

--- a/apps/web/src/components/workspace/__tests__/chat-panel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/chat-panel.test.tsx
@@ -279,6 +279,52 @@ describe('ChatPanel', () => {
     expect(html).toContain('If you want, I can make it more formal.')
   })
 
+  it('keeps tool groups separate when reasoning appears between identical tool calls', () => {
+    const html = renderChatPanel({
+      messages: [
+        {
+          id: 'm1',
+          sessionId: 's1',
+          role: 'assistant',
+          content: '',
+          timestamp: 'now',
+          parts: [
+            {
+              type: 'tool',
+              id: 'tool-read-1',
+              name: 'read',
+              state: {
+                status: 'completed',
+                input: { filePath: 'docs/first.md' },
+                output: '',
+                title: 'read first file',
+              },
+            },
+            {
+              type: 'reasoning',
+              id: 'reasoning-1',
+              text: 'Comparing it with another file before continuing.',
+            },
+            {
+              type: 'tool',
+              id: 'tool-read-2',
+              name: 'read',
+              state: {
+                status: 'completed',
+                input: { filePath: 'docs/second.md' },
+                output: '',
+                title: 'read second file',
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(html.match(/Reading file/g)).toHaveLength(2)
+    expect(html).toContain('Reasoning')
+  })
+
   it('renders unknown parts even when their debug payload contains bigint-like values', () => {
     const html = renderChatPanel({
       messages: [

--- a/apps/web/src/components/workspace/__tests__/chat-panel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/chat-panel.test.tsx
@@ -279,6 +279,46 @@ describe('ChatPanel', () => {
     expect(html).toContain('If you want, I can make it more formal.')
   })
 
+  it('renders todowrite items from the OpenCode todo input shape', () => {
+    const html = renderChatPanel({
+      messages: [
+        {
+          id: 'm1',
+          sessionId: 's1',
+          role: 'assistant',
+          content: '',
+          timestamp: 'now',
+          parts: [
+            {
+              type: 'tool',
+              id: 'tool-todo-1',
+              name: 'todowrite',
+              state: {
+                status: 'completed',
+                input: {
+                  todos: [
+                    { content: 'Inspect auth flow', status: 'completed', priority: 'high' },
+                    { content: 'Fix password mismatch', status: 'in_progress', priority: 'high' },
+                    { content: 'Verify login in dev', status: 'pending', priority: 'medium' },
+                  ],
+                },
+                output: '',
+                title: 'todo updated',
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(html).toContain('Planning')
+    expect(html).toContain('1/3 done')
+    expect(html).toContain('1 in progress')
+    expect(html).toContain('Inspect auth flow')
+    expect(html).toContain('Fix password mismatch')
+    expect(html).toContain('Verify login in dev')
+  })
+
   it('keeps tool groups separate when reasoning appears between identical tool calls', () => {
     const html = renderChatPanel({
       messages: [

--- a/apps/web/src/components/workspace/chat-panel.tsx
+++ b/apps/web/src/components/workspace/chat-panel.tsx
@@ -97,6 +97,7 @@ type ChatPanelProps = {
   onReturnToMainConversation?: () => void;
   pendingInsert?: string | null;
   onPendingInsertConsumed?: () => void;
+  workspaceRoot?: string;
 };
 
 type ConnectorSummary = {
@@ -145,7 +146,8 @@ export function ChatPanel({
   isReadOnly = false,
   onReturnToMainConversation,
   pendingInsert,
-  onPendingInsertConsumed
+  onPendingInsertConsumed,
+  workspaceRoot,
 }: ChatPanelProps) {
   const { chatFontFamily, chatFontSize } = useWorkspaceTheme();
   const activeSession = useMemo(
@@ -926,6 +928,7 @@ export function ChatPanel({
         onSelectSessionTab={onSelectSessionTab}
         scrollContainerRef={scrollContainerRef}
         sessionTabs={sessionTabs}
+        workspaceRoot={workspaceRoot}
       />
 
       {/* Input area */}

--- a/apps/web/src/components/workspace/chat-panel.tsx
+++ b/apps/web/src/components/workspace/chat-panel.tsx
@@ -1151,7 +1151,8 @@ export function ChatPanel({
               <Button
                 type="button"
                 size="sm"
-                variant="secondary"
+                variant="outline"
+                className="border-warning-foreground/30 bg-background/80 text-warning-foreground hover:bg-background"
                 onClick={onReturnToMainConversation}
               >
                 Main conversation

--- a/apps/web/src/components/workspace/chat-panel.tsx
+++ b/apps/web/src/components/workspace/chat-panel.tsx
@@ -50,6 +50,7 @@ import { useWorkspaceTheme } from "@/contexts/workspace-theme-context";
 import { useAgentMentionAutocomplete } from "@/hooks/use-agent-mention-autocomplete";
 import type { AgentCatalogItem } from "@/hooks/use-workspace";
 import type { AvailableModel } from "@/lib/opencode/types";
+import { getDesktopPlatform, getOptionalDesktopBridge } from "@/lib/runtime/desktop/client";
 import {
   buildWorkspaceSessionMarkdown,
   getWorkspaceSessionExportFilename,
@@ -193,6 +194,10 @@ export function ChatPanel({
   const [draftTitle, setDraftTitle] = useState("");
   const [isSavingTitle, setIsSavingTitle] = useState(false);
   const [renameError, setRenameError] = useState<string | null>(null);
+  const desktopBridge = getOptionalDesktopBridge();
+  const revealAttachmentsLabel = getDesktopPlatform() === "darwin"
+    ? "Reveal in Finder"
+    : "Reveal in File Explorer";
 
   const selectedAttachments = useMemo(
     () => {
@@ -579,6 +584,16 @@ export function ChatPanel({
     },
     [handleUploadAttachments]
   );
+
+  const handleRevealAttachmentsDirectory = useCallback(async () => {
+    if (!desktopBridge) return;
+
+    setAttachmentsError(null);
+    const result = await desktopBridge.revealAttachmentsDirectory();
+    if (!result.ok) {
+      setAttachmentsError(result.error ?? "reveal_attachments_failed");
+    }
+  }, [desktopBridge]);
 
   const handleTextareaPaste = useCallback(
     async (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
@@ -1361,6 +1376,19 @@ export function ChatPanel({
                         className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
                       />
                     </div>
+                    {desktopBridge ? (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void handleRevealAttachmentsDirectory();
+                        }}
+                        className="flex items-center gap-1.5 rounded-lg bg-foreground/5 px-3 py-2 text-xs text-foreground transition-colors hover:bg-foreground/10"
+                        disabled={isMutatingAttachments || isUploadingAttachment}
+                      >
+                        <FolderOpen size={14} />
+                        {revealAttachmentsLabel}
+                      </button>
+                    ) : null}
                     <button
                       type="button"
                       onClick={() => attachmentInputRef.current?.click()}

--- a/apps/web/src/components/workspace/chat-panel.tsx
+++ b/apps/web/src/components/workspace/chat-panel.tsx
@@ -1142,9 +1142,9 @@ export function ChatPanel({
         )}
 
         {isReadOnly ? (
-          <div className="flex items-center justify-between gap-3 rounded-xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-100">
-            <div className="flex items-center gap-2 text-amber-800 dark:text-amber-50/90">
-              <Info size={16} weight="fill" className="text-amber-500 dark:text-amber-300" />
+          <div className="flex items-center justify-between gap-3 rounded-xl border border-warning/20 bg-warning/10 px-4 py-3 text-sm text-warning-foreground">
+            <div className="flex items-center gap-2 text-warning-foreground">
+              <Info size={16} weight="fill" className="text-warning" />
               <span>Subagent sessions are read-only. Return to the main conversation to continue chatting.</span>
             </div>
             {onReturnToMainConversation ? (

--- a/apps/web/src/components/workspace/chat-panel/messages.tsx
+++ b/apps/web/src/components/workspace/chat-panel/messages.tsx
@@ -57,6 +57,7 @@ type ChatPanelMessagesProps = {
   onSelectSessionTab?: (id: string) => void;
   scrollContainerRef: RefObject<HTMLDivElement | null>;
   sessionTabs: SessionTabInfo[];
+  workspaceRoot?: string;
 };
 
 type ToolDisplay = {
@@ -141,6 +142,16 @@ function formatToolName(tool: string): string {
   return formatted.charAt(0).toUpperCase() + formatted.slice(1);
 }
 
+function relativizePath(absolutePath: string | undefined, workspaceRoot: string | undefined): string | undefined {
+  if (!absolutePath || !workspaceRoot) return absolutePath;
+  const prefix = workspaceRoot.endsWith("/") ? workspaceRoot : `${workspaceRoot}/`;
+  if (absolutePath.startsWith(prefix)) {
+    return absolutePath.slice(prefix.length) || ".";
+  }
+  if (absolutePath === workspaceRoot) return ".";
+  return absolutePath;
+}
+
 const getFileName = (path?: string) => (path ? path.split("/").pop() ?? path : undefined);
 const getDirectory = (path?: string) => {
   if (!path || !path.includes("/")) return undefined;
@@ -222,7 +233,8 @@ function getToolDisplay(
   tool: string,
   input?: Record<string, unknown>,
   fallbackTitle?: string,
-  connectorNamesById?: Record<string, string>
+  connectorNamesById?: Record<string, string>,
+  workspaceRoot?: string,
 ): ToolDisplay {
   const toolDisplay = getWorkspaceToolDisplay(tool, connectorNamesById);
   if (toolDisplay.isConnectorTool) {
@@ -234,8 +246,9 @@ function getToolDisplay(
 
   const rawPath = typeof input?.path === "string" ? input.path : undefined;
   const normalizedPath = rawPath === "" ? "/" : rawPath;
-  const filePath = getString(input?.filePath) ?? getString(input?.filename);
-  const searchPath = getString(normalizedPath);
+  const rawFilePath = getString(input?.filePath) ?? getString(input?.filename);
+  const filePath = relativizePath(rawFilePath, workspaceRoot);
+  const searchPath = relativizePath(getString(normalizedPath), workspaceRoot);
   const pattern = getString(input?.pattern);
   const include = getString(input?.include);
   const url = getString(input?.url);
@@ -302,7 +315,7 @@ function getToolDisplay(
     }
     case "apply_patch": {
       const count = files?.length ?? 0;
-      const singlePath = count === 1 ? files?.[0] : undefined;
+      const singlePath = count === 1 ? relativizePath(files?.[0], workspaceRoot) : undefined;
       return {
         summary: count > 0 ? `${count} file${count === 1 ? "" : "s"}` : fallbackTitle,
         label: singlePath ? getFileName(singlePath) ?? singlePath : fallbackTitle,
@@ -785,6 +798,7 @@ function ToolGroup({
   connectorNamesById,
   sessionTabs,
   onSelectSessionTab,
+  workspaceRoot,
 }: {
   tool: string;
   parts: ToolPart[];
@@ -792,6 +806,7 @@ function ToolGroup({
   connectorNamesById?: Record<string, string>;
   sessionTabs: SessionTabInfo[];
   onSelectSessionTab?: (id: string) => void;
+  workspaceRoot?: string;
 }) {
   const runningCount = parts.filter(
     (part) => part.state.status === "running" || part.state.status === "pending"
@@ -856,7 +871,8 @@ function ToolGroup({
     tool,
     lastPart?.state.input,
     getStateTitle(lastPart?.state) || lastPart?.name || toolLabel,
-    connectorNamesById
+    connectorNamesById,
+    workspaceRoot,
   );
   const summary =
     totalCount > 1
@@ -937,7 +953,8 @@ function ToolGroup({
                 tool,
                 part.state.input,
                 getStateTitle(part.state) || part.name,
-                connectorNamesById
+                connectorNamesById,
+                workspaceRoot,
               );
               const title = detail.label || getStateTitle(part.state) || part.name;
 
@@ -1104,6 +1121,7 @@ function MessagePartRenderer({
   onSelectSessionTab,
   part,
   sessionTabs,
+  workspaceRoot,
 }: {
   connectorNamesById: Record<string, string>;
   isPending: boolean;
@@ -1111,6 +1129,7 @@ function MessagePartRenderer({
   onSelectSessionTab?: (id: string) => void;
   part: MessagePart;
   sessionTabs: SessionTabInfo[];
+  workspaceRoot?: string;
 }) {
   switch (part.type) {
     case "text":
@@ -1134,6 +1153,7 @@ function MessagePartRenderer({
           connectorNamesById={connectorNamesById}
           sessionTabs={sessionTabs}
           onSelectSessionTab={onSelectSessionTab}
+          workspaceRoot={workspaceRoot}
         />
       );
 
@@ -1238,6 +1258,7 @@ export function ChatPanelMessages({
   onSelectSessionTab,
   scrollContainerRef,
   sessionTabs,
+  workspaceRoot,
 }: ChatPanelMessagesProps) {
   const showsCenteredState = isStartingNewSession || messages.length === 0;
 
@@ -1304,6 +1325,7 @@ export function ChatPanelMessages({
                                     connectorNamesById={connectorNamesById}
                                     sessionTabs={sessionTabs}
                                     onSelectSessionTab={onSelectSessionTab}
+                                    workspaceRoot={workspaceRoot}
                                   />
                                 );
                               }
@@ -1327,6 +1349,7 @@ export function ChatPanelMessages({
                                   isPending={Boolean(message.pending)}
                                   sessionTabs={sessionTabs}
                                   onSelectSessionTab={onSelectSessionTab}
+                                  workspaceRoot={workspaceRoot}
                                 />
                               );
                             })}

--- a/apps/web/src/components/workspace/chat-panel/messages.tsx
+++ b/apps/web/src/components/workspace/chat-panel/messages.tsx
@@ -44,6 +44,7 @@ import type { ChatMessage } from "@/types/workspace";
 
 type ToolPart = Extract<MessagePart, { type: "tool" }>;
 type FilePart = Extract<MessagePart, { type: "file" }>;
+type TodoItem = { id: string; title: string; status: "pending" | "in_progress" | "completed" };
 
 type ChatPanelMessagesProps = {
   chatContentStyle: CSSProperties;
@@ -134,6 +135,12 @@ const getNumber = (value: unknown) => (typeof value === "number" && Number.isFin
 const getStringArray = (value: unknown) =>
   Array.isArray(value) ? value.map((item) => String(item)) : undefined;
 
+function formatToolName(tool: string): string {
+  const formatted = tool.replace(/[_-]+/g, " ").trim();
+  if (!formatted) return tool;
+  return formatted.charAt(0).toUpperCase() + formatted.slice(1);
+}
+
 const getFileName = (path?: string) => (path ? path.split("/").pop() ?? path : undefined);
 const getDirectory = (path?: string) => {
   if (!path || !path.includes("/")) return undefined;
@@ -208,7 +215,7 @@ function getChatErrorCopy(detail?: string): { title: string; description?: strin
 function getToolLabel(tool: string, connectorNamesById?: Record<string, string>) {
   const toolDisplay = getWorkspaceToolDisplay(tool, connectorNamesById);
   if (toolDisplay.isConnectorTool) return toolDisplay.groupLabel;
-  return TOOL_LABELS[tool] ?? tool;
+  return TOOL_LABELS[tool] ?? formatToolName(tool);
 }
 
 function getToolDisplay(
@@ -507,6 +514,97 @@ function ReasoningBlock({ text, isPending }: { text: string; isPending: boolean 
   );
 }
 
+function parseTodoItems(parts: ToolPart[]): TodoItem[] {
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const todos = parts[i].state.input?.todos;
+    if (Array.isArray(todos)) {
+      return todos
+        .filter(
+          (item): item is { id: string; title: string; status: string } =>
+            typeof item === "object" &&
+            item !== null &&
+            typeof (item as Record<string, unknown>).id === "string" &&
+            typeof (item as Record<string, unknown>).title === "string"
+        )
+        .map((item) => ({
+          id: item.id,
+          title: item.title,
+          status: (["pending", "in_progress", "completed"].includes(item.status)
+            ? item.status
+            : "pending") as TodoItem["status"],
+        }));
+    }
+  }
+  return [];
+}
+
+function TodoCard({ parts }: { parts: ToolPart[] }) {
+  const isRunning = parts.some(
+    (p) => p.state.status === "running" || p.state.status === "pending"
+  );
+  const todos = parseTodoItems(parts);
+
+  if (todos.length === 0) {
+    return (
+      <div className="my-2 rounded-lg border border-border/40 bg-muted/20 px-3 py-2.5">
+        <div className="flex items-center gap-2 text-xs">
+          {isRunning ? (
+            <SpinnerGap size={12} className="animate-spin text-primary" />
+          ) : (
+            <CheckCircle size={12} weight="fill" className="text-primary" />
+          )}
+          <span className="font-medium">Planning</span>
+        </div>
+      </div>
+    );
+  }
+
+  const completedCount = todos.filter((t) => t.status === "completed").length;
+  const inProgressCount = todos.filter((t) => t.status === "in_progress").length;
+
+  return (
+    <div className="my-2 rounded-lg border border-border/40 bg-muted/20">
+      <div className="flex items-center gap-2 px-3 py-2 text-xs">
+        {isRunning ? (
+          <SpinnerGap size={12} className="animate-spin text-primary" />
+        ) : (
+          <CheckCircle size={12} weight="fill" className="text-primary" />
+        )}
+        <span className="font-medium">Planning</span>
+        <span className="text-muted-foreground">
+          {completedCount}/{todos.length} done
+          {inProgressCount > 0 ? ` · ${inProgressCount} in progress` : ""}
+        </span>
+      </div>
+      <div className="border-t border-border/50 px-3 py-2">
+        <div className="space-y-1">
+          {todos.map((todo) => (
+            <div key={todo.id} className="flex items-start gap-2 text-xs">
+              {todo.status === "completed" ? (
+                <CheckCircle size={12} weight="fill" className="mt-0.5 text-primary" />
+              ) : todo.status === "in_progress" ? (
+                <SpinnerGap size={12} className="mt-0.5 animate-spin text-primary" />
+              ) : (
+                <Circle size={12} className="mt-0.5 text-muted-foreground/60" />
+              )}
+              <span
+                className={cn(
+                  "min-w-0 flex-1",
+                  todo.status === "completed"
+                    ? "text-muted-foreground line-through"
+                    : "text-foreground/80"
+                )}
+              >
+                {todo.title}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function DelegationCard({
   parts,
   sessionTabs,
@@ -737,6 +835,10 @@ function ToolGroup({
     if (latestDraft) {
       return <EmailDraftCard draft={latestDraft} isRunning={isRunning} />;
     }
+  }
+
+  if (tool === "todowrite") {
+    return <TodoCard parts={parts} />;
   }
 
   const getStateTitle = (state: ToolPart["state"] | undefined): string | undefined => {
@@ -970,7 +1072,29 @@ function groupMessageParts(parts: MessagePart[]): PartGroup[] {
     index += 1;
   }
 
-  return groups;
+  // Post-merge: coalesce tool-groups with same name separated only by reasoning parts
+  const merged: PartGroup[] = [];
+  for (const group of groups) {
+    if (group.type === "tool-group") {
+      let targetIndex = -1;
+      for (let i = merged.length - 1; i >= 0; i--) {
+        const prev = merged[i];
+        if (prev.type === "single" && prev.part.type === "reasoning") continue;
+        if (prev.type === "tool-group" && prev.tool === group.tool) targetIndex = i;
+        break;
+      }
+      if (targetIndex >= 0) {
+        const target = merged[targetIndex] as { type: "tool-group"; tool: string; parts: ToolPart[] };
+        target.parts.push(...group.parts);
+      } else {
+        merged.push(group);
+      }
+    } else {
+      merged.push(group);
+    }
+  }
+
+  return merged;
 }
 
 function MessagePartRenderer({

--- a/apps/web/src/components/workspace/chat-panel/messages.tsx
+++ b/apps/web/src/components/workspace/chat-panel/messages.tsx
@@ -532,20 +532,23 @@ function parseTodoItems(parts: ToolPart[]): TodoItem[] {
     const todos = parts[i].state.input?.todos;
     if (Array.isArray(todos)) {
       return todos
-        .filter(
-          (item): item is { id: string; title: string; status: string } =>
-            typeof item === "object" &&
-            item !== null &&
-            typeof (item as Record<string, unknown>).id === "string" &&
-            typeof (item as Record<string, unknown>).title === "string"
-        )
-        .map((item) => ({
-          id: item.id,
-          title: item.title,
-          status: (["pending", "in_progress", "completed"].includes(item.status)
-            ? item.status
-            : "pending") as TodoItem["status"],
-        }));
+        .flatMap((item, index) => {
+          if (typeof item !== "object" || item === null) return [];
+
+          const record = item as Record<string, unknown>;
+          const title = getString(record.title) ?? getString(record.content);
+          if (!title) return [];
+
+          const rawStatus = getString(record.status);
+
+          return [{
+            id: getString(record.id) ?? `todo-${index}-${title}`,
+            title,
+            status: (["pending", "in_progress", "completed"].includes(rawStatus ?? "")
+              ? rawStatus
+              : "pending") as TodoItem["status"],
+          }];
+        });
     }
   }
   return [];

--- a/apps/web/src/components/workspace/chat-panel/messages.tsx
+++ b/apps/web/src/components/workspace/chat-panel/messages.tsx
@@ -942,7 +942,7 @@ function ToolGroup({
         </div>
       </button>
 
-      {isOpen ? (
+      {isOpen && canExpand ? (
         <div className="border-t border-border/50 px-3 py-2">
           <div className="space-y-1">
             {parts.map((part) => {

--- a/apps/web/src/components/workspace/chat-panel/messages.tsx
+++ b/apps/web/src/components/workspace/chat-panel/messages.tsx
@@ -1089,29 +1089,7 @@ function groupMessageParts(parts: MessagePart[]): PartGroup[] {
     index += 1;
   }
 
-  // Post-merge: coalesce tool-groups with same name separated only by reasoning parts
-  const merged: PartGroup[] = [];
-  for (const group of groups) {
-    if (group.type === "tool-group") {
-      let targetIndex = -1;
-      for (let i = merged.length - 1; i >= 0; i--) {
-        const prev = merged[i];
-        if (prev.type === "single" && prev.part.type === "reasoning") continue;
-        if (prev.type === "tool-group" && prev.tool === group.tool) targetIndex = i;
-        break;
-      }
-      if (targetIndex >= 0) {
-        const target = merged[targetIndex] as { type: "tool-group"; tool: string; parts: ToolPart[] };
-        target.parts.push(...group.parts);
-      } else {
-        merged.push(group);
-      }
-    } else {
-      merged.push(group);
-    }
-  }
-
-  return merged;
+  return groups;
 }
 
 function MessagePartRenderer({

--- a/apps/web/src/components/workspace/left-panel.tsx
+++ b/apps/web/src/components/workspace/left-panel.tsx
@@ -408,7 +408,7 @@ function MinifiedLeftPanel({
                   "mb-1 flex h-8 w-8 items-center justify-center rounded-lg transition-colors",
                   configRestartError
                     ? "bg-destructive/15 text-destructive hover:bg-destructive/20"
-                    : "bg-amber-500/15 text-amber-700 hover:bg-amber-500/20 dark:text-amber-300",
+                    : "bg-warning/15 text-warning hover:bg-warning/20",
                 )}
                 aria-label="Restart workspace to apply changes"
               >
@@ -1300,7 +1300,7 @@ function ExpandedLeftPanel({
             "shrink-0 rounded-xl border px-3 py-3",
             configRestartError
               ? "border-destructive/30 bg-destructive/10"
-              : "border-amber-500/30 bg-amber-500/10 dark:border-amber-400/30 dark:bg-amber-400/10",
+              : "border-warning/30 bg-warning/10",
           )}
         >
           <div className="flex items-start gap-2">
@@ -1309,7 +1309,7 @@ function ExpandedLeftPanel({
               weight="fill"
               className={cn(
                 "mt-0.5 shrink-0",
-                configRestartError ? "text-destructive" : "text-amber-700 dark:text-amber-300",
+                configRestartError ? "text-destructive" : "text-warning",
               )}
             />
             <div className="min-w-0 flex-1 space-y-2">

--- a/apps/web/src/components/workspace/workspace-shell.tsx
+++ b/apps/web/src/components/workspace/workspace-shell.tsx
@@ -1428,6 +1428,7 @@ export function WorkspaceShell({
           : null
       }
       onPendingInsertConsumed={handlePendingInsertConsumed}
+      workspaceRoot={currentVault ? `${currentVault.path}/workspace` : undefined}
     />
   );
 

--- a/apps/web/src/lib/opencode/__tests__/transform.test.ts
+++ b/apps/web/src/lib/opencode/__tests__/transform.test.ts
@@ -56,4 +56,25 @@ describe('transformParts', () => {
       },
     ])
   })
+
+  it('extracts attachment paths from local desktop file URLs', () => {
+    const parts = transformParts([
+      {
+        type: 'file',
+        id: 'file-1',
+        filename: 'photo.jpg',
+        url: 'file:///Users/alice/Arche/workspace/.arche/attachments/photo.jpg',
+      },
+    ])
+
+    expect(parts).toEqual([
+      {
+        type: 'file',
+        id: 'file-1',
+        path: '.arche/attachments/photo.jpg',
+        filename: 'photo.jpg',
+        url: 'file:///Users/alice/Arche/workspace/.arche/attachments/photo.jpg',
+      },
+    ])
+  })
 })

--- a/apps/web/src/lib/opencode/providers.ts
+++ b/apps/web/src/lib/opencode/providers.ts
@@ -42,7 +42,7 @@ export async function syncProviderAccessForInstance(
         providerId: pid,
       })
       if (!credential) continue
-      enabledByProvider.set(pid, { version: credential.version })
+      enabledByProvider.set(pid, { version: Number(credential.version) })
     }
 
     for (const providerId of PROVIDERS) {

--- a/apps/web/src/lib/opencode/transform.ts
+++ b/apps/web/src/lib/opencode/transform.ts
@@ -1,10 +1,44 @@
 import type { MessagePart, ToolState } from "@/lib/opencode/types";
+import { WORKSPACE_ATTACHMENTS_DIR } from "@/lib/workspace-attachments";
 
 /**
  * Internal-only parts that should be completely hidden.
  * These are OpenCode internals that have no user-facing value.
  */
 const HIDDEN_PART_TYPES = new Set(["snapshot", "compaction"]);
+
+function resolveFilePartPath(sourcePath: string | undefined, fileUrl: string | undefined): string | undefined {
+  if (sourcePath) {
+    return sourcePath;
+  }
+
+  if (!fileUrl?.startsWith("file://")) {
+    return undefined;
+  }
+
+  const candidates: string[] = [];
+  try {
+    candidates.push(decodeURIComponent(new URL(fileUrl).pathname));
+  } catch {
+    // Fall back to the raw URL string below.
+  }
+  candidates.push(fileUrl.slice("file://".length));
+
+  for (const rawCandidate of candidates) {
+    const candidate = rawCandidate.replace(/\\/g, "/");
+    if (candidate.startsWith("/workspace/")) {
+      return candidate.slice("/workspace/".length);
+    }
+
+    const attachmentMarker = `/${WORKSPACE_ATTACHMENTS_DIR}/`;
+    const attachmentIndex = candidate.indexOf(attachmentMarker);
+    if (attachmentIndex >= 0) {
+      return candidate.slice(attachmentIndex + 1);
+    }
+  }
+
+  return undefined;
+}
 
 function normalizeSerializableValue(value: unknown): unknown {
   if (typeof value === "bigint") {
@@ -116,16 +150,7 @@ export function transformParts(parts: unknown[]): MessagePart[] {
               : undefined;
           const fileUrl = part.url ? String(part.url) : undefined;
 
-          let resolvedPath = sourcePath;
-          if (!resolvedPath && fileUrl?.startsWith("file:///workspace/")) {
-            try {
-              resolvedPath = decodeURIComponent(
-                fileUrl.slice("file:///workspace/".length)
-              );
-            } catch {
-              resolvedPath = fileUrl.slice("file:///workspace/".length);
-            }
-          }
+          const resolvedPath = resolveFilePartPath(sourcePath, fileUrl);
           return {
             type: "file" as const,
             id: partId,

--- a/apps/web/src/lib/providers/tokens.ts
+++ b/apps/web/src/lib/providers/tokens.ts
@@ -13,7 +13,9 @@ export type GatewayTokenPayload = {
 export type GatewayTokenInput = Omit<GatewayTokenPayload, 'exp'>
 
 function encodePayload(payload: GatewayTokenPayload): string {
-  return Buffer.from(JSON.stringify(payload)).toString('base64url')
+  return Buffer.from(JSON.stringify(payload, (_key, value) =>
+    typeof value === 'bigint' ? Number(value) : value
+  )).toString('base64url')
 }
 
 function signPayload(encoded: string, secret: string): string {

--- a/apps/web/src/lib/runtime/__tests__/workspace-host-desktop.test.ts
+++ b/apps/web/src/lib/runtime/__tests__/workspace-host-desktop.test.ts
@@ -361,7 +361,10 @@ describe('desktopWorkspaceHost', () => {
       'opencode',
       expect.any(Array),
       expect.objectContaining({
-        env: expect.objectContaining({ OPENCODE_CONFIG_DIR: '/tmp/opencode-config' }),
+        env: expect.objectContaining({
+          OPENCODE_CONFIG_DIR: '/tmp/opencode-config',
+          WORKSPACE_DIR: '/tmp/arche/workspace',
+        }),
       }),
     )
   })

--- a/apps/web/src/lib/runtime/desktop/client.ts
+++ b/apps/web/src/lib/runtime/desktop/client.ts
@@ -20,6 +20,7 @@ type ArcheDesktopBridge = {
   openVaultLauncher: () => Promise<DesktopApiResult>
   pickVaultParentDirectory: () => Promise<string | null>
   quitLauncherProcess: () => Promise<DesktopApiResult>
+  revealAttachmentsDirectory: () => Promise<DesktopApiResult>
 }
 
 type ArcheBridge = {

--- a/apps/web/src/lib/runtime/workspace-host-desktop.ts
+++ b/apps/web/src/lib/runtime/workspace-host-desktop.ts
@@ -395,6 +395,7 @@ export const desktopWorkspaceHost: WorkspaceHost = {
           OPENCODE_SERVER_PASSWORD: password,
           OPENCODE_SERVER_USERNAME: DEFAULT_USERNAME,
           ...(opencodeConfigDir ? { OPENCODE_CONFIG_DIR: opencodeConfigDir } : {}),
+          WORKSPACE_DIR: workspaceDir,
           HOME: archeDataDir,
           XDG_DATA_HOME: join(archeDataDir, '.local', 'share'),
           XDG_STATE_HOME: join(archeDataDir, '.local', 'state'),

--- a/apps/web/tests/chat-stream-attachments.test.ts
+++ b/apps/web/tests/chat-stream-attachments.test.ts
@@ -65,6 +65,9 @@ describe('chat stream attachments forwarding', () => {
     vi.clearAllMocks()
     vi.resetModules()
     delete process.env.ARCHE_RUNTIME_MODE
+    delete process.env.ARCHE_DATA_DIR
+    delete process.env.ARCHE_DESKTOP_PLATFORM
+    delete process.env.ARCHE_DESKTOP_WEB_HOST
 
     mockGetAuthenticatedUser.mockResolvedValue(session('alice'))
     mockFindUnique.mockResolvedValue({
@@ -84,6 +87,9 @@ describe('chat stream attachments forwarding', () => {
 
   afterEach(() => {
     delete process.env.ARCHE_RUNTIME_MODE
+    delete process.env.ARCHE_DATA_DIR
+    delete process.env.ARCHE_DESKTOP_PLATFORM
+    delete process.env.ARCHE_DESKTOP_WEB_HOST
     vi.unstubAllGlobals()
   })
 
@@ -606,6 +612,144 @@ describe('chat stream attachments forwarding', () => {
       mime: 'image/jpeg',
       filename: 'photo.jpg',
       url: 'file:///workspace/.arche/attachments/photo.jpg',
+    })
+  })
+
+  it('uses workspace-relative attachment hints and local file URLs in desktop mode', async () => {
+    process.env.ARCHE_RUNTIME_MODE = 'desktop'
+    process.env.ARCHE_DESKTOP_PLATFORM = 'darwin'
+    process.env.ARCHE_DESKTOP_WEB_HOST = '127.0.0.1'
+    process.env.ARCHE_DATA_DIR = '/tmp/Arche'
+
+    let promptBody: Record<string, unknown> | null = null
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.endsWith('/event')) {
+        return emptyEventStreamResponse()
+      }
+
+      if (url.includes(':4097/files/read')) {
+        return new Response(
+          JSON.stringify({ ok: false, error: 'not_found' }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+
+      if (url.includes('/prompt_async')) {
+        promptBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+        return new Response('prompt_failed', { status: 500 })
+      }
+
+      throw new Error(`Unexpected fetch url: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('@/app/api/w/[slug]/chat/stream/route')
+    const req = new Request('http://localhost/api/w/alice/chat/stream', {
+      method: 'POST',
+      headers: {
+        host: 'localhost',
+        origin: 'http://localhost',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        sessionId: 'session-1',
+        text: 'Describe this',
+        attachments: [
+          {
+            path: '.arche/attachments/photo.jpg',
+            filename: 'photo.jpg',
+            mime: 'image/jpeg',
+          },
+        ],
+      }),
+    })
+
+    const res = await POST(req as never, {
+      params: Promise.resolve({ slug: 'alice' }),
+    })
+
+    expect(res.status).toBe(200)
+    await res.text()
+
+    const promptParts = (promptBody?.parts ?? []) as Array<Record<string, unknown>>
+    expect(promptParts[1]).toEqual({
+      type: 'file',
+      mime: 'image/jpeg',
+      filename: 'photo.jpg',
+      url: 'file:///tmp/Arche/workspace/.arche/attachments/photo.jpg',
+    })
+    expect(promptParts[2]).toEqual({
+      type: 'text',
+      text:
+        'Attached workspace files:\n- .arche/attachments/photo.jpg\nIf direct file parsing is unavailable, inspect these paths with available tools.',
+    })
+  })
+
+  it('uses workspace-relative spreadsheet hints in desktop mode', async () => {
+    process.env.ARCHE_RUNTIME_MODE = 'desktop'
+    process.env.ARCHE_DESKTOP_PLATFORM = 'darwin'
+    process.env.ARCHE_DESKTOP_WEB_HOST = '127.0.0.1'
+    process.env.ARCHE_DATA_DIR = '/tmp/Arche'
+
+    let promptBody: Record<string, unknown> | null = null
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.endsWith('/event')) {
+        return emptyEventStreamResponse()
+      }
+
+      if (url.includes('/prompt_async')) {
+        promptBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+        return new Response('prompt_failed', { status: 500 })
+      }
+
+      throw new Error(`Unexpected fetch url: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('@/app/api/w/[slug]/chat/stream/route')
+    const req = new Request('http://localhost/api/w/alice/chat/stream', {
+      method: 'POST',
+      headers: {
+        host: 'localhost',
+        origin: 'http://localhost',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        sessionId: 'session-1',
+        text: 'Analyze attached data',
+        attachments: [
+          {
+            path: '.arche/attachments/sales.xlsx',
+            filename: 'sales.xlsx',
+            mime: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          },
+        ],
+      }),
+    })
+
+    const res = await POST(req as never, {
+      params: Promise.resolve({ slug: 'alice' }),
+    })
+
+    expect(res.status).toBe(200)
+    await res.text()
+
+    const promptParts = (promptBody?.parts ?? []) as Array<Record<string, unknown>>
+    expect(promptParts[1]).toEqual({
+      type: 'text',
+      text:
+        'Attached spreadsheet file: .arche/attachments/sales.xlsx\nYou must use spreadsheet_inspect first to detect sheets and columns, then use spreadsheet_sample/spreadsheet_query/spreadsheet_stats for focused analysis and calculations.',
+    })
+    expect(promptParts[2]).toEqual({
+      type: 'text',
+      text:
+        'Attached workspace files:\n- .arche/attachments/sales.xlsx\nIf direct file parsing is unavailable, inspect these paths with available tools.',
     })
   })
 

--- a/apps/web/tests/chat-stream-attachments.test.ts
+++ b/apps/web/tests/chat-stream-attachments.test.ts
@@ -1475,6 +1475,81 @@ describe('chat stream attachments forwarding', () => {
     expect(sseOutput).not.toContain('stream_timeout')
   })
 
+  it('does not emit done for silent resume streams that only idle via the watchdog', async () => {
+    vi.useFakeTimers()
+    let statusChecks = 0
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/session/status')) {
+        statusChecks += 1
+        return new Response(
+          JSON.stringify({
+            'session-1': { type: 'idle' },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+
+      if (url.endsWith('/event')) {
+        let lateEventTimer: ReturnType<typeof setTimeout> | null = null
+
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            lateEventTimer = setTimeout(() => {
+              controller.close()
+            }, 30_000)
+          },
+          cancel() {
+            if (lateEventTimer) {
+              clearTimeout(lateEventTimer)
+            }
+          },
+        })
+
+        return new Response(body, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        })
+      }
+
+      throw new Error(`Unexpected fetch url: ${url}`)
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('@/app/api/w/[slug]/chat/stream/route')
+    const req = new Request('http://localhost/api/w/alice/chat/stream', {
+      method: 'POST',
+      headers: {
+        host: 'localhost',
+        origin: 'http://localhost',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        sessionId: 'session-1',
+        resume: true,
+        messageId: 'msg-assistant',
+      }),
+    })
+
+    const res = await POST(req as never, {
+      params: Promise.resolve({ slug: 'alice' }),
+    })
+
+    expect(res.status).toBe(200)
+
+    const textPromise = res.text()
+    await vi.advanceTimersByTimeAsync(30_500)
+    const sseOutput = await textPromise
+
+    expect(statusChecks).toBeGreaterThanOrEqual(1)
+    expect(sseOutput).toContain('event: error')
+    expect(sseOutput).toContain('resume_incomplete')
+    expect(sseOutput).not.toContain('event: done')
+  })
+
   it('does not ignore post-response fetch failed session errors in desktop mode', async () => {
     process.env.ARCHE_RUNTIME_MODE = 'desktop'
     process.env.ARCHE_DESKTOP_PLATFORM = 'darwin'

--- a/apps/web/tests/chat-stream-attachments.test.ts
+++ b/apps/web/tests/chat-stream-attachments.test.ts
@@ -90,6 +90,7 @@ describe('chat stream attachments forwarding', () => {
     delete process.env.ARCHE_DATA_DIR
     delete process.env.ARCHE_DESKTOP_PLATFORM
     delete process.env.ARCHE_DESKTOP_WEB_HOST
+    vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
@@ -1386,6 +1387,92 @@ describe('chat stream attachments forwarding', () => {
     expect(sseOutput).toContain('event: part')
     expect(sseOutput).toContain('event: done')
     expect(sseOutput).not.toContain('stream_incomplete')
+  })
+
+  it('does not emit stream_timeout while the upstream session is still busy', async () => {
+    vi.useFakeTimers()
+    const encoder = new TextEncoder()
+    let statusChecks = 0
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.includes('/prompt_async')) {
+        return new Response(null, { status: 204 })
+      }
+
+      if (url.endsWith('/session/status')) {
+        statusChecks += 1
+        return new Response(
+          JSON.stringify({
+            'session-1': { type: 'busy' },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+
+      if (url.endsWith('/event')) {
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            setTimeout(() => {
+              controller.enqueue(
+                encoder.encode(
+                  [
+                    'event: message',
+                    'data: {"type":"message.updated","properties":{"info":{"id":"msg-assistant","role":"assistant","sessionID":"session-1"}}}',
+                    '',
+                    'event: message',
+                    'data: {"type":"message.part.updated","properties":{"part":{"id":"part-1","type":"text","text":"Hello","messageID":"msg-assistant","sessionID":"session-1"},"delta":"Hello"}}',
+                    '',
+                    'event: message',
+                    'data: {"type":"session.status","properties":{"status":{"type":"idle"},"sessionID":"session-1"}}',
+                    '',
+                    '',
+                  ].join('\n'),
+                ),
+              )
+              controller.close()
+            }, 22_000)
+          },
+        })
+
+        return new Response(body, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        })
+      }
+
+      throw new Error(`Unexpected fetch url: ${url}`)
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('@/app/api/w/[slug]/chat/stream/route')
+    const req = new Request('http://localhost/api/w/alice/chat/stream', {
+      method: 'POST',
+      headers: {
+        host: 'localhost',
+        origin: 'http://localhost',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        sessionId: 'session-1',
+        text: 'hello',
+      }),
+    })
+
+    const res = await POST(req as never, {
+      params: Promise.resolve({ slug: 'alice' }),
+    })
+
+    const textPromise = res.text()
+    await vi.advanceTimersByTimeAsync(22_500)
+    const sseOutput = await textPromise
+
+    expect(statusChecks).toBeGreaterThanOrEqual(1)
+    expect(sseOutput).toContain('event: part')
+    expect(sseOutput).toContain('event: done')
+    expect(sseOutput).not.toContain('stream_timeout')
   })
 
   it('does not ignore post-response fetch failed session errors in desktop mode', async () => {

--- a/apps/web/tests/chat-stream-attachments.test.ts
+++ b/apps/web/tests/chat-stream-attachments.test.ts
@@ -1432,7 +1432,7 @@ describe('chat stream attachments forwarding', () => {
                 ),
               )
               controller.close()
-            }, 22_000)
+            }, 45_000)
           },
         })
 
@@ -1466,10 +1466,10 @@ describe('chat stream attachments forwarding', () => {
     })
 
     const textPromise = res.text()
-    await vi.advanceTimersByTimeAsync(22_500)
+    await vi.advanceTimersByTimeAsync(45_500)
     const sseOutput = await textPromise
 
-    expect(statusChecks).toBeGreaterThanOrEqual(1)
+    expect(statusChecks).toBeGreaterThanOrEqual(2)
     expect(sseOutput).toContain('event: part')
     expect(sseOutput).toContain('event: done')
     expect(sseOutput).not.toContain('stream_timeout')

--- a/infra/compose/compose.yaml
+++ b/infra/compose/compose.yaml
@@ -52,6 +52,27 @@ services:
       POSTGRES_DB: arche
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+    command:
+      - sh
+      - -lc
+      - |
+        set -eu
+        export PATH="/usr/lib/postgresql/$$PG_MAJOR/bin:$$PATH"
+        pid=''
+        cleanup() {
+          if [ -n "$$pid" ]; then
+            kill -TERM "$$pid" 2>/dev/null || true
+            wait "$$pid" || true
+          fi
+        }
+        trap cleanup INT TERM HUP
+        docker-entrypoint.sh postgres &
+        pid="$$!"
+        until gosu postgres pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB" >/dev/null 2>&1; do
+          sleep 1
+        done
+        gosu postgres psql -v ON_ERROR_STOP=1 -U "$$POSTGRES_USER" -d "$$POSTGRES_DB" -c "ALTER USER \"$$POSTGRES_USER\" PASSWORD '$$POSTGRES_PASSWORD';"
+        wait "$$pid"
     ports:
       - 5432:5432
     volumes:

--- a/infra/workspace-image/opencode-config/tests/spreadsheet.test.js
+++ b/infra/workspace-image/opencode-config/tests/spreadsheet.test.js
@@ -1,4 +1,4 @@
-import test from 'node:test'
+import test, { after } from 'node:test'
 import assert from 'node:assert/strict'
 import fs from 'node:fs/promises'
 
@@ -6,7 +6,19 @@ import * as XLSX from 'xlsx'
 
 import { inspect, query, resolveSpreadsheetPath, sample, stats } from '../tools/spreadsheet.js'
 
-const FIXTURE_DIR = '/workspace/.arche/attachments'
+const originalWorkspaceDir = process.env.WORKSPACE_DIR
+process.env.WORKSPACE_DIR = '/workspace'
+
+after(() => {
+  if (originalWorkspaceDir === undefined) {
+    delete process.env.WORKSPACE_DIR
+    return
+  }
+
+  process.env.WORKSPACE_DIR = originalWorkspaceDir
+})
+
+const FIXTURE_DIR = `${process.env.WORKSPACE_DIR}/.arche/attachments`
 const FIXTURE_PATH = `${FIXTURE_DIR}/spreadsheet-test.xlsx`
 
 async function ensureFixture() {

--- a/infra/workspace-image/opencode-config/tests/spreadsheet.test.js
+++ b/infra/workspace-image/opencode-config/tests/spreadsheet.test.js
@@ -60,6 +60,25 @@ test('resolveSpreadsheetPath enforces .arche/attachments boundary', () => {
   })
 })
 
+test('resolveSpreadsheetPath falls back to /workspace when WORKSPACE_DIR is unset', () => {
+  const previousWorkspaceDir = process.env.WORKSPACE_DIR
+  delete process.env.WORKSPACE_DIR
+
+  try {
+    assert.deepEqual(resolveSpreadsheetPath('.arche/attachments/fallback.xlsx'), {
+      ok: true,
+      path: '/workspace/.arche/attachments/fallback.xlsx',
+    })
+  } finally {
+    if (previousWorkspaceDir === undefined) {
+      delete process.env.WORKSPACE_DIR
+      return
+    }
+
+    process.env.WORKSPACE_DIR = previousWorkspaceDir
+  }
+})
+
 test('spreadsheet tools smoke test', async (t) => {
   try {
     await ensureFixture()

--- a/infra/workspace-image/opencode-config/tools/spreadsheet.js
+++ b/infra/workspace-image/opencode-config/tools/spreadsheet.js
@@ -1,15 +1,22 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import * as XLSX from 'xlsx'
 import { z } from 'zod'
 
-const WORKSPACE_ROOT = '/workspace'
-const ATTACHMENTS_PREFIX = '/workspace/.arche/attachments/'
 const MAX_FILE_BYTES = 25 * 1024 * 1024
 const MAX_SAMPLE_LIMIT = 500
 const MAX_QUERY_LIMIT = 1000
 const MAX_COLUMN_COUNT = 200
+
+function getWorkspaceRoot() {
+  return path.resolve(process.env.WORKSPACE_DIR?.trim() || process.cwd())
+}
+
+function getAttachmentsRoot() {
+  return path.join(getWorkspaceRoot(), '.arche', 'attachments')
+}
 
 function toToolOutput(value) {
   return JSON.stringify(value, null, 2)
@@ -19,20 +26,37 @@ function normalizeAttachmentPath(inputPath) {
   const trimmed = String(inputPath || '').trim()
   if (!trimmed) return null
 
+  if (trimmed.startsWith('file://')) {
+    try {
+      return path.resolve(fileURLToPath(trimmed))
+    } catch {
+      return null
+    }
+  }
+
   const normalized = trimmed.replace(/\\/g, '/')
   if (normalized.startsWith('/workspace/')) {
-    return normalized
+    return path.resolve(getWorkspaceRoot(), normalized.slice('/workspace/'.length))
+  }
+
+  if (path.isAbsolute(trimmed)) {
+    return path.resolve(trimmed)
   }
 
   const relative = normalized.replace(/^\.\//, '').replace(/^\/+/, '')
-  return path.posix.join(WORKSPACE_ROOT, relative)
+  return path.resolve(getWorkspaceRoot(), relative)
 }
 
 export function resolveSpreadsheetPath(inputPath) {
   const candidate = normalizeAttachmentPath(inputPath)
   if (!candidate) return { ok: false, error: 'invalid_path' }
-  const absolute = path.posix.normalize(candidate)
-  if (!absolute.startsWith(ATTACHMENTS_PREFIX)) {
+  const absolute = path.resolve(candidate)
+  const relativeToAttachments = path.relative(getAttachmentsRoot(), absolute)
+  if (
+    relativeToAttachments === '..' ||
+    relativeToAttachments.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeToAttachments)
+  ) {
     return { ok: false, error: 'path_outside_attachments' }
   }
   return { ok: true, path: absolute }

--- a/infra/workspace-image/opencode-config/tools/spreadsheet.js
+++ b/infra/workspace-image/opencode-config/tools/spreadsheet.js
@@ -9,9 +9,10 @@ const MAX_FILE_BYTES = 25 * 1024 * 1024
 const MAX_SAMPLE_LIMIT = 500
 const MAX_QUERY_LIMIT = 1000
 const MAX_COLUMN_COUNT = 200
+const DEFAULT_WORKSPACE_ROOT = '/workspace'
 
 function getWorkspaceRoot() {
-  return path.resolve(process.env.WORKSPACE_DIR?.trim() || process.cwd())
+  return path.resolve(process.env.WORKSPACE_DIR?.trim() || DEFAULT_WORKSPACE_ROOT)
 }
 
 function getAttachmentsRoot() {


### PR DESCRIPTION
## Summary
- stop emitting container-only `/workspace/...` attachment references in desktop mode and switch desktop file parts to real local `file://` URLs
- keep hidden attachments where they are, but add a desktop-only `Reveal in Finder` / `Reveal in File Explorer` action in the attachments dialog
- make spreadsheet attachment resolution runtime-aware and add coverage for desktop attachment prompts, transform normalization, desktop bridge wiring, and reveal UI

## Validation
- `pnpm test` in `apps/web`
- `pnpm lint` in `apps/web`
- `pnpm test` in `apps/desktop`
- `node --test tests/spreadsheet.test.js` in `infra/workspace-image/opencode-config`