### PR TITLE
fix(workspace): stream attachment uploads to avoid body limits

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -69,3 +69,39 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  desktop-workspace-smoke:
+    name: Desktop - Workspace Smoke
+    runs-on: macos-14
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install web dependencies
+        working-directory: apps/web
+        run: pnpm install --frozen-lockfile
+
+      - name: Refresh web native modules
+        working-directory: apps/web
+        run: pnpm rebuild argon2 better-sqlite3
+
+      - name: Install desktop dependencies
+        working-directory: apps/desktop
+        run: pnpm install --frozen-lockfile
+
+      - name: Run desktop workspace smoke test
+        working-directory: apps/desktop
+        env:
+          CI: true
+        run: pnpm test:smoke

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,6 +9,7 @@
     "prepare:runtime": "bash ../../scripts/prepare-desktop-runtime.sh",
     "dev": "pnpm prepare:runtime && tsc && electron dist/main.js",
     "build": "tsc",
+    "test:smoke": "pnpm build && node --test tests/desktop-workspace-smoke.test.js",
     "test": "pnpm build && node --test tests/create-vault.test.js tests/desktop-encryption-key.test.js tests/desktop-next-dist.test.js tests/runtime-supervisor.test.js tests/runtime-binaries.test.js tests/runtime-network.test.js tests/vault-manifest.test.js tests/vault-registry.test.js tests/vault-lock.test.js tests/vault-layout.test.js tests/vault-launch.test.js",
     "start": "electron dist/main.js",
     "pack": "pnpm prepare:runtime && electron-builder --dir --config electron-builder.config.js",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -39,6 +39,7 @@ import {
 import { createVaultManifest, tryReadVault, type DesktopVault } from './vault-manifest'
 
 const DEFAULT_DESKTOP_WEB_PORT = 3000
+const DEFAULT_SMOKE_TEST_TIMEOUT_MS = 90_000
 const LOOPBACK_HOST = '127.0.0.1'
 const DESKTOP_TOKEN_HEADER = 'x-arche-desktop-token'
 const DESKTOP_GIT_AUTHOR_NAME = 'Arche Workspace'
@@ -53,6 +54,119 @@ let gatewayTokenSecret = ''
 let launchContext: DesktopLaunchContext = { mode: 'launcher', vaultPath: null }
 let currentVault: DesktopVault | null = null
 let vaultLock: VaultLockHandle | null = null
+let smokeTestFinished = false
+let smokeTestTimer: NodeJS.Timeout | null = null
+
+function isSmokeTestEnabled(): boolean {
+  return process.env.ARCHE_DESKTOP_SMOKE_TEST === '1'
+}
+
+function getSmokeTestExpectedPath(): string {
+  const expectedPath = process.env.ARCHE_DESKTOP_SMOKE_TEST_EXPECTED_PATH?.trim()
+  return expectedPath || '/w/local'
+}
+
+function getSmokeTestTimeoutMs(): number {
+  const raw = process.env.ARCHE_DESKTOP_SMOKE_TEST_TIMEOUT_MS
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_SMOKE_TEST_TIMEOUT_MS
+  }
+
+  return parsed
+}
+
+function writeSmokeTestLog(message: string, stream: 'stdout' | 'stderr' = 'stdout'): void {
+  process[stream].write(`[desktop-smoke] ${message}\n`)
+}
+
+function completeSmokeTest(ok: boolean, message: string): void {
+  if (!isSmokeTestEnabled() || smokeTestFinished) {
+    return
+  }
+
+  smokeTestFinished = true
+  if (smokeTestTimer) {
+    clearTimeout(smokeTestTimer)
+    smokeTestTimer = null
+  }
+
+  process.exitCode = ok ? 0 : 1
+  writeSmokeTestLog(message, ok ? 'stdout' : 'stderr')
+  app.quit()
+}
+
+function showDesktopError(title: string, message: string): boolean {
+  if (isSmokeTestEnabled()) {
+    completeSmokeTest(false, message)
+    return true
+  }
+
+  dialog.showErrorBox(title, message)
+  return false
+}
+
+async function evaluateSmokeTestWindow(window: BrowserWindow): Promise<void> {
+  if (!isSmokeTestEnabled() || smokeTestFinished || window.isDestroyed()) {
+    return
+  }
+
+  try {
+    const state = await window.webContents.executeJavaScript(
+      `({ pathname: window.location.pathname, isDesktop: Boolean(window.arche?.isDesktop) })`,
+      true,
+    )
+
+    const pathname = typeof state?.pathname === 'string' ? state.pathname : 'unknown'
+    const isDesktop = state?.isDesktop === true
+    const expectedPath = getSmokeTestExpectedPath()
+
+    if (pathname === expectedPath && isDesktop) {
+      completeSmokeTest(true, `success path=${pathname}`)
+      return
+    }
+
+    writeSmokeTestLog(`waiting expected=${expectedPath} current=${pathname} desktop=${String(isDesktop)}`)
+  } catch (error) {
+    completeSmokeTest(
+      false,
+      `window evaluation failed: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}
+
+function installSmokeTestHooks(window: BrowserWindow): void {
+  if (!isSmokeTestEnabled() || smokeTestTimer) {
+    return
+  }
+
+  const timeoutMs = getSmokeTestTimeoutMs()
+  smokeTestTimer = setTimeout(() => {
+    completeSmokeTest(false, `timeout after ${timeoutMs}ms waiting for ${getSmokeTestExpectedPath()}`)
+  }, timeoutMs)
+
+  window.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+    if (!isMainFrame) {
+      return
+    }
+
+    completeSmokeTest(
+      false,
+      `did-fail-load code=${String(errorCode)} url=${validatedURL} error=${errorDescription}`,
+    )
+  })
+
+  window.webContents.on('render-process-gone', (_event, details) => {
+    completeSmokeTest(
+      false,
+      `render-process-gone reason=${details.reason} exitCode=${String(details.exitCode)}`,
+    )
+  })
+
+  window.webContents.on('did-finish-load', () => {
+    void evaluateSmokeTestWindow(window)
+  })
+}
 
 function generateDesktopApiToken(): string {
   return randomBytes(32).toString('base64url')
@@ -335,6 +449,7 @@ function createWindow(): void {
     minHeight: isLauncher ? 560 : 600,
     title: getCurrentVaultTitle(),
     backgroundColor: '#f7f4ef',
+    show: !isSmokeTestEnabled(),
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : undefined,
     trafficLightPosition: process.platform === 'darwin' ? { x: 12, y: 12 } : undefined,
     webPreferences: {
@@ -344,6 +459,8 @@ function createWindow(): void {
       sandbox: true,
     },
   })
+
+  installSmokeTestHooks(mainWindow)
 
   void mainWindow.loadURL(getNextUrl())
 
@@ -559,12 +676,22 @@ function resolveStartupVault(): DesktopVault | null {
   const registry = readVaultRegistry(metadataDir)
   launchContext = resolveLaunchContext(process.argv.slice(1), registry.lastOpenedVaultPath)
 
+  if (isSmokeTestEnabled()) {
+    writeSmokeTestLog(
+      `launch_context mode=${launchContext.mode} vaultPath=${launchContext.vaultPath ?? 'null'}`,
+    )
+  }
+
   if (launchContext.mode === 'launcher') {
     return null
   }
 
   const vault = tryReadVault(launchContext.vaultPath)
   if (!vault) {
+    if (isSmokeTestEnabled()) {
+      writeSmokeTestLog(`invalid_vault path=${launchContext.vaultPath}`, 'stderr')
+    }
+
     if (registry.lastOpenedVaultPath === launchContext.vaultPath) {
       clearLastOpenedVault(metadataDir, launchContext.vaultPath)
     }
@@ -582,10 +709,12 @@ app.whenReady().then(async () => {
   if (currentVault) {
     vaultLock = acquireVaultLock(currentVault.path)
     if (!vaultLock) {
-      dialog.showErrorBox(
+      if (showDesktopError(
         'Arche',
         `The vault "${currentVault.name}" is already open in another Arche process.`,
-      )
+      )) {
+        return
+      }
       currentVault = null
       launchContext = { mode: 'launcher', vaultPath: null }
     }
@@ -595,7 +724,9 @@ app.whenReady().then(async () => {
     setDesktopEnv()
   } catch (error) {
     console.error('Failed to initialize desktop environment:', error)
-    dialog.showErrorBox('Arche', 'Failed to initialize desktop security configuration.')
+    if (showDesktopError('Arche', 'Failed to initialize desktop security configuration.')) {
+      return
+    }
     app.quit()
     return
   }
@@ -607,7 +738,9 @@ app.whenReady().then(async () => {
       await ensureVaultDataDirectories(currentVault)
     } catch (error) {
       console.error('Failed to initialize vault data directories:', error)
-      dialog.showErrorBox('Arche', 'Failed to initialize the selected vault.')
+      if (showDesktopError('Arche', 'Failed to initialize the selected vault.')) {
+        return
+      }
       app.quit()
       return
     }
@@ -618,10 +751,12 @@ app.whenReady().then(async () => {
 
   const missingRuntimeBinaries = verifyPackagedRuntimeBinaries()
   if (missingRuntimeBinaries.length > 0) {
-    dialog.showErrorBox(
+    if (showDesktopError(
       'Arche',
       `Missing packaged runtime resources: ${missingRuntimeBinaries.join(', ')}.`,
-    )
+    )) {
+      return
+    }
     app.quit()
     return
   }
@@ -630,7 +765,9 @@ app.whenReady().then(async () => {
     await startNextServer()
   } catch (error) {
     console.error('Failed to start Next.js server:', error)
-    dialog.showErrorBox('Arche', 'Failed to start the local desktop runtime.')
+    if (showDesktopError('Arche', 'Failed to start the local desktop runtime.')) {
+      return
+    }
     app.quit()
     return
   }

--- a/apps/desktop/tests/desktop-workspace-smoke.test.js
+++ b/apps/desktop/tests/desktop-workspace-smoke.test.js
@@ -1,0 +1,159 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { execFileSync, spawn } = require('node:child_process')
+const { mkdirSync, mkdtempSync, rmSync, writeFileSync } = require('node:fs')
+const { tmpdir } = require('node:os')
+const { dirname, join } = require('node:path')
+
+const electronPath = require('electron')
+
+const { getDesktopKbConfigDir, getDesktopKbContentDir } = require('../dist/vault-layout.js')
+const { createVaultManifest } = require('../dist/vault-manifest.js')
+
+async function withTempDir(run) {
+  const root = mkdtempSync(join(tmpdir(), 'arche-desktop-smoke-'))
+  try {
+    return await run(root)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+function runGit(args, cwd) {
+  execFileSync('git', args, {
+    cwd,
+    env: {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_TERMINAL_PROMPT: '0',
+    },
+    stdio: 'pipe',
+  })
+}
+
+function createBareRepoWithFiles(repoPath, files) {
+  mkdirSync(repoPath, { recursive: true })
+  runGit(['init', '--bare', '--initial-branch=main', repoPath], join(repoPath, '..'))
+
+  const checkoutDir = mkdtempSync(join(tmpdir(), 'arche-desktop-smoke-repo-'))
+
+  try {
+    runGit(['clone', repoPath, checkoutDir], join(repoPath, '..'))
+
+    for (const [relativePath, content] of Object.entries(files)) {
+      const absolutePath = join(checkoutDir, relativePath)
+      mkdirSync(dirname(absolutePath), { recursive: true })
+      writeFileSync(absolutePath, content, 'utf-8')
+    }
+
+    runGit(['add', '-A'], checkoutDir)
+    runGit(
+      [
+        '-c',
+        'user.name=Arche Smoke',
+        '-c',
+        'user.email=smoke@arche.local',
+        '-c',
+        'commit.gpgsign=false',
+        'commit',
+        '-m',
+        'Initialize smoke vault',
+      ],
+      checkoutDir,
+    )
+    runGit(['push', 'origin', 'HEAD:refs/heads/main'], checkoutDir)
+  } finally {
+    rmSync(checkoutDir, { recursive: true, force: true })
+  }
+}
+
+function createKickstartedVault(rootDir) {
+  const vaultPath = join(rootDir, 'smoke-vault')
+  mkdirSync(vaultPath, { recursive: true })
+  createVaultManifest(vaultPath, 'smoke-vault')
+
+  createBareRepoWithFiles(getDesktopKbConfigDir(vaultPath), {
+    'AGENTS.md': '# Arche\n',
+    'CommonWorkspaceConfig.json': `${JSON.stringify(
+      {
+        $schema: 'https://opencode.ai/config.json',
+        default_agent: 'assistant',
+        agent: {
+          assistant: {
+            display_name: 'Assistant',
+            mode: 'primary',
+            model: 'openai/gpt-5.2',
+            prompt: 'You are a helpful assistant.',
+            tools: {
+              bash: true,
+              edit: true,
+              write: true,
+            },
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  })
+
+  createBareRepoWithFiles(getDesktopKbContentDir(vaultPath), {
+    'README.md': '# Smoke Test\n',
+  })
+
+  return vaultPath
+}
+
+test('opens the desktop workspace for a ready vault', { timeout: 180_000, skip: process.platform !== 'darwin' }, async (t) => {
+  await withTempDir(async (rootDir) => {
+    const vaultPath = createKickstartedVault(rootDir)
+    const stdout = []
+    const stderr = []
+    const desktopDir = join(__dirname, '..')
+    const mainEntry = join(desktopDir, 'dist', 'main.js')
+
+    const child = spawn(electronPath, [mainEntry, `--vault-path=${vaultPath}`], {
+      cwd: desktopDir,
+      env: {
+        ...process.env,
+        ARCHE_DESKTOP_SMOKE_TEST: '1',
+        ARCHE_DESKTOP_SMOKE_TEST_EXPECTED_PATH: '/w/local',
+        ARCHE_DESKTOP_SMOKE_TEST_TIMEOUT_MS: '180000',
+        ELECTRON_ENABLE_LOGGING: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    t.after(() => {
+      if (!child.killed) {
+        child.kill('SIGKILL')
+      }
+    })
+
+    child.stdout.on('data', (chunk) => {
+      stdout.push(chunk.toString())
+    })
+
+    child.stderr.on('data', (chunk) => {
+      stderr.push(chunk.toString())
+    })
+
+    const result = await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error(`Timed out waiting for Electron workspace launch\n\n${stdout.join('')}${stderr.join('')}`))
+      }, 120_000)
+
+      child.once('error', reject)
+      child.once('exit', (code, signal) => {
+        clearTimeout(timeout)
+        resolve({ code, signal })
+      })
+    })
+
+    const output = `${stdout.join('')}${stderr.join('')}`
+
+    assert.deepEqual(result, { code: 0, signal: null }, output)
+    assert.match(output, /\[desktop-smoke\] success path=\/w\/local/)
+  })
+})

--- a/apps/web/src/app/api/u/[slug]/team/route.ts
+++ b/apps/web/src/app/api/u/[slug]/team/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-import argon2 from 'argon2'
-
+import { hashArgon2 } from '@/lib/argon2'
 import { auditEvent } from '@/lib/auth'
 import { requireCapability } from '@/lib/runtime/require-capability'
 import { withAuth } from '@/lib/runtime/with-auth'
@@ -124,7 +123,7 @@ export const POST = withAuth<{ user: TeamUserListItem } | { error: string; messa
       return NextResponse.json({ error }, { status: 409 })
     }
 
-    const passwordHash = await argon2.hash(password)
+    const passwordHash = await hashArgon2(password)
 
     try {
       const createdUser = await userService.create({

--- a/apps/web/src/app/api/w/[slug]/attachments/route.ts
+++ b/apps/web/src/app/api/w/[slug]/attachments/route.ts
@@ -1,19 +1,18 @@
 import { NextRequest } from 'next/server'
 
 import { withAuth } from '@/lib/runtime/with-auth'
+import { createWorkspaceAgentClient } from '@/lib/workspace-agent/client'
+import { workspaceAgentFetch, type WorkspaceAgent } from '@/lib/workspace-agent-client'
 import {
   ensureUniqueAttachmentFilename,
   inferAttachmentMimeType,
   isWorkspaceAttachmentPath,
-  MAX_ATTACHMENTS_PER_UPLOAD,
   MAX_ATTACHMENT_UPLOAD_BYTES,
   MAX_ATTACHMENT_UPLOAD_MEGABYTES,
   normalizeAttachmentPath,
   sanitizeAttachmentFilename,
   WORKSPACE_ATTACHMENTS_DIR,
 } from '@/lib/workspace-attachments'
-import { workspaceAgentFetch, type WorkspaceAgent } from '@/lib/workspace-agent-client'
-import { createWorkspaceAgentClient } from '@/lib/workspace-agent/client'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -29,6 +28,15 @@ type WorkspaceAgentListEntry = {
 type WorkspaceAgentListResponse = {
   ok: boolean
   entries?: WorkspaceAgentListEntry[]
+  error?: string
+}
+
+type WorkspaceAgentUploadResponse = {
+  ok: boolean
+  path?: string
+  hash?: string
+  size?: number
+  modifiedAt?: number
   error?: string
 }
 
@@ -56,19 +64,30 @@ function fileTooLargeResponse() {
   })
 }
 
-function isRequestBodyTooLargeError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false
-
-  const message = error.message.toLowerCase()
-
-  return message.includes('request body exceeded') || message.includes('body exceeded')
-}
-
 function normalizeAndValidateAttachmentPath(path: unknown): string | null {
   if (typeof path !== 'string') return null
   const normalized = normalizeAttachmentPath(path)
   if (!isWorkspaceAttachmentPath(normalized)) return null
   return normalized
+}
+
+function getRequestContentLength(request: NextRequest): number | null {
+  const raw = request.headers.get('content-length')
+  if (!raw) return null
+
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed < 0) return null
+
+  return parsed
+}
+
+function inferUploadedAttachmentMimeType(request: NextRequest, filename: string): string {
+  const rawContentType = request.headers.get('content-type')?.trim()
+  if (rawContentType && rawContentType !== 'application/octet-stream') {
+    return rawContentType
+  }
+
+  return inferAttachmentMimeType(filename)
 }
 
 async function getWorkspaceAgentForSlug(slug: string) {
@@ -149,31 +168,23 @@ export const POST = withAuth(
     const auth = await getWorkspaceAgentForSlug(slug)
     if (!auth.ok) return auth.response
 
-    let formData: FormData
-
-    try {
-      formData = await request.formData()
-    } catch (error) {
-      if (isRequestBodyTooLargeError(error)) {
-        return fileTooLargeResponse()
-      }
-
-      return jsonResponse(400, { error: 'invalid_form_data' })
+    const { searchParams } = new URL(request.url)
+    const requestedName = searchParams.get('filename')
+    if (typeof requestedName !== 'string') {
+      return jsonResponse(400, { error: 'invalid_name' })
     }
 
-    const files = formData
-      .getAll('files')
-      .filter((value): value is File => value instanceof File)
+    const sanitizedName = sanitizeAttachmentFilename(requestedName)
+    if (sanitizedName.length === 0) {
+      return jsonResponse(400, { error: 'invalid_name' })
+    }
 
-    if (files.length === 0) {
+    if (!request.body) {
       return jsonResponse(400, { error: 'missing_files' })
     }
 
-    if (files.length > MAX_ATTACHMENTS_PER_UPLOAD) {
-      return jsonResponse(400, { error: 'too_many_files' })
-    }
-
-    if (files.some((file) => file.size > MAX_ATTACHMENT_UPLOAD_BYTES)) {
+    const contentLength = getRequestContentLength(request)
+    if (contentLength !== null && contentLength > MAX_ATTACHMENT_UPLOAD_BYTES) {
       return fileTooLargeResponse()
     }
 
@@ -183,83 +194,63 @@ export const POST = withAuth(
     }
 
     const usedNames = new Set(existing.attachments.map((attachment) => attachment.name))
-    const uploadTargets = files.map((file) => {
-      const safeName = sanitizeAttachmentFilename(file.name)
-      const uniqueName = ensureUniqueAttachmentFilename(safeName, usedNames)
-      usedNames.add(uniqueName)
+    const uniqueName = ensureUniqueAttachmentFilename(sanitizedName, usedNames)
+    const path = `${WORKSPACE_ATTACHMENTS_DIR}/${uniqueName}`
 
-      return {
-        file,
-        name: uniqueName,
-        path: `${WORKSPACE_ATTACHMENTS_DIR}/${uniqueName}`,
-      }
+    const headers = new Headers({
+      Accept: 'application/json',
+      Authorization: auth.agent.authHeader,
     })
-
-    const results = await Promise.allSettled(
-      uploadTargets.map(async ({ file, name, path }) => {
-        const bytes = Buffer.from(await file.arrayBuffer())
-        const fileType = file.type.trim()
-        const mime =
-          fileType.length > 0 && fileType !== 'application/octet-stream'
-            ? fileType
-            : inferAttachmentMimeType(name)
-        const uploadedAt = Date.now()
-
-        const response = await workspaceAgentFetch<{ ok: boolean; hash?: string; error?: string }>(
-          auth.agent,
-          '/files/write',
-          {
-            path,
-            content: bytes.toString('base64'),
-            encoding: 'base64',
-          },
-        )
-
-        if (!response.ok) {
-          throw new Error(response.error)
-        }
-
-        return {
-          id: path,
-          path,
-          name,
-          mime,
-          size: bytes.length,
-          uploadedAt,
-        } satisfies WorkspaceAttachment
-      }),
-    )
-
-    const uploaded: WorkspaceAttachment[] = []
-    const failed: Array<{ name: string; error: string }> = []
-
-    for (let index = 0; index < results.length; index += 1) {
-      const result = results[index]
-      const target = uploadTargets[index]
-
-      if (result.status === 'fulfilled') {
-        uploaded.push(result.value)
-        continue
-      }
-
-      failed.push({
-        name: target.name,
-        error:
-          result.reason instanceof Error && result.reason.message
-            ? result.reason.message
-            : 'upload_failed',
-      })
+    const contentType = request.headers.get('content-type')
+    if (contentType) {
+      headers.set('Content-Type', contentType)
     }
 
-    if (failed.length > 0 && uploaded.length === 0) {
-      return jsonResponse(502, { error: 'upload_failed', uploaded, failed })
+    const uploadRequestInit: RequestInit & { duplex?: 'half' } = {
+      method: 'POST',
+      headers,
+      body: request.body,
+      cache: 'no-store',
+      duplex: 'half',
     }
 
-    if (failed.length > 0) {
-      return jsonResponse(207, { uploaded, failed })
+    let upstreamResponse: Response
+    try {
+      upstreamResponse = await fetch(
+        `${auth.agent.baseUrl}/files/upload?path=${encodeURIComponent(path)}`,
+        uploadRequestInit,
+      )
+    } catch {
+      return jsonResponse(502, { error: 'upload_failed' })
     }
 
-    return jsonResponse(201, { uploaded, failed: [] })
+    const uploaded = (await upstreamResponse.json().catch(() => null)) as WorkspaceAgentUploadResponse | null
+
+    if (upstreamResponse.status === 413) {
+      return fileTooLargeResponse()
+    }
+
+    if (
+      !upstreamResponse.ok ||
+      !uploaded?.ok ||
+      typeof uploaded.path !== 'string' ||
+      typeof uploaded.hash !== 'string' ||
+      typeof uploaded.size !== 'number' ||
+      typeof uploaded.modifiedAt !== 'number'
+    ) {
+      return jsonResponse(502, { error: uploaded?.error ?? 'upload_failed' })
+    }
+
+    const attachment: WorkspaceAttachment = {
+      id: uploaded.path,
+      path: uploaded.path,
+      name: uniqueName,
+      mime: inferUploadedAttachmentMimeType(request, uniqueName),
+      size: uploaded.size,
+      uploadedAt: uploaded.modifiedAt,
+    }
+
+    return jsonResponse(201, { uploaded: [attachment], failed: [] })
   },
 )
 

--- a/apps/web/src/app/auth/verify-2fa/route.ts
+++ b/apps/web/src/app/auth/verify-2fa/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import argon2 from 'argon2'
-
+import { verifyArgon2 } from '@/lib/argon2'
 import { auditEvent, createSession, getCookieDomain, SESSION_COOKIE_NAME, shouldUseSecureCookies } from '@/lib/auth'
 import { checkRateLimit, resetRateLimit } from '@/lib/rate-limit'
 import { hashSessionToken } from '@/lib/security'
@@ -47,7 +46,7 @@ export async function POST(request: Request) {
 
   if (isRecoveryCode) {
     for (const recovery of user.twoFactorRecovery) {
-      if (await argon2.verify(recovery.codeHash, code.toUpperCase())) {
+      if (await verifyArgon2(recovery.codeHash, code.toUpperCase())) {
         await userService.markRecoveryCodeUsed(recovery.id)
         verified = true
         await auditEvent({

--- a/apps/web/src/app/u/[slug]/settings/security/__tests__/actions.test.ts
+++ b/apps/web/src/app/u/[slug]/settings/security/__tests__/actions.test.ts
@@ -1,10 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockHash = vi.fn<(password: string) => Promise<string>>()
-vi.mock('argon2', () => ({
-  default: {
-    hash: (password: string) => mockHash(password),
-  },
+vi.mock('@/lib/argon2', () => ({
+  hashArgon2: (password: string) => mockHash(password),
 }))
 
 const mockAuditEvent = vi.fn()

--- a/apps/web/src/app/u/[slug]/settings/security/actions.ts
+++ b/apps/web/src/app/u/[slug]/settings/security/actions.ts
@@ -1,7 +1,6 @@
 'use server'
 
-import argon2 from 'argon2'
-
+import { hashArgon2 } from '@/lib/argon2'
 import {
   auditEvent,
   verifyPassword,
@@ -105,7 +104,7 @@ export async function changePassword(
     }
   }
 
-  const passwordHash = await argon2.hash(newPassword)
+  const passwordHash = await hashArgon2(newPassword)
   await userService.updatePasswordHash(user.id, passwordHash)
   await sessionService.revokeByUserIdExceptSession(user.id, session.sessionId)
 
@@ -169,7 +168,7 @@ export async function verify2FASetup(
 
   const recoveryCodes = generateRecoveryCodes()
   const hashedCodes = await Promise.all(
-    recoveryCodes.map((c) => argon2.hash(c))
+    recoveryCodes.map((c) => hashArgon2(c))
   )
 
   await userService.enableTwoFactor(
@@ -229,7 +228,7 @@ export async function regenerateRecoveryCodes(password: string): Promise<
 
   const recoveryCodes = generateRecoveryCodes()
   const hashedCodes = await Promise.all(
-    recoveryCodes.map((c) => argon2.hash(c))
+    recoveryCodes.map((c) => hashArgon2(c))
   )
 
   await userService.regenerateRecoveryCodes(

--- a/apps/web/src/components/workspace/__tests__/chat-panel-textarea.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/chat-panel-textarea.test.tsx
@@ -71,6 +71,14 @@ function getSendButton(): HTMLButtonElement {
   return sendButton;
 }
 
+function getAttachmentInput(): HTMLInputElement {
+  const input = document.querySelector('input[type="file"]');
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error("Expected attachment input element");
+  }
+  return input;
+}
+
 function createClipboardImageData(file: File) {
   return {
     items: [
@@ -229,21 +237,16 @@ describe("ChatPanel textarea", () => {
 
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       if (init?.method === "POST") {
+        expect(String(_input)).toBe(
+          "/api/w/alice/attachments?filename=clipboard-image.png"
+        );
         const requestBody = init.body;
-        if (!(requestBody instanceof FormData)) {
-          throw new Error("Expected upload request body to be FormData");
+        if (!(requestBody instanceof File)) {
+          throw new Error("Expected upload request body to be File");
         }
 
-        const files = requestBody.getAll("files");
-        expect(files).toHaveLength(1);
-
-        const uploadedFile = files[0];
-        if (!(uploadedFile instanceof File)) {
-          throw new Error("Expected uploaded file in FormData");
-        }
-
-        expect(uploadedFile.type).toBe("image/png");
-        expect(uploadedFile.name).toBe("clipboard-image.png");
+        expect(requestBody.type).toBe("image/png");
+        expect(requestBody.name).toBe("clipboard-image.png");
 
         attachmentStore.push(uploadedAttachment);
 
@@ -298,6 +301,77 @@ describe("ChatPanel textarea", () => {
         contextPaths: [],
       }
     );
+  });
+
+  it("uploads selected files one by one", async () => {
+    const attachmentStore: MockAttachment[] = [];
+    const uploadedByName: Record<string, MockAttachment> = {
+      "first.txt": {
+        id: ".arche/attachments/first.txt",
+        path: ".arche/attachments/first.txt",
+        name: "first.txt",
+        mime: "text/plain",
+        size: 5,
+        uploadedAt: 1,
+      },
+      "second.txt": {
+        id: ".arche/attachments/second.txt",
+        path: ".arche/attachments/second.txt",
+        name: "second.txt",
+        mime: "text/plain",
+        size: 6,
+        uploadedAt: 2,
+      },
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        const requestUrl = String(input);
+        const filename = new URL(requestUrl, "http://localhost").searchParams.get("filename");
+        if (!filename || !(filename in uploadedByName)) {
+          throw new Error(`Unexpected upload filename: ${filename}`);
+        }
+
+        attachmentStore.push(uploadedByName[filename]);
+
+        return {
+          ok: true,
+          json: async () => ({ uploaded: [uploadedByName[filename]], failed: [] }),
+        };
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ attachments: attachmentStore }),
+      };
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderChatPanel();
+
+    const attachmentInput = getAttachmentInput();
+    fireEvent.change(attachmentInput, {
+      target: {
+        files: [
+          new File(["first"], "first.txt", { type: "text/plain" }),
+          new File(["second"], "second.txt", { type: "text/plain" }),
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      const uploadCalls = fetchMock.mock.calls.filter(([, init]) => init?.method === "POST");
+      expect(uploadCalls).toHaveLength(2);
+    });
+
+    const uploadUrls = fetchMock.mock.calls
+      .filter(([, init]) => init?.method === "POST")
+      .map(([input]) => String(input));
+    expect(uploadUrls).toEqual([
+      "/api/w/alice/attachments?filename=first.txt",
+      "/api/w/alice/attachments?filename=second.txt",
+    ]);
   });
 
   it("shows a clear error when a pasted image exceeds the upload limit", async () => {

--- a/apps/web/src/components/workspace/chat-panel.tsx
+++ b/apps/web/src/components/workspace/chat-panel.tsx
@@ -562,39 +562,45 @@ export function ChatPanel({
       return;
     }
 
-    const formData = new FormData();
-    files.forEach((file) => {
-      formData.append("files", file);
-    });
-
     setIsUploadingAttachment(true);
     setAttachmentsError(null);
 
     try {
-      const response = await fetch(`/api/w/${slug}/attachments`, {
-        method: "POST",
-        body: formData,
-      });
+      const uploaded: WorkspaceAttachment[] = [];
+      let firstFailure: string | null = null;
 
-      const data = (await response
-        .json()
-        .catch(() => null)) as {
-        uploaded?: WorkspaceAttachment[];
-        failed?: Array<{ name: string; error: string }>;
-        error?: string;
-      } | null;
+      for (const file of files) {
+        const headers = file.type ? { "Content-Type": file.type } : undefined;
+        const response = await fetch(
+          `/api/w/${slug}/attachments?filename=${encodeURIComponent(file.name)}`,
+          {
+            method: "POST",
+            headers,
+            body: file,
+          }
+        );
 
-      if (response.status === 413) {
-        setAttachmentsError("file_too_large");
-        return;
+        const data = (await response
+          .json()
+          .catch(() => null)) as {
+          uploaded?: WorkspaceAttachment[];
+          error?: string;
+        } | null;
+
+        if (response.status === 413) {
+          firstFailure ??= "file_too_large";
+          continue;
+        }
+
+        if (!response.ok || !data?.uploaded?.length) {
+          firstFailure ??= data?.error ?? "upload_failed";
+          continue;
+        }
+
+        uploaded.push(...data.uploaded);
       }
 
-      if (!response.ok || !data?.uploaded) {
-        setAttachmentsError(data?.error ?? "upload_failed");
-        return;
-      }
-
-      const uploaded = data.uploaded;
+      if (uploaded.length > 0) {
       setAttachments((previous) => {
         const indexed = new Map(previous.map((attachment) => [attachment.path, attachment]));
         uploaded.forEach((attachment) => indexed.set(attachment.path, attachment));
@@ -605,8 +611,10 @@ export function ChatPanel({
         uploaded.forEach((attachment) => selected.add(attachment.path));
         return [...selected];
       });
-      if ((data.failed?.length ?? 0) > 0) {
-        setAttachmentsError("upload_partial_failure");
+      }
+
+      if (firstFailure) {
+        setAttachmentsError(uploaded.length > 0 ? "upload_partial_failure" : firstFailure);
       } else {
         setAttachmentsError(null);
       }

--- a/apps/web/src/lib/argon2.ts
+++ b/apps/web/src/lib/argon2.ts
@@ -1,0 +1,46 @@
+type Argon2Api = {
+  hash(value: string): Promise<string>
+  verify(hash: string, value: string): Promise<boolean>
+}
+
+let argon2Promise: Promise<Argon2Api> | null = null
+
+async function importArgon2Module(): Promise<unknown> {
+  return import('argon2')
+}
+
+function isArgon2Api(value: unknown): value is Argon2Api {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  return 'hash' in value && typeof value.hash === 'function' && 'verify' in value && typeof value.verify === 'function'
+}
+
+async function getArgon2(): Promise<Argon2Api> {
+  if (!argon2Promise) {
+    argon2Promise = importArgon2Module().then((module) => {
+      if (isArgon2Api(module)) {
+        return module
+      }
+
+      if (typeof module === 'object' && module !== null && 'default' in module && isArgon2Api(module.default)) {
+        return module.default
+      }
+
+      throw new Error('argon2 module did not expose hash/verify functions')
+    })
+  }
+
+  return argon2Promise
+}
+
+export async function hashArgon2(value: string): Promise<string> {
+  const argon2 = await getArgon2()
+  return argon2.hash(value)
+}
+
+export async function verifyArgon2(hash: string, value: string): Promise<boolean> {
+  const argon2 = await getArgon2()
+  return argon2.verify(hash, value)
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,5 +1,4 @@
-import argon2 from 'argon2'
-
+import { verifyArgon2 } from '@/lib/argon2'
 import { getClientIp } from '@/lib/http'
 import { hashSessionToken, newSessionToken } from '@/lib/security'
 import { auditService, sessionService } from '@/lib/services'
@@ -46,7 +45,7 @@ export async function auditEvent(args: {
 }
 
 export async function verifyPassword(password: string, passwordHash: string): Promise<boolean> {
-  return argon2.verify(passwordHash, password)
+  return verifyArgon2(passwordHash, password)
 }
 
 export async function createSession(params: {

--- a/apps/web/src/lib/runtime/__tests__/capabilities.test.ts
+++ b/apps/web/src/lib/runtime/__tests__/capabilities.test.ts
@@ -43,7 +43,7 @@ describe('runtime capabilities', () => {
     expect(caps.containers).toBe(false)
     expect(caps.workspaceAgent).toBe(true)
     expect(caps.reaper).toBe(false)
-    expect(caps.csrf).toBe(true)
+    expect(caps.csrf).toBe(false)
     expect(caps.twoFactor).toBe(false)
     expect(caps.teamManagement).toBe(false)
     expect(caps.connectors).toBe(true)

--- a/apps/web/src/lib/runtime/__tests__/capability-matrix.test.ts
+++ b/apps/web/src/lib/runtime/__tests__/capability-matrix.test.ts
@@ -55,7 +55,7 @@ describe('capability enforcement matrix', () => {
     { capability: 'containers', web: true, desktop: false },
     { capability: 'workspaceAgent', web: true, desktop: true },
     { capability: 'reaper', web: true, desktop: false },
-    { capability: 'csrf', web: true, desktop: true },
+    { capability: 'csrf', web: true, desktop: false },
     { capability: 'twoFactor', web: true, desktop: false },
     { capability: 'teamManagement', web: true, desktop: false },
     { capability: 'connectors', web: true, desktop: true },

--- a/apps/web/src/lib/runtime/__tests__/session.test.ts
+++ b/apps/web/src/lib/runtime/__tests__/session.test.ts
@@ -1,15 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mockGetAuthenticatedUser = vi.fn()
+const mockGetWebSession = vi.fn()
 const mockGetDesktopSession = vi.fn()
-
-vi.mock('@/lib/auth', () => ({
-  getAuthenticatedUser: (...args: unknown[]) => mockGetAuthenticatedUser(...args),
-}))
-
-vi.mock('@/lib/runtime/session-desktop', () => ({
-  getDesktopSession: (...args: unknown[]) => mockGetDesktopSession(...args),
-}))
 
 describe('runtime session dispatcher', () => {
   const originalEnv = process.env
@@ -22,6 +14,14 @@ describe('runtime session dispatcher', () => {
       user: { id: 'local', email: 'local@arche.local', slug: 'local', role: 'ADMIN' },
       sessionId: 'local',
     })
+
+    vi.doMock('@/lib/runtime/session-web', () => ({
+      getWebSession: (...args: unknown[]) => mockGetWebSession(...args),
+    }))
+
+    vi.doMock('@/lib/runtime/session-desktop', () => ({
+      getDesktopSession: (...args: unknown[]) => mockGetDesktopSession(...args),
+    }))
   })
 
   afterEach(() => {
@@ -35,18 +35,18 @@ describe('runtime session dispatcher', () => {
       user: { id: 'u1', email: 'a@b.com', slug: 'alice', role: 'USER' },
       sessionId: 's1',
     }
-    mockGetAuthenticatedUser.mockResolvedValue(webSession)
+    mockGetWebSession.mockResolvedValue(webSession)
 
     const { getSession } = await import('../session')
     const result = await getSession()
 
     expect(result).toEqual(webSession)
-    expect(mockGetAuthenticatedUser).toHaveBeenCalledOnce()
+    expect(mockGetWebSession).toHaveBeenCalledOnce()
   })
 
   it('returns null when web session is not authenticated', async () => {
     delete process.env.ARCHE_RUNTIME_MODE
-    mockGetAuthenticatedUser.mockResolvedValue(null)
+    mockGetWebSession.mockResolvedValue(null)
 
     const { getSession } = await import('../session')
     const result = await getSession()
@@ -66,6 +66,30 @@ describe('runtime session dispatcher', () => {
     expect(result!.user.slug).toBe('local')
     expect(result!.user.role).toBe('ADMIN')
     expect(result!.sessionId).toBe('local')
-    expect(mockGetAuthenticatedUser).not.toHaveBeenCalled()
+    expect(mockGetWebSession).not.toHaveBeenCalled()
+  })
+
+  it('does not import the web session module in desktop mode', async () => {
+    vi.resetModules()
+    process.env = {
+      ...originalEnv,
+      ARCHE_RUNTIME_MODE: 'desktop',
+      ARCHE_DESKTOP_PLATFORM: 'darwin',
+      ARCHE_DESKTOP_WEB_HOST: '127.0.0.1',
+    }
+
+    vi.doMock('@/lib/runtime/session-web', () => {
+      throw new Error('session-web should not load in desktop mode')
+    })
+
+    vi.doMock('@/lib/runtime/session-desktop', () => ({
+      getDesktopSession: (...args: unknown[]) => mockGetDesktopSession(...args),
+    }))
+
+    const { getSession } = await import('../session')
+    const result = await getSession()
+
+    expect(result).not.toBeNull()
+    expect(result!.sessionId).toBe('local')
   })
 })

--- a/apps/web/src/lib/runtime/capabilities.ts
+++ b/apps/web/src/lib/runtime/capabilities.ts
@@ -36,7 +36,7 @@ const DESKTOP_CAPABILITIES: RuntimeCapabilities = {
   containers: false,
   workspaceAgent: true,
   reaper: false,
-  csrf: true,
+  csrf: false,
   twoFactor: false,
   teamManagement: false,
   connectors: true,

--- a/apps/web/src/lib/runtime/session.ts
+++ b/apps/web/src/lib/runtime/session.ts
@@ -1,12 +1,13 @@
 import { getRuntimeCapabilities } from '@/lib/runtime/capabilities'
-import { getDesktopSession } from '@/lib/runtime/session-desktop'
-import { getWebSession } from '@/lib/runtime/session-web'
 import type { RuntimeSessionResult } from '@/lib/runtime/types'
 
 export async function getSession(): Promise<RuntimeSessionResult> {
   const caps = getRuntimeCapabilities()
   if (!caps.auth) {
+    const { getDesktopSession } = await import('@/lib/runtime/session-desktop')
     return getDesktopSession()
   }
+
+  const { getWebSession } = await import('@/lib/runtime/session-web')
   return getWebSession()
 }

--- a/apps/web/tests/attachments-routes.test.ts
+++ b/apps/web/tests/attachments-routes.test.ts
@@ -32,34 +32,34 @@ async function callGetAttachments(slug = 'alice') {
   return { status: res.status, body: await res.json() }
 }
 
-async function callPostAttachments(options: {
+async function callPostAttachment(options: {
   slug?: string
-  files: File[]
+  file: File
   includeOrigin?: boolean
-  formDataOverride?: FormData
+  contentLength?: number
 }) {
   const { POST } = await import('@/app/api/w/[slug]/attachments/route')
   const slug = options.slug ?? 'alice'
-
-  const formData = new FormData()
-  options.files.forEach((file) => formData.append('files', file))
 
   const headers = new Headers({ host: 'localhost' })
   if (options.includeOrigin !== false) {
     headers.set('origin', 'http://localhost')
   }
+  if (options.file.type) {
+    headers.set('content-type', options.file.type)
+  }
+  if (typeof options.contentLength === 'number') {
+    headers.set('content-length', String(options.contentLength))
+  }
 
-  const req = new Request(`http://localhost/api/w/${slug}/attachments`, {
+  const req = new Request(
+    `http://localhost/api/w/${slug}/attachments?filename=${encodeURIComponent(options.file.name)}`,
+    {
     method: 'POST',
     headers,
-    body: formData,
-  })
-
-  if (options.formDataOverride) {
-    Object.defineProperty(req, 'formData', {
-      value: async () => options.formDataOverride,
-    })
-  }
+      body: options.file,
+    },
+  )
 
   const res = await POST(req as never, { params: Promise.resolve({ slug }) })
   return { status: res.status, body: await res.json() }
@@ -192,8 +192,8 @@ describe('workspace attachments route', () => {
   it('POST enforces same-origin validation', async () => {
     mockGetAuthenticatedUser.mockResolvedValue(session('alice'))
 
-    const { status, body } = await callPostAttachments({
-      files: [new File(['x'], 'a.txt', { type: 'text/plain' })],
+    const { status, body } = await callPostAttachment({
+      file: new File(['x'], 'a.txt', { type: 'text/plain' }),
       includeOrigin: false,
     })
 
@@ -201,7 +201,7 @@ describe('workspace attachments route', () => {
     expect(body.error).toBe('forbidden')
   })
 
-  it('POST uploads files using base64 encoding and resolves name conflicts', async () => {
+  it('POST streams raw file uploads and resolves name conflicts', async () => {
     mockGetAuthenticatedUser.mockResolvedValue(session('alice'))
     const fetchMock = vi
       .fn()
@@ -223,37 +223,36 @@ describe('workspace attachments route', () => {
         ),
       )
       .mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: true, hash: 'h1' }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: true, hash: 'h2' }), {
+        new Response(JSON.stringify({
+          ok: true,
+          path: '.arche/attachments/report (1).pdf',
+          hash: 'h1',
+          size: 8,
+          modifiedAt: 123,
+        }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         }),
       )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { status, body } = await callPostAttachments({
-      files: [
-        new File(['pdf-data'], 'report.pdf', { type: 'application/pdf' }),
-        new File(['img-data'], 'diagram.png', { type: 'image/png' }),
-      ],
+    const { status, body } = await callPostAttachment({
+      file: new File(['pdf-data'], 'report.pdf', { type: 'application/pdf' }),
     })
 
     expect(status).toBe(201)
-    expect(body.uploaded).toHaveLength(2)
+    expect(body.uploaded).toHaveLength(1)
     expect(body.failed).toEqual([])
     expect(body.uploaded[0].name).toBe('report (1).pdf')
-    expect(body.uploaded[1].name).toBe('diagram.png')
 
-    const firstWriteBody = JSON.parse(String(fetchMock.mock.calls[1][1]?.body))
-    expect(firstWriteBody.path).toBe('.arche/attachments/report (1).pdf')
-    expect(firstWriteBody.encoding).toBe('base64')
-    expect(typeof firstWriteBody.content).toBe('string')
-    expect(firstWriteBody.content.length).toBeGreaterThan(0)
+    expect(String(fetchMock.mock.calls[1][0])).toBe(
+      'http://agent/files/upload?path=.arche%2Fattachments%2Freport%20(1).pdf',
+    )
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({
+      method: 'POST',
+      duplex: 'half',
+    })
+    expect(fetchMock.mock.calls[1][1]?.body).toBeTruthy()
   })
 
   it('POST rejects files larger than the upload limit', async () => {
@@ -261,17 +260,9 @@ describe('workspace attachments route', () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
 
-    const oversizedFile = new File(['x'], 'huge.bin', { type: 'application/octet-stream' })
-    Object.defineProperty(oversizedFile, 'size', {
-      value: MAX_ATTACHMENT_UPLOAD_BYTES + 1,
-    })
-
-    const formData = new FormData()
-    formData.append('files', oversizedFile)
-
-    const { status, body } = await callPostAttachments({
-      files: [oversizedFile],
-      formDataOverride: formData,
+    const { status, body } = await callPostAttachment({
+      file: new File(['x'], 'huge.bin', { type: 'application/octet-stream' }),
+      contentLength: MAX_ATTACHMENT_UPLOAD_BYTES + 1,
     })
 
     expect(status).toBe(413)
@@ -283,7 +274,7 @@ describe('workspace attachments route', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('POST returns per-file failures without losing successes', async () => {
+  it('POST maps upstream 413 responses to file_too_large', async () => {
     mockGetAuthenticatedUser.mockResolvedValue(session('alice'))
     const fetchMock = vi
       .fn()
@@ -297,10 +288,33 @@ describe('workspace attachments route', () => {
         ),
       )
       .mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: true, hash: 'h1' }), {
-          status: 200,
+        new Response(JSON.stringify({ ok: false, error: 'file_too_large' }), {
+          status: 413,
           headers: { 'Content-Type': 'application/json' },
         }),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { status, body } = await callPostAttachment({
+      file: new File(['bad'], 'bad.txt', { type: 'text/plain' }),
+    })
+
+    expect(status).toBe(413)
+    expect(body.error).toBe('file_too_large')
+  })
+
+  it('POST returns 502 when the workspace agent upload fails', async () => {
+    mockGetAuthenticatedUser.mockResolvedValue(session('alice'))
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            entries: [],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
       )
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ ok: false, error: 'write_failed' }), {
@@ -310,18 +324,12 @@ describe('workspace attachments route', () => {
       )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { status, body } = await callPostAttachments({
-      files: [
-        new File(['ok'], 'ok.txt', { type: 'text/plain' }),
-        new File(['bad'], 'bad.txt', { type: 'text/plain' }),
-      ],
+    const { status, body } = await callPostAttachment({
+      file: new File(['bad'], 'bad.txt', { type: 'text/plain' }),
     })
 
-    expect(status).toBe(207)
-    expect(body.uploaded).toHaveLength(1)
-    expect(body.failed).toHaveLength(1)
-    expect(body.failed[0].name).toBe('bad.txt')
-    expect(body.failed[0].error).toBe('write_failed')
+    expect(status).toBe(502)
+    expect(body.error).toBe('write_failed')
   })
 
   it('PATCH renames a workspace attachment', async () => {

--- a/apps/web/tests/chat-stream-route.test.ts
+++ b/apps/web/tests/chat-stream-route.test.ts
@@ -3,6 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RuntimeSessionResult } from '@/lib/runtime/types'
 
 const mockGetSession = vi.fn<() => Promise<RuntimeSessionResult>>()
+const mockGetRuntimeCapabilities = vi.fn()
+const mockIsDesktop = vi.fn(() => false)
+const mockValidateDesktopToken = vi.fn(() => false)
 
 const mockFindCredentialsBySlug = vi.fn()
 
@@ -21,22 +24,11 @@ async function loadRoute() {
   }))
 
   vi.doMock('@/lib/runtime/mode', () => ({
-    isDesktop: () => false,
+    isDesktop: () => mockIsDesktop(),
   }))
 
   vi.doMock('@/lib/runtime/capabilities', () => ({
-    getRuntimeCapabilities: () => ({
-      multiUser: true,
-      auth: true,
-      containers: true,
-      workspaceAgent: true,
-      reaper: true,
-      csrf: true,
-      twoFactor: true,
-      teamManagement: true,
-      connectors: true,
-      kickstart: true,
-    }),
+    getRuntimeCapabilities: () => mockGetRuntimeCapabilities(),
   }))
 
   vi.doMock('@/lib/csrf', () => ({
@@ -48,7 +40,7 @@ async function loadRoute() {
 
   vi.doMock('@/lib/runtime/desktop/token', () => ({
     DESKTOP_TOKEN_HEADER: 'x-arche-desktop-token',
-    validateDesktopToken: () => false,
+    validateDesktopToken: () => mockValidateDesktopToken(),
   }))
 
   vi.doMock('@/lib/services', () => ({
@@ -111,6 +103,20 @@ describe('POST /api/w/[slug]/chat/stream', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.resetModules()
+    mockIsDesktop.mockReturnValue(false)
+    mockValidateDesktopToken.mockReturnValue(false)
+    mockGetRuntimeCapabilities.mockReturnValue({
+      multiUser: true,
+      auth: true,
+      containers: true,
+      workspaceAgent: true,
+      reaper: true,
+      csrf: true,
+      twoFactor: true,
+      teamManagement: true,
+      connectors: true,
+      kickstart: true,
+    })
     mockGetSession.mockResolvedValue(session('alice'))
     mockFindCredentialsBySlug.mockResolvedValue({
       serverPassword: 'encrypted-password',
@@ -172,6 +178,41 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     const { POST } = await loadRoute()
     const response = await POST(createRequest() as never, {
       params: Promise.resolve({ slug: 'alice' }),
+    })
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({ error: 'instance_unavailable' })
+  })
+
+  it('accepts desktop chat requests without origin when the desktop token is valid', async () => {
+    mockIsDesktop.mockReturnValue(true)
+    mockValidateDesktopToken.mockReturnValue(true)
+    mockGetRuntimeCapabilities.mockReturnValue({
+      multiUser: false,
+      auth: false,
+      containers: false,
+      workspaceAgent: true,
+      reaper: false,
+      csrf: false,
+      twoFactor: false,
+      teamManagement: false,
+      connectors: true,
+      kickstart: true,
+    })
+    mockGetSession.mockResolvedValue(session('local', 'ADMIN'))
+    mockFindCredentialsBySlug.mockResolvedValue(null)
+
+    const { POST } = await loadRoute()
+    const response = await POST(new Request('http://localhost/api/w/local/chat/stream', {
+      method: 'POST',
+      headers: {
+        host: 'localhost',
+        'content-type': 'application/json',
+        'x-arche-desktop-token': 'desktop-token',
+      },
+      body: JSON.stringify({ sessionId: 'session-1', text: 'Hello' }),
+    }) as never, {
+      params: Promise.resolve({ slug: 'local' }),
     })
 
     expect(response.status).toBe(503)

--- a/infra/workspace-image/workspace-agent/main.go
+++ b/infra/workspace-image/workspace-agent/main.go
@@ -5,15 +5,15 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
-  "encoding/hex"
-  "encoding/json"
-  "errors"
-  "flag"
-  "io"
-  "log"
-  "net/http"
-  "os"
-  "os/exec"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -23,73 +23,74 @@ import (
 )
 
 const (
-  defaultAddr      = "0.0.0.0:4097"
-  defaultWorkspace = "/workspace"
-  maxBodyBytes     = 20 << 20
+	defaultAddr        = "0.0.0.0:4097"
+	defaultWorkspace   = "/workspace"
+	maxBodyBytes       = 20 << 20
+	maxUploadBodyBytes = 100 << 20
 )
 
 type server struct {
-  workspace string
-  username  string
-  password  string
+	workspace string
+	username  string
+	password  string
 }
 
 type errorResponse struct {
-  Ok    bool   `json:"ok"`
-  Error string `json:"error"`
+	Ok    bool   `json:"ok"`
+	Error string `json:"error"`
 }
 
 type gitDiffEntry struct {
-  Path      string `json:"path"`
-  Status    string `json:"status"`
-  Additions int    `json:"additions"`
-  Deletions int    `json:"deletions"`
-  Diff      string `json:"diff"`
-  Conflicted bool  `json:"conflicted"`
+	Path       string `json:"path"`
+	Status     string `json:"status"`
+	Additions  int    `json:"additions"`
+	Deletions  int    `json:"deletions"`
+	Diff       string `json:"diff"`
+	Conflicted bool   `json:"conflicted"`
 }
 
 type gitDiffResponse struct {
-  Ok    bool          `json:"ok"`
-  Diffs []gitDiffEntry `json:"diffs"`
+	Ok    bool           `json:"ok"`
+	Diffs []gitDiffEntry `json:"diffs"`
 }
 
 type gitConflictRequest struct {
-  Path string `json:"path"`
+	Path string `json:"path"`
 }
 
 type gitConflictResponse struct {
-  Ok      bool   `json:"ok"`
-  Path    string `json:"path"`
-  Ours    string `json:"ours"`
-  Theirs  string `json:"theirs"`
-  Base    string `json:"base,omitempty"`
-  Working string `json:"working,omitempty"`
+	Ok      bool   `json:"ok"`
+	Path    string `json:"path"`
+	Ours    string `json:"ours"`
+	Theirs  string `json:"theirs"`
+	Base    string `json:"base,omitempty"`
+	Working string `json:"working,omitempty"`
 }
 
 type gitResolveRequest struct {
-  Path     string `json:"path"`
-  Strategy string `json:"strategy"`
-  Content  string `json:"content,omitempty"`
+	Path     string `json:"path"`
+	Strategy string `json:"strategy"`
+	Content  string `json:"content,omitempty"`
 }
 
 type gitResolveResponse struct {
-  Ok       bool   `json:"ok"`
-  Path     string `json:"path"`
-  Strategy string `json:"strategy"`
-  Message  string `json:"message,omitempty"`
+	Ok       bool   `json:"ok"`
+	Path     string `json:"path"`
+	Strategy string `json:"strategy"`
+	Message  string `json:"message,omitempty"`
 }
 
 type gitDiscardRequest struct {
-  Path string `json:"path"`
+	Path string `json:"path"`
 }
 
 type gitDiscardResponse struct {
-  Ok   bool   `json:"ok"`
-  Path string `json:"path"`
+	Ok   bool   `json:"ok"`
+	Path string `json:"path"`
 }
 
 type fileReadRequest struct {
-  Path string `json:"path"`
+	Path string `json:"path"`
 }
 
 type fileReadResponse struct {
@@ -126,19 +127,27 @@ type fileWriteRequest struct {
 }
 
 type fileWriteResponse struct {
-  Ok   bool   `json:"ok"`
-  Path string `json:"path"`
-  Hash string `json:"hash"`
+	Ok   bool   `json:"ok"`
+	Path string `json:"path"`
+	Hash string `json:"hash"`
+}
+
+type fileUploadResponse struct {
+	Ok         bool   `json:"ok"`
+	Path       string `json:"path"`
+	Hash       string `json:"hash"`
+	Size       int64  `json:"size"`
+	ModifiedAt int64  `json:"modifiedAt"`
 }
 
 type fileDeleteRequest struct {
-  Path string `json:"path"`
+	Path string `json:"path"`
 }
 
 type fileDeleteResponse struct {
-  Ok      bool   `json:"ok"`
-  Path    string `json:"path"`
-  Deleted bool   `json:"deleted"`
+	Ok      bool   `json:"ok"`
+	Path    string `json:"path"`
+	Deleted bool   `json:"deleted"`
 }
 
 type fileRenameRequest struct {
@@ -153,464 +162,465 @@ type fileRenameResponse struct {
 }
 
 type fileApplyPatchRequest struct {
-  Patch string `json:"patch"`
+	Patch string `json:"patch"`
 }
 
 type fileApplyPatchResponse struct {
-  Ok bool `json:"ok"`
+	Ok bool `json:"ok"`
 }
 
 type syncKbResponse struct {
-  Ok        bool     `json:"ok"`
-  Status    string   `json:"status"`
-  Message   string   `json:"message,omitempty"`
-  Conflicts []string `json:"conflicts,omitempty"`
+	Ok        bool     `json:"ok"`
+	Status    string   `json:"status"`
+	Message   string   `json:"message,omitempty"`
+	Conflicts []string `json:"conflicts,omitempty"`
 }
 
 type syncStatusResponse struct {
-  Ok           bool     `json:"ok"`
-  HasConflicts bool     `json:"hasConflicts"`
-  Conflicts    []string `json:"conflicts,omitempty"`
+	Ok           bool     `json:"ok"`
+	HasConflicts bool     `json:"hasConflicts"`
+	Conflicts    []string `json:"conflicts,omitempty"`
 }
 
 type publishKbResponse struct {
-  Ok         bool     `json:"ok"`
-  Status     string   `json:"status"`
-  CommitHash string   `json:"commitHash,omitempty"`
-  Files      []string `json:"files,omitempty"`
-  Message    string   `json:"message,omitempty"`
+	Ok         bool     `json:"ok"`
+	Status     string   `json:"status"`
+	CommitHash string   `json:"commitHash,omitempty"`
+	Files      []string `json:"files,omitempty"`
+	Message    string   `json:"message,omitempty"`
 }
 
 func main() {
-  addr := flag.String("addr", getenv("WORKSPACE_AGENT_ADDR", defaultAddr), "listen address")
-  workspace := flag.String("workspace", getenv("WORKSPACE_DIR", defaultWorkspace), "workspace root")
-  flag.Parse()
+	addr := flag.String("addr", getenv("WORKSPACE_AGENT_ADDR", defaultAddr), "listen address")
+	workspace := flag.String("workspace", getenv("WORKSPACE_DIR", defaultWorkspace), "workspace root")
+	flag.Parse()
 
-  username := getenv("WORKSPACE_AGENT_USERNAME", "opencode")
-  password := os.Getenv("WORKSPACE_AGENT_PASSWORD")
-  if password == "" {
-    password = os.Getenv("OPENCODE_SERVER_PASSWORD")
-  }
+	username := getenv("WORKSPACE_AGENT_USERNAME", "opencode")
+	password := os.Getenv("WORKSPACE_AGENT_PASSWORD")
+	if password == "" {
+		password = os.Getenv("OPENCODE_SERVER_PASSWORD")
+	}
 
-  if password == "" {
-    log.Printf("workspace-agent: missing OPENCODE_SERVER_PASSWORD")
-    os.Exit(1)
-  }
+	if password == "" {
+		log.Printf("workspace-agent: missing OPENCODE_SERVER_PASSWORD")
+		os.Exit(1)
+	}
 
-  s := &server{
-    workspace: *workspace,
-    username:  username,
-    password:  password,
-  }
+	s := &server{
+		workspace: *workspace,
+		username:  username,
+		password:  password,
+	}
 
-  mux := http.NewServeMux()
-  mux.HandleFunc("/health", s.withAuth(s.handleHealth))
-  mux.HandleFunc("/git/diffs", s.withAuth(s.handleGitDiffs))
-  mux.HandleFunc("/git/conflict", s.withAuth(s.handleGitConflict))
-  mux.HandleFunc("/git/resolve", s.withAuth(s.handleGitResolve))
-  mux.HandleFunc("/git/discard", s.withAuth(s.handleGitDiscard))
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", s.withAuth(s.handleHealth))
+	mux.HandleFunc("/git/diffs", s.withAuth(s.handleGitDiffs))
+	mux.HandleFunc("/git/conflict", s.withAuth(s.handleGitConflict))
+	mux.HandleFunc("/git/resolve", s.withAuth(s.handleGitResolve))
+	mux.HandleFunc("/git/discard", s.withAuth(s.handleGitDiscard))
 	mux.HandleFunc("/files/read", s.withAuth(s.handleFileRead))
 	mux.HandleFunc("/files/list", s.withAuth(s.handleFileList))
+	mux.HandleFunc("/files/upload", s.withAuth(s.handleFileUpload))
 	mux.HandleFunc("/files/write", s.withAuth(s.handleFileWrite))
 	mux.HandleFunc("/files/delete", s.withAuth(s.handleFileDelete))
 	mux.HandleFunc("/files/rename", s.withAuth(s.handleFileRename))
 	mux.HandleFunc("/files/apply_patch", s.withAuth(s.handleApplyPatch))
-  mux.HandleFunc("/kb/sync", s.withAuth(s.handleKbSync))
-  mux.HandleFunc("/kb/status", s.withAuth(s.handleKbStatus))
-  mux.HandleFunc("/kb/publish", s.withAuth(s.handleKbPublish))
+	mux.HandleFunc("/kb/sync", s.withAuth(s.handleKbSync))
+	mux.HandleFunc("/kb/status", s.withAuth(s.handleKbStatus))
+	mux.HandleFunc("/kb/publish", s.withAuth(s.handleKbPublish))
 
-  server := &http.Server{
-    Addr:              *addr,
-    Handler:           logRequests(mux),
-    ReadHeaderTimeout: 5 * time.Second,
-    ReadTimeout:       15 * time.Second,
-    WriteTimeout:      30 * time.Second,
-    IdleTimeout:       60 * time.Second,
-  }
+	server := &http.Server{
+		Addr:              *addr,
+		Handler:           logRequests(mux),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
 
-  log.Printf("workspace-agent listening on http://%s", *addr)
-  if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-    log.Fatalf("workspace-agent failed: %v", err)
-  }
+	log.Printf("workspace-agent listening on http://%s", *addr)
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("workspace-agent failed: %v", err)
+	}
 }
 
 func (s *server) withAuth(next http.HandlerFunc) http.HandlerFunc {
-  return func(w http.ResponseWriter, r *http.Request) {
-    username, password, ok := r.BasicAuth()
-    if !ok || username != s.username || password != s.password {
-      w.Header().Set("WWW-Authenticate", "Basic")
-      writeError(w, http.StatusUnauthorized, "unauthorized")
-      return
-    }
-    next(w, r)
-  }
+	return func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != s.username || password != s.password {
+			w.Header().Set("WWW-Authenticate", "Basic")
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		next(w, r)
+	}
 }
 
 func (s *server) handleHealth(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodGet {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
-  writeJSON(w, http.StatusOK, map[string]any{
-    "ok":      true,
-    "service": "workspace-agent",
-  })
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":      true,
+		"service": "workspace-agent",
+	})
 }
 
 func (s *server) handleGitDiffs(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodGet {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  entries, err := s.gitStatusEntries(r.Context())
-  if err != nil {
-    writeError(w, http.StatusBadGateway, err.Error())
-    return
-  }
-  if len(entries) == 0 {
-    writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: []gitDiffEntry{}})
-    return
-  }
-  diffs := make([]gitDiffEntry, 0, len(entries))
+	entries, err := s.gitStatusEntries(r.Context())
+	if err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	if len(entries) == 0 {
+		writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: []gitDiffEntry{}})
+		return
+	}
+	diffs := make([]gitDiffEntry, 0, len(entries))
 
-  for _, entry := range entries {
-    diffArgs := []string{"git", "diff", "--no-color", "HEAD", "--", entry.Path}
-    numstatArgs := []string{"git", "diff", "--numstat", "HEAD", "--", entry.Path}
-    if entry.Untracked {
-      diffArgs = []string{"git", "diff", "--no-color", "--no-index", "--", "/dev/null", entry.Path}
-      numstatArgs = []string{"git", "diff", "--numstat", "--no-index", "--", "/dev/null", entry.Path}
-    }
+	for _, entry := range entries {
+		diffArgs := []string{"git", "diff", "--no-color", "HEAD", "--", entry.Path}
+		numstatArgs := []string{"git", "diff", "--numstat", "HEAD", "--", entry.Path}
+		if entry.Untracked {
+			diffArgs = []string{"git", "diff", "--no-color", "--no-index", "--", "/dev/null", entry.Path}
+			numstatArgs = []string{"git", "diff", "--numstat", "--no-index", "--", "/dev/null", entry.Path}
+		}
 
-    diffOut, diffErr, diffCode, diffExecErr := runCmd(r.Context(), s.workspace, diffArgs)
-    if diffExecErr != nil || diffCode > 1 {
-      msg := strings.TrimSpace(diffErr)
-      if msg == "" {
-        msg = "git_diff_failed"
-      }
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
+		diffOut, diffErr, diffCode, diffExecErr := runCmd(r.Context(), s.workspace, diffArgs)
+		if diffExecErr != nil || diffCode > 1 {
+			msg := strings.TrimSpace(diffErr)
+			if msg == "" {
+				msg = "git_diff_failed"
+			}
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
 
-    numstatOut, numstatErr, numstatCode, numstatExecErr := runCmd(r.Context(), s.workspace, numstatArgs)
-    if numstatExecErr != nil || numstatCode > 1 {
-      msg := strings.TrimSpace(numstatErr)
-      if msg == "" {
-        msg = "git_numstat_failed"
-      }
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
+		numstatOut, numstatErr, numstatCode, numstatExecErr := runCmd(r.Context(), s.workspace, numstatArgs)
+		if numstatExecErr != nil || numstatCode > 1 {
+			msg := strings.TrimSpace(numstatErr)
+			if msg == "" {
+				msg = "git_numstat_failed"
+			}
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
 
-    additions, deletions := parseNumstat(numstatOut)
-    diffs = append(diffs, gitDiffEntry{
-      Path:      entry.Path,
-      Status:    entry.Status,
-      Additions: additions,
-      Deletions: deletions,
-      Diff:      strings.TrimSpace(diffOut),
-      Conflicted: entry.Conflicted,
-    })
-  }
+		additions, deletions := parseNumstat(numstatOut)
+		diffs = append(diffs, gitDiffEntry{
+			Path:       entry.Path,
+			Status:     entry.Status,
+			Additions:  additions,
+			Deletions:  deletions,
+			Diff:       strings.TrimSpace(diffOut),
+			Conflicted: entry.Conflicted,
+		})
+	}
 
-  writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: diffs})
+	writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: diffs})
 }
 
 func (s *server) handleGitConflict(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req gitConflictRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req gitConflictRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  relPath, absPath, err := s.resolveRelPath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
+	relPath, absPath, err := s.resolveRelPath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
-  entries, _ := s.gitStatusEntries(r.Context(), relPath)
-  conflicted := false
-  for _, e := range entries {
-    if e.Conflicted {
-      conflicted = true
-      break
-    }
-  }
-  if !conflicted {
-    writeError(w, http.StatusNotFound, "not_conflicted")
-    return
-  }
+	entries, _ := s.gitStatusEntries(r.Context(), relPath)
+	conflicted := false
+	for _, e := range entries {
+		if e.Conflicted {
+			conflicted = true
+			break
+		}
+	}
+	if !conflicted {
+		writeError(w, http.StatusNotFound, "not_conflicted")
+		return
+	}
 
-  ours, err := s.readGitStage(r.Context(), 2, relPath)
-  if err != nil {
-    writeError(w, http.StatusBadGateway, "git_show_failed")
-    return
-  }
+	ours, err := s.readGitStage(r.Context(), 2, relPath)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "git_show_failed")
+		return
+	}
 
-  theirs, err := s.readGitStage(r.Context(), 3, relPath)
-  if err != nil {
-    writeError(w, http.StatusBadGateway, "git_show_failed")
-    return
-  }
+	theirs, err := s.readGitStage(r.Context(), 3, relPath)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "git_show_failed")
+		return
+	}
 
-  base, err := s.readGitStage(r.Context(), 1, relPath)
-  if err != nil {
-    writeError(w, http.StatusBadGateway, "git_show_failed")
-    return
-  }
+	base, err := s.readGitStage(r.Context(), 1, relPath)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "git_show_failed")
+		return
+	}
 
-  working := ""
-  if data, err := os.ReadFile(absPath); err == nil {
-    working = string(data)
-  }
+	working := ""
+	if data, err := os.ReadFile(absPath); err == nil {
+		working = string(data)
+	}
 
-  writeJSON(w, http.StatusOK, gitConflictResponse{
-    Ok:      true,
-    Path:    req.Path,
-    Ours:    ours,
-    Theirs:  theirs,
-    Base:    base,
-    Working: working,
-  })
+	writeJSON(w, http.StatusOK, gitConflictResponse{
+		Ok:      true,
+		Path:    req.Path,
+		Ours:    ours,
+		Theirs:  theirs,
+		Base:    base,
+		Working: working,
+	})
 }
 
 func (s *server) handleGitResolve(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req gitResolveRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req gitResolveRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  relPath, absPath, err := s.resolveRelPath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
+	relPath, absPath, err := s.resolveRelPath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
-  switch req.Strategy {
-  case "ours":
-    _, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
-      "git", "checkout", "--ours", "--", relPath,
-    })
-    if checkoutExecErr != nil || checkoutCode != 0 {
-      msg := strings.TrimSpace(checkoutErr)
-      if msg == "" {
-        msg = "git_checkout_failed"
-      }
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
-  case "theirs":
-    _, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
-      "git", "checkout", "--theirs", "--", relPath,
-    })
-    if checkoutExecErr != nil || checkoutCode != 0 {
-      msg := strings.TrimSpace(checkoutErr)
-      if msg == "" {
-        msg = "git_checkout_failed"
-      }
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
-  case "manual":
-    if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
-      writeError(w, http.StatusInternalServerError, "mkdir_failed")
-      return
-    }
-    if err := writeFileAtomic(absPath, []byte(req.Content), 0o644); err != nil {
-      writeError(w, http.StatusInternalServerError, "write_failed")
-      return
-    }
-  default:
-    writeError(w, http.StatusBadRequest, "invalid_strategy")
-    return
-  }
+	switch req.Strategy {
+	case "ours":
+		_, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
+			"git", "checkout", "--ours", "--", relPath,
+		})
+		if checkoutExecErr != nil || checkoutCode != 0 {
+			msg := strings.TrimSpace(checkoutErr)
+			if msg == "" {
+				msg = "git_checkout_failed"
+			}
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
+	case "theirs":
+		_, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
+			"git", "checkout", "--theirs", "--", relPath,
+		})
+		if checkoutExecErr != nil || checkoutCode != 0 {
+			msg := strings.TrimSpace(checkoutErr)
+			if msg == "" {
+				msg = "git_checkout_failed"
+			}
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
+	case "manual":
+		if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+			writeError(w, http.StatusInternalServerError, "mkdir_failed")
+			return
+		}
+		if err := writeFileAtomic(absPath, []byte(req.Content), 0o644); err != nil {
+			writeError(w, http.StatusInternalServerError, "write_failed")
+			return
+		}
+	default:
+		writeError(w, http.StatusBadRequest, "invalid_strategy")
+		return
+	}
 
-  _, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "add", "--", relPath,
-  })
-  if addExecErr != nil || addCode != 0 {
-    msg := strings.TrimSpace(addErr)
-    if msg == "" {
-      msg = "git_add_failed"
-    }
-    writeError(w, http.StatusBadGateway, msg)
-    return
-  }
+	_, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "add", "--", relPath,
+	})
+	if addExecErr != nil || addCode != 0 {
+		msg := strings.TrimSpace(addErr)
+		if msg == "" {
+			msg = "git_add_failed"
+		}
+		writeError(w, http.StatusBadGateway, msg)
+		return
+	}
 
-  writeJSON(w, http.StatusOK, gitResolveResponse{
-    Ok:       true,
-    Path:     req.Path,
-    Strategy: req.Strategy,
-  })
+	writeJSON(w, http.StatusOK, gitResolveResponse{
+		Ok:       true,
+		Path:     req.Path,
+		Strategy: req.Strategy,
+	})
 }
 
 func (s *server) handleGitDiscard(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req gitDiscardRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req gitDiscardRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  relPath, absPath, err := s.resolveRelPath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
+	relPath, absPath, err := s.resolveRelPath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
-  entries, statusErr := s.gitStatusEntries(r.Context(), relPath)
-  if statusErr != nil {
-    writeError(w, http.StatusBadGateway, statusErr.Error())
-    return
-  }
+	entries, statusErr := s.gitStatusEntries(r.Context(), relPath)
+	if statusErr != nil {
+		writeError(w, http.StatusBadGateway, statusErr.Error())
+		return
+	}
 
-  var entry *gitStatusEntry
-  for i := range entries {
-    if entries[i].Path == relPath {
-      entry = &entries[i]
-      break
-    }
-  }
-  if entry == nil {
-    writeError(w, http.StatusNotFound, "not_modified")
-    return
-  }
+	var entry *gitStatusEntry
+	for i := range entries {
+		if entries[i].Path == relPath {
+			entry = &entries[i]
+			break
+		}
+	}
+	if entry == nil {
+		writeError(w, http.StatusNotFound, "not_modified")
+		return
+	}
 
-  // Untracked files can be safely removed without involving git.
-  if entry.Untracked {
-    if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-      writeError(w, http.StatusInternalServerError, "delete_failed")
-      return
-    }
-    writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
-    return
-  }
+	// Untracked files can be safely removed without involving git.
+	if entry.Untracked {
+		if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			writeError(w, http.StatusInternalServerError, "delete_failed")
+			return
+		}
+		writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
+		return
+	}
 
-  // Best-effort: clear index state for this path (helps with conflict stages).
-  _, resetErrOut, resetCode, resetExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "reset", "-q", "--", relPath,
-  })
-  if resetExecErr != nil {
-    writeError(w, http.StatusBadGateway, "git_reset_failed")
-    return
-  }
-  if resetCode != 0 {
-    msg := strings.TrimSpace(resetErrOut)
-    // Ignore common "pathspec" errors (e.g. when the path only exists in the index).
-    if msg != "" && !strings.Contains(strings.ToLower(msg), "pathspec") {
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
-  }
+	// Best-effort: clear index state for this path (helps with conflict stages).
+	_, resetErrOut, resetCode, resetExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "reset", "-q", "--", relPath,
+	})
+	if resetExecErr != nil {
+		writeError(w, http.StatusBadGateway, "git_reset_failed")
+		return
+	}
+	if resetCode != 0 {
+		msg := strings.TrimSpace(resetErrOut)
+		// Ignore common "pathspec" errors (e.g. when the path only exists in the index).
+		if msg != "" && !strings.Contains(strings.ToLower(msg), "pathspec") {
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
+	}
 
-  // If the path exists in HEAD, restore it. Otherwise, drop it from the index and delete it.
-  _, _, catCode, _ := runCmd(r.Context(), s.workspace, []string{
-    "git", "cat-file", "-e", "HEAD:" + relPath,
-  })
+	// If the path exists in HEAD, restore it. Otherwise, drop it from the index and delete it.
+	_, _, catCode, _ := runCmd(r.Context(), s.workspace, []string{
+		"git", "cat-file", "-e", "HEAD:" + relPath,
+	})
 
-  if catCode == 0 {
-    _, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
-      "git", "checkout", "--", relPath,
-    })
-    if checkoutExecErr != nil || checkoutCode != 0 {
-      msg := strings.TrimSpace(checkoutErr)
-      if msg == "" {
-        msg = "git_checkout_failed"
-      }
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
+	if catCode == 0 {
+		_, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
+			"git", "checkout", "--", relPath,
+		})
+		if checkoutExecErr != nil || checkoutCode != 0 {
+			msg := strings.TrimSpace(checkoutErr)
+			if msg == "" {
+				msg = "git_checkout_failed"
+			}
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
 
-    writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
-    return
-  }
+		writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
+		return
+	}
 
-  // New tracked file (not in HEAD).
-  _, rmErr, rmCode, rmExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "rm", "-f", "--cached", "--", relPath,
-  })
-  if rmExecErr != nil {
-    writeError(w, http.StatusBadGateway, "git_rm_failed")
-    return
-  }
-  if rmCode != 0 {
-    // If it wasn't in the index, keep going.
-    _ = rmErr
-  }
+	// New tracked file (not in HEAD).
+	_, rmErr, rmCode, rmExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "rm", "-f", "--cached", "--", relPath,
+	})
+	if rmExecErr != nil {
+		writeError(w, http.StatusBadGateway, "git_rm_failed")
+		return
+	}
+	if rmCode != 0 {
+		// If it wasn't in the index, keep going.
+		_ = rmErr
+	}
 
-  if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-    writeError(w, http.StatusInternalServerError, "delete_failed")
-    return
-  }
-  writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
+	if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		writeError(w, http.StatusInternalServerError, "delete_failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
 }
 
 func (s *server) handleFileRead(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req fileReadRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req fileReadRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  path, err := s.resolvePath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
-  if err := s.ensurePathWithinWorkspace(path); err != nil {
-    writeError(w, http.StatusForbidden, err.Error())
-    return
-  }
+	path, err := s.resolvePath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := s.ensurePathWithinWorkspace(path); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
 
-  info, err := os.Stat(path)
-  if err != nil {
-    if os.IsNotExist(err) {
-      writeError(w, http.StatusNotFound, "not_found")
-      return
-    }
-    writeError(w, http.StatusInternalServerError, "stat_failed")
-    return
-  }
-  if info.IsDir() {
-    writeError(w, http.StatusBadRequest, "is_directory")
-    return
-  }
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeError(w, http.StatusNotFound, "not_found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "stat_failed")
+		return
+	}
+	if info.IsDir() {
+		writeError(w, http.StatusBadRequest, "is_directory")
+		return
+	}
 
-  data, err := os.ReadFile(path)
-  if err != nil {
-    writeError(w, http.StatusInternalServerError, "read_failed")
-    return
-  }
+	data, err := os.ReadFile(path)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "read_failed")
+		return
+	}
 
-  content, encoding := encodeContent(data)
-  writeJSON(w, http.StatusOK, fileReadResponse{
-    Ok:       true,
-    Path:     req.Path,
-    Content:  content,
-    Encoding: encoding,
-    Hash:     hashBytes(data),
-  })
+	content, encoding := encodeContent(data)
+	writeJSON(w, http.StatusOK, fileReadResponse{
+		Ok:       true,
+		Path:     req.Path,
+		Content:  content,
+		Encoding: encoding,
+		Hash:     hashBytes(data),
+	})
 }
 
 func (s *server) handleFileList(w http.ResponseWriter, r *http.Request) {
@@ -732,46 +742,46 @@ func (s *server) handleFileList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleFileWrite(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req fileWriteRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req fileWriteRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  path, err := s.resolvePath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
-  if err := s.ensurePathWithinWorkspace(path); err != nil {
-    writeError(w, http.StatusForbidden, err.Error())
-    return
-  }
+	path, err := s.resolvePath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := s.ensurePathWithinWorkspace(path); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
 
-  if req.ExpectedHash != "" {
-    currentHash, ok, err := verifyExpectedHash(path, req.ExpectedHash)
-    if err != nil {
-      if errors.Is(err, os.ErrNotExist) {
-        writeError(w, http.StatusNotFound, "not_found")
-        return
-      }
-      writeError(w, http.StatusInternalServerError, "hash_check_failed")
-      return
-    }
-    if !ok {
-      writeJSON(w, http.StatusConflict, map[string]any{
-        "ok":          false,
-        "error":       "conflict",
-        "currentHash": currentHash,
-      })
-      return
-    }
-  }
+	if req.ExpectedHash != "" {
+		currentHash, ok, err := verifyExpectedHash(path, req.ExpectedHash)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				writeError(w, http.StatusNotFound, "not_found")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "hash_check_failed")
+			return
+		}
+		if !ok {
+			writeJSON(w, http.StatusConflict, map[string]any{
+				"ok":          false,
+				"error":       "conflict",
+				"currentHash": currentHash,
+			})
+			return
+		}
+	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		writeError(w, http.StatusInternalServerError, "mkdir_failed")
@@ -798,59 +808,103 @@ func (s *server) handleFileWrite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-  data, err := os.ReadFile(path)
-  if err != nil {
-    writeError(w, http.StatusInternalServerError, "read_failed")
-    return
-  }
+	data, err := os.ReadFile(path)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "read_failed")
+		return
+	}
 
-  writeJSON(w, http.StatusOK, fileWriteResponse{
-    Ok:   true,
-    Path: req.Path,
-    Hash: hashBytes(data),
-  })
+	writeJSON(w, http.StatusOK, fileWriteResponse{
+		Ok:   true,
+		Path: req.Path,
+		Hash: hashBytes(data),
+	})
+}
+
+func (s *server) handleFileUpload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
+
+	relPath, path, err := s.resolveRelPath(r.URL.Query().Get("path"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		writeError(w, http.StatusInternalServerError, "mkdir_failed")
+		return
+	}
+
+	limitedBody := http.MaxBytesReader(w, r.Body, maxUploadBodyBytes)
+	hash, size, err := writeStreamFileAtomic(path, limitedBody, 0o644)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "file_too_large")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "write_failed")
+		return
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "stat_failed")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, fileUploadResponse{
+		Ok:         true,
+		Path:       relPath,
+		Hash:       hash,
+		Size:       size,
+		ModifiedAt: info.ModTime().UnixMilli(),
+	})
 }
 
 func (s *server) handleFileDelete(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req fileDeleteRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req fileDeleteRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  path, err := s.resolvePath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
-  if err := s.ensurePathWithinWorkspace(path); err != nil {
-    writeError(w, http.StatusForbidden, err.Error())
-    return
-  }
+	path, err := s.resolvePath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := s.ensurePathWithinWorkspace(path); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
 
-  info, err := os.Stat(path)
-  if err != nil {
-    if os.IsNotExist(err) {
-      writeError(w, http.StatusNotFound, "not_found")
-      return
-    }
-    writeError(w, http.StatusInternalServerError, "stat_failed")
-    return
-  }
-  if info.IsDir() {
-    writeError(w, http.StatusBadRequest, "is_directory")
-    return
-  }
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeError(w, http.StatusNotFound, "not_found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "stat_failed")
+		return
+	}
+	if info.IsDir() {
+		writeError(w, http.StatusBadRequest, "is_directory")
+		return
+	}
 
-  if err := os.Remove(path); err != nil {
-    writeError(w, http.StatusInternalServerError, "delete_failed")
-    return
-  }
+	if err := os.Remove(path); err != nil {
+		writeError(w, http.StatusInternalServerError, "delete_failed")
+		return
+	}
 
 	writeJSON(w, http.StatusOK, fileDeleteResponse{
 		Ok:      true,
@@ -939,43 +993,43 @@ func (s *server) handleFileRename(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleApplyPatch(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req fileApplyPatchRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
-  if strings.TrimSpace(req.Patch) == "" {
-    writeError(w, http.StatusBadRequest, "empty_patch")
-    return
-  }
+	var req fileApplyPatchRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
+	if strings.TrimSpace(req.Patch) == "" {
+		writeError(w, http.StatusBadRequest, "empty_patch")
+		return
+	}
 
-  cmd := exec.CommandContext(r.Context(), "git", "apply", "--whitespace=nowarn", "--")
-  cmd.Dir = s.workspace
-  cmd.Stdin = strings.NewReader(req.Patch)
-  var stdout bytes.Buffer
-  var stderr bytes.Buffer
-  cmd.Stdout = &stdout
-  cmd.Stderr = &stderr
+	cmd := exec.CommandContext(r.Context(), "git", "apply", "--whitespace=nowarn", "--")
+	cmd.Dir = s.workspace
+	cmd.Stdin = strings.NewReader(req.Patch)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
-  err := cmd.Run()
-  if err != nil {
-    msg := strings.TrimSpace(stderr.String())
-    if msg == "" {
-      msg = "apply_patch_failed"
-    }
-    writeJSON(w, http.StatusConflict, map[string]any{
-      "ok":    false,
-      "error": msg,
-    })
-    return
-  }
+	err := cmd.Run()
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = "apply_patch_failed"
+		}
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"ok":    false,
+			"error": msg,
+		})
+		return
+	}
 
-  writeJSON(w, http.StatusOK, fileApplyPatchResponse{Ok: true})
+	writeJSON(w, http.StatusOK, fileApplyPatchResponse{Ok: true})
 }
 
 // fetchAndMergeKb fetches from the kb remote and merges the remote branch.
@@ -983,351 +1037,351 @@ func (s *server) handleApplyPatch(w http.ResponseWriter, r *http.Request) {
 // was no remote branch yet). If ok is false and conflicts is non-empty the merge
 // produced conflicts. Otherwise errMsg describes the failure.
 func (s *server) fetchAndMergeKb(ctx context.Context) (bool, []string, string) {
-  _, fetchErr, fetchCode, fetchExecErr := runCmd(ctx, s.workspace, []string{
-    "git", "fetch", "kb",
-  })
-  if fetchExecErr != nil || fetchCode != 0 {
-    msg := strings.TrimSpace(fetchErr)
-    if msg == "" {
-      msg = "fetch_failed"
-    }
-    return false, nil, "Fetch failed: " + msg
-  }
+	_, fetchErr, fetchCode, fetchExecErr := runCmd(ctx, s.workspace, []string{
+		"git", "fetch", "kb",
+	})
+	if fetchExecErr != nil || fetchCode != 0 {
+		msg := strings.TrimSpace(fetchErr)
+		if msg == "" {
+			msg = "fetch_failed"
+		}
+		return false, nil, "Fetch failed: " + msg
+	}
 
-  kbBranch := s.resolveKbBranch(ctx)
+	kbBranch := s.resolveKbBranch(ctx)
 
-  if !s.remoteBranchExists(ctx, kbBranch) {
-    // First publish — nothing to merge.
-    return true, nil, ""
-  }
+	if !s.remoteBranchExists(ctx, kbBranch) {
+		// First publish — nothing to merge.
+		return true, nil, ""
+	}
 
-  _, mergeErr, mergeCode, mergeExecErr := runCmd(ctx, s.workspace, []string{
-    "git", "merge", "kb/" + kbBranch, "--no-edit",
-  })
-  if mergeExecErr == nil && mergeCode == 0 {
-    return true, nil, ""
-  }
+	_, mergeErr, mergeCode, mergeExecErr := runCmd(ctx, s.workspace, []string{
+		"git", "merge", "kb/" + kbBranch, "--no-edit",
+	})
+	if mergeExecErr == nil && mergeCode == 0 {
+		return true, nil, ""
+	}
 
-  if isUnrelatedHistoryError(mergeErr) {
-    _, mergeErrAllow, mergeCodeAllow, mergeExecErrAllow := runCmd(ctx, s.workspace, []string{
-      "git", "merge", "kb/" + kbBranch, "--no-edit", "--allow-unrelated-histories",
-    })
-    if mergeExecErrAllow == nil && mergeCodeAllow == 0 {
-      return true, nil, ""
-    }
+	if isUnrelatedHistoryError(mergeErr) {
+		_, mergeErrAllow, mergeCodeAllow, mergeExecErrAllow := runCmd(ctx, s.workspace, []string{
+			"git", "merge", "kb/" + kbBranch, "--no-edit", "--allow-unrelated-histories",
+		})
+		if mergeExecErrAllow == nil && mergeCodeAllow == 0 {
+			return true, nil, ""
+		}
 
-    conflicts := s.listConflictFiles(ctx)
-    if len(conflicts) > 0 {
-      return false, conflicts, "Merge has conflicts that need to be resolved"
-    }
+		conflicts := s.listConflictFiles(ctx)
+		if len(conflicts) > 0 {
+			return false, conflicts, "Merge has conflicts that need to be resolved"
+		}
 
-    msg := strings.TrimSpace(mergeErrAllow)
-    if msg == "" {
-      msg = "merge_failed"
-    }
-    return false, nil, "Merge failed: " + msg
-  }
+		msg := strings.TrimSpace(mergeErrAllow)
+		if msg == "" {
+			msg = "merge_failed"
+		}
+		return false, nil, "Merge failed: " + msg
+	}
 
-  conflicts := s.listConflictFiles(ctx)
-  if len(conflicts) > 0 {
-    return false, conflicts, "Merge has conflicts that need to be resolved"
-  }
+	conflicts := s.listConflictFiles(ctx)
+	if len(conflicts) > 0 {
+		return false, conflicts, "Merge has conflicts that need to be resolved"
+	}
 
-  msg := strings.TrimSpace(mergeErr)
-  if msg == "" {
-    msg = "merge_failed"
-  }
-  return false, nil, "Merge failed: " + msg
+	msg := strings.TrimSpace(mergeErr)
+	if msg == "" {
+		msg = "merge_failed"
+	}
+	return false, nil, "Merge failed: " + msg
 }
 
 func (s *server) handleKbSync(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  _, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "remote", "get-url", "kb",
-  })
-  if remoteExecErr != nil || remoteCode != 0 {
-    writeJSON(w, http.StatusOK, syncKbResponse{
-      Ok:      false,
-      Status:  "no_remote",
-      Message: "KB remote not configured. Workspace may not have been initialized with KB.",
-    })
-    return
-  }
+	_, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "remote", "get-url", "kb",
+	})
+	if remoteExecErr != nil || remoteCode != 0 {
+		writeJSON(w, http.StatusOK, syncKbResponse{
+			Ok:      false,
+			Status:  "no_remote",
+			Message: "KB remote not configured. Workspace may not have been initialized with KB.",
+		})
+		return
+	}
 
-  mergeOk, conflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
-  if mergeOk {
-    writeJSON(w, http.StatusOK, syncKbResponse{
-      Ok:      true,
-      Status:  "synced",
-      Message: "KB synchronized successfully",
-    })
-    return
-  }
+	mergeOk, conflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
+	if mergeOk {
+		writeJSON(w, http.StatusOK, syncKbResponse{
+			Ok:      true,
+			Status:  "synced",
+			Message: "KB synchronized successfully",
+		})
+		return
+	}
 
-  if len(conflicts) > 0 {
-    writeJSON(w, http.StatusOK, syncKbResponse{
-      Ok:        true,
-      Status:    "conflicts",
-      Message:   "Merge has conflicts that need to be resolved",
-      Conflicts: conflicts,
-    })
-    return
-  }
+	if len(conflicts) > 0 {
+		writeJSON(w, http.StatusOK, syncKbResponse{
+			Ok:        true,
+			Status:    "conflicts",
+			Message:   "Merge has conflicts that need to be resolved",
+			Conflicts: conflicts,
+		})
+		return
+	}
 
-  writeJSON(w, http.StatusOK, syncKbResponse{
-    Ok:      false,
-    Status:  "error",
-    Message: mergeErrMsg,
-  })
+	writeJSON(w, http.StatusOK, syncKbResponse{
+		Ok:      false,
+		Status:  "error",
+		Message: mergeErrMsg,
+	})
 }
 
 func (s *server) handleKbStatus(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodGet {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  conflicts := s.listConflictFiles(r.Context())
-  writeJSON(w, http.StatusOK, syncStatusResponse{
-    Ok:           true,
-    HasConflicts: len(conflicts) > 0,
-    Conflicts:    conflicts,
-  })
+	conflicts := s.listConflictFiles(r.Context())
+	writeJSON(w, http.StatusOK, syncStatusResponse{
+		Ok:           true,
+		HasConflicts: len(conflicts) > 0,
+		Conflicts:    conflicts,
+	})
 }
 
 func (s *server) handleKbPublish(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  _, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "remote", "get-url", "kb",
-  })
-  if remoteExecErr != nil || remoteCode != 0 {
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "no_remote",
-      Message: "KB remote not configured.",
-    })
-    return
-  }
+	_, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "remote", "get-url", "kb",
+	})
+	if remoteExecErr != nil || remoteCode != 0 {
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "no_remote",
+			Message: "KB remote not configured.",
+		})
+		return
+	}
 
-  conflicts := s.listConflictFiles(r.Context())
-  if len(conflicts) > 0 {
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "conflicts",
-      Files:   conflicts,
-      Message: "Resolve conflicts before publishing.",
-    })
-    return
-  }
+	conflicts := s.listConflictFiles(r.Context())
+	if len(conflicts) > 0 {
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "conflicts",
+			Files:   conflicts,
+			Message: "Resolve conflicts before publishing.",
+		})
+		return
+	}
 
-  entries, statusErr := s.gitStatusEntries(r.Context())
-  if statusErr != nil {
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "error",
-      Message: statusErr.Error(),
-    })
-    return
-  }
+	entries, statusErr := s.gitStatusEntries(r.Context())
+	if statusErr != nil {
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "error",
+			Message: statusErr.Error(),
+		})
+		return
+	}
 
-  if len(entries) == 0 {
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      true,
-      Status:  "nothing_to_publish",
-      Message: "Nothing to publish.",
-    })
-    return
-  }
+	if len(entries) == 0 {
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      true,
+			Status:  "nothing_to_publish",
+			Message: "Nothing to publish.",
+		})
+		return
+	}
 
-  _, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "add", "-A",
-  })
-  if addExecErr != nil || addCode != 0 {
-    msg := strings.TrimSpace(addErr)
-    if msg == "" {
-      msg = "git_add_failed"
-    }
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "error",
-      Message: "git add failed: " + msg,
-    })
-    return
-  }
+	_, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "add", "-A",
+	})
+	if addExecErr != nil || addCode != 0 {
+		msg := strings.TrimSpace(addErr)
+		if msg == "" {
+			msg = "git_add_failed"
+		}
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "error",
+			Message: "git add failed: " + msg,
+		})
+		return
+	}
 
-  statOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
-    "git", "diff", "--cached", "--stat",
-  })
-  commitMessage := generateCommitMessage(statOut)
+	statOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
+		"git", "diff", "--cached", "--stat",
+	})
+	commitMessage := generateCommitMessage(statOut)
 
-  _, commitErr, commitCode, commitExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "commit", "-m", commitMessage,
-  })
-  if commitExecErr != nil || commitCode != 0 {
-    msg := strings.TrimSpace(commitErr)
-    if msg == "" {
-      msg = "git_commit_failed"
-    }
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "error",
-      Message: "git commit failed: " + msg,
-    })
-    return
-  }
+	_, commitErr, commitCode, commitExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "commit", "-m", commitMessage,
+	})
+	if commitExecErr != nil || commitCode != 0 {
+		msg := strings.TrimSpace(commitErr)
+		if msg == "" {
+			msg = "git_commit_failed"
+		}
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "error",
+			Message: "git commit failed: " + msg,
+		})
+		return
+	}
 
-  hashOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
-    "git", "rev-parse", "--short", "HEAD",
-  })
-  commitHash := strings.TrimSpace(hashOut)
+	hashOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
+		"git", "rev-parse", "--short", "HEAD",
+	})
+	commitHash := strings.TrimSpace(hashOut)
 
-  filesOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
-    "git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD",
-  })
-  files := splitLines(filesOut)
+	filesOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
+		"git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD",
+	})
+	files := splitLines(filesOut)
 
-  // Fetch and merge remote before pushing to avoid rejected pushes.
-  mergeOk, mergeConflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
-  if !mergeOk {
-    if len(mergeConflicts) > 0 {
-      writeJSON(w, http.StatusOK, publishKbResponse{
-        Ok:      false,
-        Status:  "conflicts",
-        Files:   mergeConflicts,
-        Message: "Merge conflicts during publish. Resolve and retry.",
-      })
-      return
-    }
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "error",
-      Message: mergeErrMsg,
-    })
-    return
-  }
+	// Fetch and merge remote before pushing to avoid rejected pushes.
+	mergeOk, mergeConflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
+	if !mergeOk {
+		if len(mergeConflicts) > 0 {
+			writeJSON(w, http.StatusOK, publishKbResponse{
+				Ok:      false,
+				Status:  "conflicts",
+				Files:   mergeConflicts,
+				Message: "Merge conflicts during publish. Resolve and retry.",
+			})
+			return
+		}
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "error",
+			Message: mergeErrMsg,
+		})
+		return
+	}
 
-  kbBranch := s.resolveKbBranch(r.Context())
-  _, pushErr, pushCode, pushExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "push", "kb", "HEAD:refs/heads/" + kbBranch,
-  })
-  if pushExecErr != nil || pushCode != 0 {
-    msg := strings.TrimSpace(pushErr)
-    if msg == "" {
-      msg = "git_push_failed"
-    }
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:         false,
-      Status:     "push_rejected",
-      CommitHash: commitHash,
-      Files:      files,
-      Message:    msg,
-    })
-    return
-  }
+	kbBranch := s.resolveKbBranch(r.Context())
+	_, pushErr, pushCode, pushExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "push", "kb", "HEAD:refs/heads/" + kbBranch,
+	})
+	if pushExecErr != nil || pushCode != 0 {
+		msg := strings.TrimSpace(pushErr)
+		if msg == "" {
+			msg = "git_push_failed"
+		}
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:         false,
+			Status:     "push_rejected",
+			CommitHash: commitHash,
+			Files:      files,
+			Message:    msg,
+		})
+		return
+	}
 
-  writeJSON(w, http.StatusOK, publishKbResponse{
-    Ok:         true,
-    Status:     "published",
-    CommitHash: commitHash,
-    Files:      files,
-  })
+	writeJSON(w, http.StatusOK, publishKbResponse{
+		Ok:         true,
+		Status:     "published",
+		CommitHash: commitHash,
+		Files:      files,
+	})
 }
 
 func (s *server) gitStatusEntries(ctx context.Context, paths ...string) ([]gitStatusEntry, error) {
-  args := []string{"git", "-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=all"}
-  if len(paths) > 0 {
-    args = append(args, "--")
-    args = append(args, paths...)
-  }
-  out, stderr, code, err := runCmd(ctx, s.workspace, args)
-  if err != nil || code != 0 {
-    msg := strings.TrimSpace(stderr)
-    if msg == "" {
-      msg = "git_status_failed"
-    }
-    return nil, errors.New(msg)
-  }
-  return parseGitStatus(out), nil
+	args := []string{"git", "-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=all"}
+	if len(paths) > 0 {
+		args = append(args, "--")
+		args = append(args, paths...)
+	}
+	out, stderr, code, err := runCmd(ctx, s.workspace, args)
+	if err != nil || code != 0 {
+		msg := strings.TrimSpace(stderr)
+		if msg == "" {
+			msg = "git_status_failed"
+		}
+		return nil, errors.New(msg)
+	}
+	return parseGitStatus(out), nil
 }
 
 func (s *server) listConflictFiles(ctx context.Context) []string {
-  entries, _ := s.gitStatusEntries(ctx)
-  var result []string
-  for _, e := range entries {
-    if e.Conflicted {
-      result = append(result, e.Path)
-    }
-  }
-  return result
+	entries, _ := s.gitStatusEntries(ctx)
+	var result []string
+	for _, e := range entries {
+		if e.Conflicted {
+			result = append(result, e.Path)
+		}
+	}
+	return result
 }
 
 func isUnrelatedHistoryError(message string) bool {
-  msg := strings.ToLower(message)
-  return strings.Contains(msg, "unrelated histories")
+	msg := strings.ToLower(message)
+	return strings.Contains(msg, "unrelated histories")
 }
 
 func (s *server) resolveKbBranch(ctx context.Context) string {
-  _, _, _, _ = runCmd(ctx, s.workspace, []string{
-    "git", "remote", "set-head", "kb", "-a",
-  })
+	_, _, _, _ = runCmd(ctx, s.workspace, []string{
+		"git", "remote", "set-head", "kb", "-a",
+	})
 
-  headOut, _, headCode, _ := runCmd(ctx, s.workspace, []string{
-    "git", "symbolic-ref", "-q", "--short", "refs/remotes/kb/HEAD",
-  })
-  headRef := strings.TrimSpace(headOut)
-  if headCode == 0 && strings.HasPrefix(headRef, "kb/") {
-    branch := strings.TrimPrefix(headRef, "kb/")
-    if branch != "" {
-      return branch
-    }
-  }
+	headOut, _, headCode, _ := runCmd(ctx, s.workspace, []string{
+		"git", "symbolic-ref", "-q", "--short", "refs/remotes/kb/HEAD",
+	})
+	headRef := strings.TrimSpace(headOut)
+	if headCode == 0 && strings.HasPrefix(headRef, "kb/") {
+		branch := strings.TrimPrefix(headRef, "kb/")
+		if branch != "" {
+			return branch
+		}
+	}
 
-  if s.remoteBranchExists(ctx, "main") {
-    return "main"
-  }
+	if s.remoteBranchExists(ctx, "main") {
+		return "main"
+	}
 
-  current := s.currentBranch(ctx)
-  if current != "" && s.remoteBranchExists(ctx, current) {
-    return current
-  }
+	current := s.currentBranch(ctx)
+	if current != "" && s.remoteBranchExists(ctx, current) {
+		return current
+	}
 
-  return "main"
+	return "main"
 }
 
 func (s *server) remoteBranchExists(ctx context.Context, branch string) bool {
-  _, _, code, _ := runCmd(ctx, s.workspace, []string{
-    "git", "show-ref", "--verify", "--quiet", "refs/remotes/kb/" + branch,
-  })
-  return code == 0
+	_, _, code, _ := runCmd(ctx, s.workspace, []string{
+		"git", "show-ref", "--verify", "--quiet", "refs/remotes/kb/" + branch,
+	})
+	return code == 0
 }
 
 func (s *server) currentBranch(ctx context.Context) string {
-  out, _, code, _ := runCmd(ctx, s.workspace, []string{
-    "git", "rev-parse", "--abbrev-ref", "HEAD",
-  })
-  if code != 0 {
-    return ""
-  }
-  branch := strings.TrimSpace(out)
-  if branch == "" || branch == "HEAD" {
-    return ""
-  }
-  return branch
+	out, _, code, _ := runCmd(ctx, s.workspace, []string{
+		"git", "rev-parse", "--abbrev-ref", "HEAD",
+	})
+	if code != 0 {
+		return ""
+	}
+	branch := strings.TrimSpace(out)
+	if branch == "" || branch == "HEAD" {
+		return ""
+	}
+	return branch
 }
 
 type gitStatusEntry struct {
-  Path      string
-  Status    string
-  Untracked bool
-  Conflicted bool
+	Path       string
+	Status     string
+	Untracked  bool
+	Conflicted bool
 }
 
 func isInternalWorkspacePath(path string) bool {
@@ -1343,290 +1397,319 @@ func isInternalWorkspacePath(path string) bool {
 }
 
 func parseGitStatus(output string) []gitStatusEntry {
-  raw := []byte(output)
-  if len(raw) == 0 {
-    return nil
-  }
-  parts := bytes.Split(raw, []byte{0})
-  results := make([]gitStatusEntry, 0, len(parts))
-  for i := 0; i < len(parts); i++ {
-    entry := parts[i]
-    if len(entry) == 0 {
-      continue
-    }
-    // git status --porcelain=v1 -z output is:
-    //   XY<space>PATH\0
-    // where X and Y can be spaces. Do NOT split on the first space.
-    if len(entry) < 4 {
-      continue
-    }
-    statusField := string(entry[:2])
-    if statusField == "!!" {
-      continue
-    }
+	raw := []byte(output)
+	if len(raw) == 0 {
+		return nil
+	}
+	parts := bytes.Split(raw, []byte{0})
+	results := make([]gitStatusEntry, 0, len(parts))
+	for i := 0; i < len(parts); i++ {
+		entry := parts[i]
+		if len(entry) == 0 {
+			continue
+		}
+		// git status --porcelain=v1 -z output is:
+		//   XY<space>PATH\0
+		// where X and Y can be spaces. Do NOT split on the first space.
+		if len(entry) < 4 {
+			continue
+		}
+		statusField := string(entry[:2])
+		if statusField == "!!" {
+			continue
+		}
 
-    // After the two status characters there is a single space.
-    // We keep the raw path as-is (no TrimSpace) because it is a filename.
-    path := string(entry[3:])
+		// After the two status characters there is a single space.
+		// We keep the raw path as-is (no TrimSpace) because it is a filename.
+		path := string(entry[3:])
 
-    // For renames/copies, git status -z provides a second NUL-separated path.
-    // The first path is the source; the second is the destination.
-    if len(statusField) > 0 && (statusField[0] == 'R' || statusField[0] == 'C') {
-      if i+1 < len(parts) && len(parts[i+1]) > 0 {
-        path = string(parts[i+1])
-        i++
-      }
-    }
+		// For renames/copies, git status -z provides a second NUL-separated path.
+		// The first path is the source; the second is the destination.
+		if len(statusField) > 0 && (statusField[0] == 'R' || statusField[0] == 'C') {
+			if i+1 < len(parts) && len(parts[i+1]) > 0 {
+				path = string(parts[i+1])
+				i++
+			}
+		}
 
-    if path == "" {
-      continue
-    }
-    if isInternalWorkspacePath(path) {
-      continue
-    }
+		if path == "" {
+			continue
+		}
+		if isInternalWorkspacePath(path) {
+			continue
+		}
 
-    untracked := statusField == "??"
-    conflicted := strings.Contains(statusField, "U") || statusField == "AA" || statusField == "DD"
-    fileStatus := "modified"
-    if untracked || strings.Contains(statusField, "A") || (len(statusField) > 0 && statusField[0] == 'C') {
-      fileStatus = "added"
-    } else if strings.Contains(statusField, "D") {
-      fileStatus = "deleted"
-    }
+		untracked := statusField == "??"
+		conflicted := strings.Contains(statusField, "U") || statusField == "AA" || statusField == "DD"
+		fileStatus := "modified"
+		if untracked || strings.Contains(statusField, "A") || (len(statusField) > 0 && statusField[0] == 'C') {
+			fileStatus = "added"
+		} else if strings.Contains(statusField, "D") {
+			fileStatus = "deleted"
+		}
 
-    results = append(results, gitStatusEntry{
-      Path:      path,
-      Status:    fileStatus,
-      Untracked: untracked,
-      Conflicted: conflicted,
-    })
-  }
-  return results
+		results = append(results, gitStatusEntry{
+			Path:       path,
+			Status:     fileStatus,
+			Untracked:  untracked,
+			Conflicted: conflicted,
+		})
+	}
+	return results
 }
 
 func parseNumstat(output string) (int, int) {
-  line := ""
-  for _, candidate := range strings.Split(strings.TrimSpace(output), "\n") {
-    if strings.TrimSpace(candidate) != "" {
-      line = candidate
-      break
-    }
-  }
-  if line == "" {
-    return 0, 0
-  }
-  fields := strings.Split(line, "\t")
-  if len(fields) < 2 {
-    return 0, 0
-  }
-  add := parseNum(fields[0])
-  del := parseNum(fields[1])
-  return add, del
+	line := ""
+	for _, candidate := range strings.Split(strings.TrimSpace(output), "\n") {
+		if strings.TrimSpace(candidate) != "" {
+			line = candidate
+			break
+		}
+	}
+	if line == "" {
+		return 0, 0
+	}
+	fields := strings.Split(line, "\t")
+	if len(fields) < 2 {
+		return 0, 0
+	}
+	add := parseNum(fields[0])
+	del := parseNum(fields[1])
+	return add, del
 }
 
 func parseNum(value string) int {
-  if value == "-" {
-    return 0
-  }
-  parsed, err := strconv.Atoi(value)
-  if err != nil {
-    return 0
-  }
-  return parsed
+	if value == "-" {
+		return 0
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0
+	}
+	return parsed
 }
 
 func splitLines(output string) []string {
-  lines := strings.Split(output, "\n")
-  result := make([]string, 0, len(lines))
-  for _, line := range lines {
-    trimmed := strings.TrimSpace(line)
-    if trimmed != "" {
-      result = append(result, trimmed)
-    }
-  }
-  return result
+	lines := strings.Split(output, "\n")
+	result := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }
 
 func generateCommitMessage(statOutput string) string {
-  lines := splitLines(statOutput)
-  fileNames := make([]string, 0, len(lines))
+	lines := splitLines(statOutput)
+	fileNames := make([]string, 0, len(lines))
 
-  for _, line := range lines {
-    if !strings.Contains(line, "|") {
-      continue
-    }
-    parts := strings.Split(line, "|")
-    if len(parts) == 0 {
-      continue
-    }
-    name := strings.TrimSpace(parts[0])
-    if name != "" {
-      fileNames = append(fileNames, name)
-    }
-  }
+	for _, line := range lines {
+		if !strings.Contains(line, "|") {
+			continue
+		}
+		parts := strings.Split(line, "|")
+		if len(parts) == 0 {
+			continue
+		}
+		name := strings.TrimSpace(parts[0])
+		if name != "" {
+			fileNames = append(fileNames, name)
+		}
+	}
 
-  if len(fileNames) == 0 {
-    return "Update files"
-  }
-  if len(fileNames) <= 3 {
-    return "Update " + strings.Join(fileNames, ", ")
-  }
-  return "Update " + strconv.Itoa(len(fileNames)) + " files"
+	if len(fileNames) == 0 {
+		return "Update files"
+	}
+	if len(fileNames) <= 3 {
+		return "Update " + strings.Join(fileNames, ", ")
+	}
+	return "Update " + strconv.Itoa(len(fileNames)) + " files"
 }
 
 func runCmd(ctx context.Context, dir string, args []string) (string, string, int, error) {
-  if len(args) == 0 {
-    return "", "", 1, errors.New("no_command")
-  }
-  cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-  cmd.Dir = dir
-  var stdout bytes.Buffer
-  var stderr bytes.Buffer
-  cmd.Stdout = &stdout
-  cmd.Stderr = &stderr
-  err := cmd.Run()
-  if err != nil {
-    var exitErr *exec.ExitError
-    if errors.As(err, &exitErr) {
-      return stdout.String(), stderr.String(), exitErr.ExitCode(), nil
-    }
-    return stdout.String(), stderr.String(), 1, err
-  }
-  return stdout.String(), stderr.String(), 0, nil
+	if len(args) == 0 {
+		return "", "", 1, errors.New("no_command")
+	}
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Dir = dir
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return stdout.String(), stderr.String(), exitErr.ExitCode(), nil
+		}
+		return stdout.String(), stderr.String(), 1, err
+	}
+	return stdout.String(), stderr.String(), 0, nil
 }
 
 func (s *server) readGitStage(ctx context.Context, stage int, relPath string) (string, error) {
-  spec := ":" + strconv.Itoa(stage) + ":" + relPath
-  out, _, code, execErr := runCmd(ctx, s.workspace, []string{
-    "git", "show", spec,
-  })
-  if execErr != nil {
-    return "", execErr
-  }
-  if code != 0 {
-    return "", nil
-  }
-  return out, nil
+	spec := ":" + strconv.Itoa(stage) + ":" + relPath
+	out, _, code, execErr := runCmd(ctx, s.workspace, []string{
+		"git", "show", spec,
+	})
+	if execErr != nil {
+		return "", execErr
+	}
+	if code != 0 {
+		return "", nil
+	}
+	return out, nil
 }
 
 func (s *server) resolveRelPath(rel string) (string, string, error) {
-  abs, err := s.resolvePath(rel)
-  if err != nil {
-    return "", "", err
-  }
-  workspaceAbs, err := filepath.Abs(s.workspace)
-  if err != nil {
-    return "", "", errors.New("workspace_invalid")
-  }
-  relPath, err := filepath.Rel(workspaceAbs, abs)
-  if err != nil {
-    return "", "", errors.New("invalid_path")
-  }
-  if relPath == "." || relPath == "" {
-    return "", "", errors.New("invalid_path")
-  }
-  return filepath.ToSlash(relPath), abs, nil
+	abs, err := s.resolvePath(rel)
+	if err != nil {
+		return "", "", err
+	}
+	workspaceAbs, err := filepath.Abs(s.workspace)
+	if err != nil {
+		return "", "", errors.New("workspace_invalid")
+	}
+	relPath, err := filepath.Rel(workspaceAbs, abs)
+	if err != nil {
+		return "", "", errors.New("invalid_path")
+	}
+	if relPath == "." || relPath == "" {
+		return "", "", errors.New("invalid_path")
+	}
+	return filepath.ToSlash(relPath), abs, nil
 }
 
 func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
-  dir := filepath.Dir(path)
-  temp, err := os.CreateTemp(dir, ".tmp-*")
-  if err != nil {
-    return err
-  }
-  tempName := temp.Name()
-  defer os.Remove(tempName)
+	dir := filepath.Dir(path)
+	temp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempName := temp.Name()
+	defer os.Remove(tempName)
 
-  if _, err := temp.Write(data); err != nil {
-    temp.Close()
-    return err
-  }
-  if err := temp.Chmod(perm); err != nil {
-    temp.Close()
-    return err
-  }
-  if err := temp.Close(); err != nil {
-    return err
-  }
-  return os.Rename(tempName, path)
+	if _, err := temp.Write(data); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Chmod(perm); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempName, path)
+}
+
+func writeStreamFileAtomic(path string, reader io.Reader, perm os.FileMode) (string, int64, error) {
+	dir := filepath.Dir(path)
+	temp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return "", 0, err
+	}
+	tempName := temp.Name()
+	defer os.Remove(tempName)
+
+	sum := sha256.New()
+	written, err := io.Copy(io.MultiWriter(temp, sum), reader)
+	if err != nil {
+		temp.Close()
+		return "", 0, err
+	}
+	if err := temp.Chmod(perm); err != nil {
+		temp.Close()
+		return "", 0, err
+	}
+	if err := temp.Close(); err != nil {
+		return "", 0, err
+	}
+	if err := os.Rename(tempName, path); err != nil {
+		return "", 0, err
+	}
+
+	return "sha256:" + hex.EncodeToString(sum.Sum(nil)), written, nil
 }
 
 func verifyExpectedHash(path string, expected string) (string, bool, error) {
-  data, err := os.ReadFile(path)
-  if err != nil {
-    return "", false, err
-  }
-  currentHash := hashBytes(data)
-  return currentHash, expected == currentHash, nil
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false, err
+	}
+	currentHash := hashBytes(data)
+	return currentHash, expected == currentHash, nil
 }
 
 func hashBytes(data []byte) string {
-  sum := sha256.Sum256(data)
-  return "sha256:" + hex.EncodeToString(sum[:])
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func encodeContent(data []byte) (string, string) {
-  if utf8.Valid(data) {
-    return string(data), "utf-8"
-  }
-  return base64.StdEncoding.EncodeToString(data), "base64"
+	if utf8.Valid(data) {
+		return string(data), "utf-8"
+	}
+	return base64.StdEncoding.EncodeToString(data), "base64"
 }
 
 func decodeJSON(w http.ResponseWriter, r *http.Request, target any) error {
-  r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
-  decoder := json.NewDecoder(r.Body)
-  if err := decoder.Decode(target); err != nil {
-    return err
-  }
-  if err := decoder.Decode(&struct{}{}); err != nil && !errors.Is(err, io.EOF) {
-    return errors.New("unexpected_data")
-  }
-  return nil
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != nil && !errors.Is(err, io.EOF) {
+		return errors.New("unexpected_data")
+	}
+	return nil
 }
 
 func writeJSON(w http.ResponseWriter, status int, payload any) {
-  w.Header().Set("Content-Type", "application/json")
-  w.WriteHeader(status)
-  encoder := json.NewEncoder(w)
-  encoder.SetEscapeHTML(false)
-  _ = encoder.Encode(payload)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	_ = encoder.Encode(payload)
 }
 
 func writeError(w http.ResponseWriter, status int, message string) {
-  writeJSON(w, status, errorResponse{Ok: false, Error: message})
+	writeJSON(w, status, errorResponse{Ok: false, Error: message})
 }
 
 func (s *server) resolvePath(rel string) (string, error) {
-  if strings.TrimSpace(rel) == "" {
-    return "", errors.New("path_required")
-  }
-  if strings.Contains(rel, "\x00") {
-    return "", errors.New("invalid_path")
-  }
-  if filepath.IsAbs(rel) {
-    return "", errors.New("absolute_paths_not_allowed")
-  }
+	if strings.TrimSpace(rel) == "" {
+		return "", errors.New("path_required")
+	}
+	if strings.Contains(rel, "\x00") {
+		return "", errors.New("invalid_path")
+	}
+	if filepath.IsAbs(rel) {
+		return "", errors.New("absolute_paths_not_allowed")
+	}
 
-  cleaned := filepath.Clean(rel)
-  if cleaned == "." || cleaned == "" {
-    return "", errors.New("invalid_path")
-  }
-  if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(os.PathSeparator)) {
-    return "", errors.New("path_outside_workspace")
-  }
-  if cleaned == ".git" || strings.HasPrefix(cleaned, ".git"+string(os.PathSeparator)) {
-    return "", errors.New("git_dir_not_allowed")
-  }
+	cleaned := filepath.Clean(rel)
+	if cleaned == "." || cleaned == "" {
+		return "", errors.New("invalid_path")
+	}
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(os.PathSeparator)) {
+		return "", errors.New("path_outside_workspace")
+	}
+	if cleaned == ".git" || strings.HasPrefix(cleaned, ".git"+string(os.PathSeparator)) {
+		return "", errors.New("git_dir_not_allowed")
+	}
 
-  workspaceAbs, err := filepath.Abs(s.workspace)
-  if err != nil {
-    return "", errors.New("workspace_invalid")
-  }
-  abs := filepath.Join(workspaceAbs, cleaned)
-  abs, err = filepath.Abs(abs)
-  if err != nil {
-    return "", errors.New("invalid_path")
-  }
+	workspaceAbs, err := filepath.Abs(s.workspace)
+	if err != nil {
+		return "", errors.New("workspace_invalid")
+	}
+	abs := filepath.Join(workspaceAbs, cleaned)
+	abs, err = filepath.Abs(abs)
+	if err != nil {
+		return "", errors.New("invalid_path")
+	}
 
 	if !strings.HasPrefix(abs+string(os.PathSeparator), workspaceAbs+string(os.PathSeparator)) && abs != workspaceAbs {
 		return "", errors.New("path_outside_workspace")
@@ -1651,17 +1734,17 @@ func (s *server) ensurePathWithinWorkspace(absPath string) error {
 }
 
 func getenv(key, fallback string) string {
-  value := os.Getenv(key)
-  if value == "" {
-    return fallback
-  }
-  return value
+	value := os.Getenv(key)
+	if value == "" {
+		return fallback
+	}
+	return value
 }
 
 func logRequests(next http.Handler) http.Handler {
-  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-    start := time.Now()
-    next.ServeHTTP(w, r)
-    log.Printf("%s %s %s", r.Method, r.URL.Path, time.Since(start))
-  })
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		next.ServeHTTP(w, r)
+		log.Printf("%s %s %s", r.Method, r.URL.Path, time.Since(start))
+	})
 }

--- a/infra/workspace-image/workspace-agent/main_test.go
+++ b/infra/workspace-image/workspace-agent/main_test.go
@@ -1,159 +1,213 @@
 package main
 
 import (
-  "encoding/base64"
-  "encoding/json"
-  "context"
-  "net/http"
-  "net/http/httptest"
-  "os"
-  "path/filepath"
-  "strings"
-  "testing"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
 )
 
 func TestGitStatusEntriesReturnsNestedUntrackedFiles(t *testing.T) {
-  workspace := t.TempDir()
-  ctx := context.Background()
+	workspace := t.TempDir()
+	ctx := context.Background()
 
-  runGit(t, ctx, workspace, "init", "-b", "main")
-  runGit(t, ctx, workspace, "config", "user.email", "tests@example.com")
-  runGit(t, ctx, workspace, "config", "user.name", "Workspace Agent Tests")
+	runGit(t, ctx, workspace, "init", "-b", "main")
+	runGit(t, ctx, workspace, "config", "user.email", "tests@example.com")
+	runGit(t, ctx, workspace, "config", "user.name", "Workspace Agent Tests")
 
-  baselineFile := filepath.Join(workspace, "README.md")
-  if err := os.WriteFile(baselineFile, []byte("baseline\n"), 0o644); err != nil {
-    t.Fatalf("write baseline file: %v", err)
-  }
+	baselineFile := filepath.Join(workspace, "README.md")
+	if err := os.WriteFile(baselineFile, []byte("baseline\n"), 0o644); err != nil {
+		t.Fatalf("write baseline file: %v", err)
+	}
 
-  runGit(t, ctx, workspace, "add", "README.md")
-  runGit(t, ctx, workspace, "commit", "-m", "baseline")
+	runGit(t, ctx, workspace, "add", "README.md")
+	runGit(t, ctx, workspace, "commit", "-m", "baseline")
 
-  nestedPath := filepath.Join(workspace, "Outputs", "Communications", "2026-02-12 - Summary.md")
-  if err := os.MkdirAll(filepath.Dir(nestedPath), 0o755); err != nil {
-    t.Fatalf("create nested directory: %v", err)
-  }
-  if err := os.WriteFile(nestedPath, []byte("content\n"), 0o644); err != nil {
-    t.Fatalf("write nested file: %v", err)
-  }
+	nestedPath := filepath.Join(workspace, "Outputs", "Communications", "2026-02-12 - Summary.md")
+	if err := os.MkdirAll(filepath.Dir(nestedPath), 0o755); err != nil {
+		t.Fatalf("create nested directory: %v", err)
+	}
+	if err := os.WriteFile(nestedPath, []byte("content\n"), 0o644); err != nil {
+		t.Fatalf("write nested file: %v", err)
+	}
 
-  s := &server{workspace: workspace}
-  entries, err := s.gitStatusEntries(ctx)
-  if err != nil {
-    t.Fatalf("gitStatusEntries failed: %v", err)
-  }
+	s := &server{workspace: workspace}
+	entries, err := s.gitStatusEntries(ctx)
+	if err != nil {
+		t.Fatalf("gitStatusEntries failed: %v", err)
+	}
 
-  expected := filepath.ToSlash("Outputs/Communications/2026-02-12 - Summary.md")
-  for _, entry := range entries {
-    if entry.Path == expected {
-      if entry.Untracked != true {
-        t.Fatalf("expected untracked entry for %q", expected)
-      }
-      if entry.Status != "added" {
-        t.Fatalf("expected status added for %q, got %q", expected, entry.Status)
-      }
-      return
-    }
-  }
+	expected := filepath.ToSlash("Outputs/Communications/2026-02-12 - Summary.md")
+	for _, entry := range entries {
+		if entry.Path == expected {
+			if entry.Untracked != true {
+				t.Fatalf("expected untracked entry for %q", expected)
+			}
+			if entry.Status != "added" {
+				t.Fatalf("expected status added for %q, got %q", expected, entry.Status)
+			}
+			return
+		}
+	}
 
-  t.Fatalf("expected nested untracked file %q in status entries: %#v", expected, entries)
+	t.Fatalf("expected nested untracked file %q in status entries: %#v", expected, entries)
 }
 
 func runGit(t *testing.T, ctx context.Context, dir string, args ...string) {
-  t.Helper()
+	t.Helper()
 
-  command := append([]string{"git"}, args...)
-  _, stderr, code, err := runCmd(ctx, dir, command)
-  if err != nil {
-    t.Fatalf("git command failed (%v): %v", command, err)
-  }
-  if code != 0 {
-    t.Fatalf("git command exited with code %d (%v): %s", code, command, stderr)
-  }
+	command := append([]string{"git"}, args...)
+	_, stderr, code, err := runCmd(ctx, dir, command)
+	if err != nil {
+		t.Fatalf("git command failed (%v): %v", command, err)
+	}
+	if code != 0 {
+		t.Fatalf("git command exited with code %d (%v): %s", code, command, stderr)
+	}
 }
 
 func TestIsInternalWorkspacePath(t *testing.T) {
-  cases := []struct {
-    name string
-    path string
-    want bool
-  }{
-    {name: "dot arche", path: ".arche", want: true},
-    {name: "attachments file", path: ".arche/attachments/file.txt", want: true},
-    {name: "normal file", path: "normal/file.txt", want: false},
-    {name: "empty", path: "", want: false},
-    {name: "duplicate slashes", path: ".arche//attachments/file.txt", want: true},
-  }
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "dot arche", path: ".arche", want: true},
+		{name: "attachments file", path: ".arche/attachments/file.txt", want: true},
+		{name: "normal file", path: "normal/file.txt", want: false},
+		{name: "empty", path: "", want: false},
+		{name: "duplicate slashes", path: ".arche//attachments/file.txt", want: true},
+	}
 
-  for _, tc := range cases {
-    t.Run(tc.name, func(t *testing.T) {
-      got := isInternalWorkspacePath(tc.path)
-      if got != tc.want {
-        t.Fatalf("isInternalWorkspacePath(%q) = %v, want %v", tc.path, got, tc.want)
-      }
-    })
-  }
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isInternalWorkspacePath(tc.path)
+			if got != tc.want {
+				t.Fatalf("isInternalWorkspacePath(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
 }
 
 func TestFileHandlersHappyPath(t *testing.T) {
-  workspace := t.TempDir()
-  s := &server{workspace: workspace}
+	workspace := t.TempDir()
+	s := &server{workspace: workspace}
 
-  t.Run("handleFileWrite base64", func(t *testing.T) {
-    payload := map[string]string{
-      "path":     ".arche/attachments/hello.txt",
-      "content":  base64.StdEncoding.EncodeToString([]byte("hello world")),
-      "encoding": "base64",
-    }
-    req := httptest.NewRequest(http.MethodPost, "/files/write", strings.NewReader(mustJSON(t, payload)))
-    recorder := httptest.NewRecorder()
+	t.Run("handleFileWrite base64", func(t *testing.T) {
+		payload := map[string]string{
+			"path":     ".arche/attachments/hello.txt",
+			"content":  base64.StdEncoding.EncodeToString([]byte("hello world")),
+			"encoding": "base64",
+		}
+		req := httptest.NewRequest(http.MethodPost, "/files/write", strings.NewReader(mustJSON(t, payload)))
+		recorder := httptest.NewRecorder()
 
-    s.handleFileWrite(recorder, req)
+		s.handleFileWrite(recorder, req)
 
-    if recorder.Code != http.StatusOK {
-      t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
-    }
-  })
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+		}
+	})
 
-  t.Run("handleFileList", func(t *testing.T) {
-    req := httptest.NewRequest(http.MethodPost, "/files/list", strings.NewReader(`{"path":".arche/attachments","recursive":false}`))
-    recorder := httptest.NewRecorder()
+	t.Run("handleFileList", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/files/list", strings.NewReader(`{"path":".arche/attachments","recursive":false}`))
+		recorder := httptest.NewRecorder()
 
-    s.handleFileList(recorder, req)
+		s.handleFileList(recorder, req)
 
-    if recorder.Code != http.StatusOK {
-      t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
-    }
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+		}
 
-    var response fileListResponse
-    if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
-      t.Fatalf("decode response: %v", err)
-    }
-    if !response.Ok || len(response.Entries) != 1 {
-      t.Fatalf("unexpected list response: %+v", response)
-    }
-  })
+		var response fileListResponse
+		if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if !response.Ok || len(response.Entries) != 1 {
+			t.Fatalf("unexpected list response: %+v", response)
+		}
+	})
 
-  t.Run("handleFileRename", func(t *testing.T) {
-    req := httptest.NewRequest(http.MethodPost, "/files/rename", strings.NewReader(`{"path":".arche/attachments/hello.txt","newPath":".arche/attachments/renamed.txt"}`))
-    recorder := httptest.NewRecorder()
+	t.Run("handleFileRename", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/files/rename", strings.NewReader(`{"path":".arche/attachments/hello.txt","newPath":".arche/attachments/renamed.txt"}`))
+		recorder := httptest.NewRecorder()
 
-    s.handleFileRename(recorder, req)
+		s.handleFileRename(recorder, req)
 
-    if recorder.Code != http.StatusOK {
-      t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
-    }
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+		}
 
-    if _, err := os.Stat(filepath.Join(workspace, ".arche", "attachments", "renamed.txt")); err != nil {
-      t.Fatalf("renamed file missing: %v", err)
-    }
-  })
+		if _, err := os.Stat(filepath.Join(workspace, ".arche", "attachments", "renamed.txt")); err != nil {
+			t.Fatalf("renamed file missing: %v", err)
+		}
+	})
+}
+
+func TestHandleFileUploadHappyPath(t *testing.T) {
+	workspace := t.TempDir()
+	s := &server{workspace: workspace}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/files/upload?path=.arche/attachments/uploaded.txt",
+		strings.NewReader("uploaded content"),
+	)
+	recorder := httptest.NewRecorder()
+
+	s.handleFileUpload(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(workspace, ".arche", "attachments", "uploaded.txt"))
+	if err != nil {
+		t.Fatalf("uploaded file missing: %v", err)
+	}
+	if string(data) != "uploaded content" {
+		t.Fatalf("uploaded file content = %q", string(data))
+	}
+}
+
+func TestHandleFileUploadRejectsTooLargeBody(t *testing.T) {
+	s := &server{workspace: t.TempDir()}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/files/upload?path=.arche/attachments/too-large.bin",
+		io.LimitReader(infiniteReader{}, maxUploadBodyBytes+1),
+	)
+	recorder := httptest.NewRecorder()
+
+	s.handleFileUpload(recorder, req)
+
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+type infiniteReader struct{}
+
+func (infiniteReader) Read(p []byte) (int, error) {
+	for index := range p {
+		p[index] = 'a'
+	}
+
+	return len(p), nil
 }
 
 func mustJSON(t *testing.T, value any) string {
-  t.Helper()
-  encoded, err := json.Marshal(value)
-  if err != nil {
-    t.Fatalf("marshal json: %v", err)
-  }
-  return string(encoded)
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal json: %v", err)
+	}
+	return string(encoded)
 }

--- a/scripts/dev-desktop.sh
+++ b/scripts/dev-desktop.sh
@@ -23,8 +23,8 @@ echo "==> Installing web dependencies..."
 cd "$WEB_DIR"
 "$PNPM_BIN" install
 
-echo "==> Rebuilding desktop SQLite native module for $(node -v)..."
-"$PNPM_BIN" rebuild better-sqlite3
+echo "==> Rebuilding desktop native modules for $(node -v)..."
+"$PNPM_BIN" rebuild argon2 better-sqlite3
 
 echo "==> Generating Prisma clients..."
 "$PNPM_BIN" prisma:generate


### PR DESCRIPTION
## Summary
- stream attachment uploads from the web app to the workspace agent as raw request bodies instead of re-encoding them as base64 JSON
- add a dedicated `/files/upload` workspace-agent endpoint with its own 100 MB body limit so large attachments no longer fail behind the 20 MB JSON control-plane limit
- upload files one by one in the workspace UI and update attachment tests to cover the new request shape and large-body handling

## Validation
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...` in `infra/workspace-image/workspace-agent`
- `pnpm test && pnpm lint` in `apps/web`
- `bash scripts/check-podman-images.sh`