### PR TITLE
fix(workspace): keep attachment paths canonical in prompts

### DIFF
--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -354,7 +354,7 @@ export const POST = withAuth(
         if (!resume) {
           const promptParts: Array<
             { type: 'text'; text: string } |
-            { type: 'file'; mime: string; filename?: string; url: string }
+            { type: 'file'; path: string; mime: string; filename?: string; url: string }
           > = []
 
           if (typeof text === 'string' && text.trim().length > 0) {
@@ -445,6 +445,7 @@ export const POST = withAuth(
                   const base64 = imageBytes.toString('base64')
                   promptParts.push({
                     type: 'file',
+                    path: attachmentPath,
                     mime,
                     filename: fileName,
                     url: `data:${mime};base64,${base64}`,
@@ -452,6 +453,7 @@ export const POST = withAuth(
                 } else {
                   promptParts.push({
                     type: 'file',
+                    path: attachmentPath,
                     mime,
                     filename: fileName,
                     url: toWorkspaceFileUrl(attachmentPath),
@@ -464,6 +466,7 @@ export const POST = withAuth(
 
               promptParts.push({
                 type: 'file',
+                path: attachmentPath,
                 mime,
                 filename: fileName,
                 url: toWorkspaceFileUrl(attachmentPath),

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -1,6 +1,3 @@
-import { join } from 'path'
-import { pathToFileURL } from 'url'
-
 import { NextRequest, NextResponse } from 'next/server'
 
 import { getIdleFinalizationOutcome, getSilentStreamOutcome } from '@/app/api/w/[slug]/chat/stream/watchdog'
@@ -8,7 +5,6 @@ import { createUpstreamSessionStatusReader } from '@/app/api/w/[slug]/chat/strea
 import { extractPdfText, isPdfMime } from '@/lib/attachments/pdf-text-extractor'
 import { getInstanceUrl } from '@/lib/opencode/client'
 import { normalizeProviderId, resolveRuntimeProviderId } from '@/lib/providers/catalog'
-import { DESKTOP_WORKSPACE_DIR_NAME } from '@/lib/runtime/desktop/vault-layout-constants'
 import { isDesktop } from '@/lib/runtime/mode'
 import { withAuth } from '@/lib/runtime/with-auth'
 import { instanceService } from '@/lib/services'
@@ -129,23 +125,6 @@ async function readWorkspaceImageAttachment(
   if (!decoded || decoded.length === 0) return null
   if (decoded.length > MAX_IMAGE_BYTES_FOR_INLINE) return null
   return decoded
-}
-
-function toWorkspaceFileUrl(path: string): string {
-  const normalized = normalizeAttachmentPath(path)
-
-  if (isDesktop()) {
-    const vaultRoot = process.env.ARCHE_DATA_DIR?.trim()
-    if (vaultRoot) {
-      return pathToFileURL(join(vaultRoot, DESKTOP_WORKSPACE_DIR_NAME, ...normalized.split('/'))).toString()
-    }
-  }
-
-  const encodedPath = normalized
-    .split('/')
-    .map((segment) => encodeURIComponent(segment))
-    .join('/')
-  return `file:///workspace/${encodedPath}`
 }
 
 function toAttachmentPromptPath(path: string): string {
@@ -354,7 +333,7 @@ export const POST = withAuth(
         if (!resume) {
           const promptParts: Array<
             { type: 'text'; text: string } |
-            { type: 'file'; path: string; mime: string; filename?: string; url: string }
+            { type: 'file'; mime: string; filename?: string; url: string }
           > = []
 
           if (typeof text === 'string' && text.trim().length > 0) {
@@ -445,32 +424,15 @@ export const POST = withAuth(
                   const base64 = imageBytes.toString('base64')
                   promptParts.push({
                     type: 'file',
-                    path: attachmentPath,
                     mime,
                     filename: fileName,
                     url: `data:${mime};base64,${base64}`,
-                  })
-                } else {
-                  promptParts.push({
-                    type: 'file',
-                    path: attachmentPath,
-                    mime,
-                    filename: fileName,
-                    url: toWorkspaceFileUrl(attachmentPath),
                   })
                 }
 
                 attachmentPathsForHint.push(attachmentPath)
                 continue
               }
-
-              promptParts.push({
-                type: 'file',
-                path: attachmentPath,
-                mime,
-                filename: fileName,
-                url: toWorkspaceFileUrl(attachmentPath),
-              })
 
               attachmentPathsForHint.push(attachmentPath)
             }

--- a/apps/web/src/lib/opencode/__tests__/transform.test.ts
+++ b/apps/web/src/lib/opencode/__tests__/transform.test.ts
@@ -77,4 +77,26 @@ describe('transformParts', () => {
       },
     ])
   })
+
+  it('prefers canonical file paths over absolute file URLs', () => {
+    const parts = transformParts([
+      {
+        type: 'file',
+        id: 'file-2',
+        path: '.arche/attachments/photo.jpg',
+        filename: 'photo.jpg',
+        url: 'file:///Users/alice/Arche/workspace/.arche/attachments/photo.jpg',
+      },
+    ])
+
+    expect(parts).toEqual([
+      {
+        type: 'file',
+        id: 'file-2',
+        path: '.arche/attachments/photo.jpg',
+        filename: 'photo.jpg',
+        url: 'file:///Users/alice/Arche/workspace/.arche/attachments/photo.jpg',
+      },
+    ])
+  })
 })

--- a/apps/web/src/lib/opencode/__tests__/transform.test.ts
+++ b/apps/web/src/lib/opencode/__tests__/transform.test.ts
@@ -77,26 +77,4 @@ describe('transformParts', () => {
       },
     ])
   })
-
-  it('prefers canonical file paths over absolute file URLs', () => {
-    const parts = transformParts([
-      {
-        type: 'file',
-        id: 'file-2',
-        path: '.arche/attachments/photo.jpg',
-        filename: 'photo.jpg',
-        url: 'file:///Users/alice/Arche/workspace/.arche/attachments/photo.jpg',
-      },
-    ])
-
-    expect(parts).toEqual([
-      {
-        type: 'file',
-        id: 'file-2',
-        path: '.arche/attachments/photo.jpg',
-        filename: 'photo.jpg',
-        url: 'file:///Users/alice/Arche/workspace/.arche/attachments/photo.jpg',
-      },
-    ])
-  })
 })

--- a/apps/web/tests/chat-stream-attachments.test.ts
+++ b/apps/web/tests/chat-stream-attachments.test.ts
@@ -541,6 +541,7 @@ describe('chat stream attachments forwarding', () => {
     })
     expect(promptParts[1]).toEqual({
       type: 'file',
+      path: '.arche/attachments/screenshot.png',
       mime: 'image/png',
       filename: 'screenshot.png',
       url: `data:image/png;base64,${fakeImageBytes.toString('base64')}`,
@@ -610,6 +611,7 @@ describe('chat stream attachments forwarding', () => {
     const promptParts = (promptBody?.parts ?? []) as Array<Record<string, unknown>>
     expect(promptParts[1]).toEqual({
       type: 'file',
+      path: '.arche/attachments/photo.jpg',
       mime: 'image/jpeg',
       filename: 'photo.jpg',
       url: 'file:///workspace/.arche/attachments/photo.jpg',
@@ -678,6 +680,7 @@ describe('chat stream attachments forwarding', () => {
     const promptParts = (promptBody?.parts ?? []) as Array<Record<string, unknown>>
     expect(promptParts[1]).toEqual({
       type: 'file',
+      path: '.arche/attachments/photo.jpg',
       mime: 'image/jpeg',
       filename: 'photo.jpg',
       url: 'file:///tmp/Arche/workspace/.arche/attachments/photo.jpg',

--- a/apps/web/tests/chat-stream-attachments.test.ts
+++ b/apps/web/tests/chat-stream-attachments.test.ts
@@ -361,7 +361,7 @@ describe('chat stream attachments forwarding', () => {
     })
   })
 
-  it('normalizes unsupported octet-stream mime to safe fallback', async () => {
+  it('routes unsupported octet-stream attachments through the hint only', async () => {
     let promptBody: Record<string, unknown> | null = null
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -409,7 +409,13 @@ describe('chat stream attachments forwarding', () => {
     await res.text()
 
     const promptParts = (promptBody?.parts ?? []) as Array<Record<string, unknown>>
-    expect(promptParts[1].mime).toBe('text/plain')
+    expect(promptParts).toHaveLength(2)
+    expect(promptParts[1]).toEqual({
+      type: 'text',
+      text:
+        'Attached workspace files:\n- /workspace/.arche/attachments/blob.unknown\nIf direct file parsing is unavailable, inspect these paths with available tools.',
+    })
+    expect(JSON.stringify(promptBody)).not.toContain('file://')
   })
 
   it('routes spreadsheet attachments to spreadsheet tools hints', async () => {
@@ -541,7 +547,6 @@ describe('chat stream attachments forwarding', () => {
     })
     expect(promptParts[1]).toEqual({
       type: 'file',
-      path: '.arche/attachments/screenshot.png',
       mime: 'image/png',
       filename: 'screenshot.png',
       url: `data:image/png;base64,${fakeImageBytes.toString('base64')}`,
@@ -553,7 +558,7 @@ describe('chat stream attachments forwarding', () => {
     })
   })
 
-  it('falls back to file URL when image read fails', async () => {
+  it('omits the file part and relies on the workspace-relative hint when image read fails', async () => {
     let promptBody: Record<string, unknown> | null = null
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -609,16 +614,19 @@ describe('chat stream attachments forwarding', () => {
 
     expect(promptBody).not.toBeNull()
     const promptParts = (promptBody?.parts ?? []) as Array<Record<string, unknown>>
+    expect(promptParts).toHaveLength(2)
+    expect(promptParts[0]).toEqual({ type: 'text', text: 'Describe this' })
     expect(promptParts[1]).toEqual({
-      type: 'file',
-      path: '.arche/attachments/photo.jpg',
-      mime: 'image/jpeg',
-      filename: 'photo.jpg',
-      url: 'file:///workspace/.arche/attachments/photo.jpg',
+      type: 'text',
+      text:
+        'Attached workspace files:\n- /workspace/.arche/attachments/photo.jpg\nIf direct file parsing is unavailable, inspect these paths with available tools.',
     })
+    for (const part of promptParts) {
+      expect(JSON.stringify(part)).not.toContain('file://')
+    }
   })
 
-  it('uses workspace-relative attachment hints and local file URLs in desktop mode', async () => {
+  it('never leaks absolute vault paths in desktop mode when image read fails', async () => {
     process.env.ARCHE_RUNTIME_MODE = 'desktop'
     process.env.ARCHE_DESKTOP_PLATFORM = 'darwin'
     process.env.ARCHE_DESKTOP_WEB_HOST = '127.0.0.1'
@@ -678,18 +686,97 @@ describe('chat stream attachments forwarding', () => {
     await res.text()
 
     const promptParts = (promptBody?.parts ?? []) as Array<Record<string, unknown>>
+    expect(promptParts).toHaveLength(2)
     expect(promptParts[1]).toEqual({
-      type: 'file',
-      path: '.arche/attachments/photo.jpg',
-      mime: 'image/jpeg',
-      filename: 'photo.jpg',
-      url: 'file:///tmp/Arche/workspace/.arche/attachments/photo.jpg',
-    })
-    expect(promptParts[2]).toEqual({
       type: 'text',
       text:
         'Attached workspace files:\n- .arche/attachments/photo.jpg\nIf direct file parsing is unavailable, inspect these paths with available tools.',
     })
+    const serialized = JSON.stringify(promptBody)
+    expect(serialized).not.toContain('file://')
+    expect(serialized).not.toContain('/tmp/Arche')
+  })
+
+  it('inlines images as data URLs in desktop mode without leaking vault paths', async () => {
+    process.env.ARCHE_RUNTIME_MODE = 'desktop'
+    process.env.ARCHE_DESKTOP_PLATFORM = 'darwin'
+    process.env.ARCHE_DESKTOP_WEB_HOST = '127.0.0.1'
+    process.env.ARCHE_DATA_DIR = '/tmp/Arche'
+
+    let promptBody: Record<string, unknown> | null = null
+    const fakeImageBytes = Buffer.from('fake-png-content')
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.endsWith('/event')) {
+        return emptyEventStreamResponse()
+      }
+
+      if (url.includes(':4097/files/read')) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            content: fakeImageBytes.toString('base64'),
+            encoding: 'base64',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+
+      if (url.includes('/prompt_async')) {
+        promptBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+        return new Response('prompt_failed', { status: 500 })
+      }
+
+      throw new Error(`Unexpected fetch url: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('@/app/api/w/[slug]/chat/stream/route')
+    const req = new Request('http://localhost/api/w/alice/chat/stream', {
+      method: 'POST',
+      headers: {
+        host: 'localhost',
+        origin: 'http://localhost',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        sessionId: 'session-1',
+        text: 'What does this image show?',
+        attachments: [
+          {
+            path: '.arche/attachments/screenshot.png',
+            filename: 'screenshot.png',
+            mime: 'image/png',
+          },
+        ],
+      }),
+    })
+
+    const res = await POST(req as never, {
+      params: Promise.resolve({ slug: 'alice' }),
+    })
+
+    expect(res.status).toBe(200)
+    await res.text()
+
+    const promptParts = (promptBody?.parts ?? []) as Array<Record<string, unknown>>
+    expect(promptParts).toHaveLength(3)
+    expect(promptParts[1]).toEqual({
+      type: 'file',
+      mime: 'image/png',
+      filename: 'screenshot.png',
+      url: `data:image/png;base64,${fakeImageBytes.toString('base64')}`,
+    })
+    expect(promptParts[2]).toEqual({
+      type: 'text',
+      text:
+        'Attached workspace files:\n- .arche/attachments/screenshot.png\nIf direct file parsing is unavailable, inspect these paths with available tools.',
+    })
+    const serialized = JSON.stringify(promptBody)
+    expect(serialized).not.toContain('file://')
+    expect(serialized).not.toContain('/tmp/Arche')
   })
 
   it('uses workspace-relative spreadsheet hints in desktop mode', async () => {


### PR DESCRIPTION
## Summary
- preserve the workspace-relative attachment path in chat `file` parts instead of relying only on transport URLs
- prevent desktop sessions from reusing absolute vault paths from earlier attachments when they later inspect the knowledge base
- cover the canonical-path behavior with chat stream and OpenCode transform regressions

## Verification
- pnpm test
- pnpm lint
- bash scripts/check-podman-images.sh