### PR TITLE
fix(workspace): stream attachment uploads for large files

### DIFF
--- a/apps/web/src/app/api/w/[slug]/attachments/route.ts
+++ b/apps/web/src/app/api/w/[slug]/attachments/route.ts
@@ -5,7 +5,6 @@ import {
   ensureUniqueAttachmentFilename,
   inferAttachmentMimeType,
   isWorkspaceAttachmentPath,
-  MAX_ATTACHMENTS_PER_UPLOAD,
   MAX_ATTACHMENT_UPLOAD_BYTES,
   MAX_ATTACHMENT_UPLOAD_MEGABYTES,
   normalizeAttachmentPath,
@@ -29,6 +28,15 @@ type WorkspaceAgentListEntry = {
 type WorkspaceAgentListResponse = {
   ok: boolean
   entries?: WorkspaceAgentListEntry[]
+  error?: string
+}
+
+type WorkspaceAgentUploadResponse = {
+  ok: boolean
+  path?: string
+  hash?: string
+  size?: number
+  modifiedAt?: number
   error?: string
 }
 
@@ -56,19 +64,17 @@ function fileTooLargeResponse() {
   })
 }
 
-function isRequestBodyTooLargeError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false
-
-  const message = error.message.toLowerCase()
-
-  return message.includes('request body exceeded') || message.includes('body exceeded')
-}
-
 function normalizeAndValidateAttachmentPath(path: unknown): string | null {
   if (typeof path !== 'string') return null
   const normalized = normalizeAttachmentPath(path)
   if (!isWorkspaceAttachmentPath(normalized)) return null
   return normalized
+}
+
+function getAttachmentUploadName(request: NextRequest): string | null {
+  const filename = new URL(request.url).searchParams.get('filename')
+  if (!filename || filename.trim().length === 0) return null
+  return sanitizeAttachmentFilename(filename)
 }
 
 async function getWorkspaceAgentForSlug(slug: string) {
@@ -149,32 +155,21 @@ export const POST = withAuth(
     const auth = await getWorkspaceAgentForSlug(slug)
     if (!auth.ok) return auth.response
 
-    let formData: FormData
+    const filename = getAttachmentUploadName(request)
+    if (!filename) {
+      return jsonResponse(400, { error: 'invalid_filename' })
+    }
 
-    try {
-      formData = await request.formData()
-    } catch (error) {
-      if (isRequestBodyTooLargeError(error)) {
+    if (!request.body) {
+      return jsonResponse(400, { error: 'missing_file' })
+    }
+
+    const contentLengthHeader = request.headers.get('content-length')
+    if (contentLengthHeader) {
+      const contentLength = Number(contentLengthHeader)
+      if (Number.isFinite(contentLength) && contentLength > MAX_ATTACHMENT_UPLOAD_BYTES) {
         return fileTooLargeResponse()
       }
-
-      return jsonResponse(400, { error: 'invalid_form_data' })
-    }
-
-    const files = formData
-      .getAll('files')
-      .filter((value): value is File => value instanceof File)
-
-    if (files.length === 0) {
-      return jsonResponse(400, { error: 'missing_files' })
-    }
-
-    if (files.length > MAX_ATTACHMENTS_PER_UPLOAD) {
-      return jsonResponse(400, { error: 'too_many_files' })
-    }
-
-    if (files.some((file) => file.size > MAX_ATTACHMENT_UPLOAD_BYTES)) {
-      return fileTooLargeResponse()
     }
 
     const existing = await listWorkspaceAttachments(auth.agent)
@@ -183,83 +178,67 @@ export const POST = withAuth(
     }
 
     const usedNames = new Set(existing.attachments.map((attachment) => attachment.name))
-    const uploadTargets = files.map((file) => {
-      const safeName = sanitizeAttachmentFilename(file.name)
-      const uniqueName = ensureUniqueAttachmentFilename(safeName, usedNames)
-      usedNames.add(uniqueName)
+    const uniqueName = ensureUniqueAttachmentFilename(filename, usedNames)
+    const path = `${WORKSPACE_ATTACHMENTS_DIR}/${uniqueName}`
+    const contentType = request.headers.get('content-type')?.trim() ?? ''
+    const mime =
+      contentType.length > 0 && contentType !== 'application/octet-stream'
+        ? contentType
+        : inferAttachmentMimeType(uniqueName)
 
-      return {
-        file,
-        name: uniqueName,
-        path: `${WORKSPACE_ATTACHMENTS_DIR}/${uniqueName}`,
-      }
+    const headers = new Headers({
+      Accept: 'application/json',
+      Authorization: auth.agent.authHeader,
     })
-
-    const results = await Promise.allSettled(
-      uploadTargets.map(async ({ file, name, path }) => {
-        const bytes = Buffer.from(await file.arrayBuffer())
-        const fileType = file.type.trim()
-        const mime =
-          fileType.length > 0 && fileType !== 'application/octet-stream'
-            ? fileType
-            : inferAttachmentMimeType(name)
-        const uploadedAt = Date.now()
-
-        const response = await workspaceAgentFetch<{ ok: boolean; hash?: string; error?: string }>(
-          auth.agent,
-          '/files/write',
-          {
-            path,
-            content: bytes.toString('base64'),
-            encoding: 'base64',
-          },
-        )
-
-        if (!response.ok) {
-          throw new Error(response.error)
-        }
-
-        return {
-          id: path,
-          path,
-          name,
-          mime,
-          size: bytes.length,
-          uploadedAt,
-        } satisfies WorkspaceAttachment
-      }),
-    )
-
-    const uploaded: WorkspaceAttachment[] = []
-    const failed: Array<{ name: string; error: string }> = []
-
-    for (let index = 0; index < results.length; index += 1) {
-      const result = results[index]
-      const target = uploadTargets[index]
-
-      if (result.status === 'fulfilled') {
-        uploaded.push(result.value)
-        continue
-      }
-
-      failed.push({
-        name: target.name,
-        error:
-          result.reason instanceof Error && result.reason.message
-            ? result.reason.message
-            : 'upload_failed',
-      })
+    if (contentType) {
+      headers.set('Content-Type', contentType)
     }
 
-    if (failed.length > 0 && uploaded.length === 0) {
-      return jsonResponse(502, { error: 'upload_failed', uploaded, failed })
+    const upstreamUrl = `${auth.agent.baseUrl}/files/upload?path=${encodeURIComponent(path)}`
+    const init: RequestInit & { duplex?: 'half' } = {
+      method: 'POST',
+      headers,
+      body: request.body,
+      cache: 'no-store',
+    }
+    init.duplex = 'half'
+
+    let response: Response
+    try {
+      response = await fetch(upstreamUrl, init)
+    } catch {
+      return jsonResponse(502, { error: 'upload_failed' })
     }
 
-    if (failed.length > 0) {
-      return jsonResponse(207, { uploaded, failed })
+    const data = (await response.json().catch(() => null)) as WorkspaceAgentUploadResponse | null
+
+    if (response.status === 413) {
+      return fileTooLargeResponse()
     }
 
-    return jsonResponse(201, { uploaded, failed: [] })
+    if (!response.ok) {
+      return jsonResponse(502, { error: data?.error ?? 'upload_failed' })
+    }
+
+    if (
+      !data?.ok ||
+      typeof data.path !== 'string' ||
+      typeof data.size !== 'number' ||
+      typeof data.modifiedAt !== 'number'
+    ) {
+      return jsonResponse(502, { error: 'upload_failed' })
+    }
+
+    return jsonResponse(201, {
+      attachment: {
+        id: data.path,
+        path: data.path,
+        name: uniqueName,
+        mime,
+        size: data.size,
+        uploadedAt: data.modifiedAt,
+      } satisfies WorkspaceAttachment,
+    })
   },
 )
 

--- a/apps/web/src/app/api/w/[slug]/attachments/route.ts
+++ b/apps/web/src/app/api/w/[slug]/attachments/route.ts
@@ -71,6 +71,12 @@ function normalizeAndValidateAttachmentPath(path: unknown): string | null {
   return normalized
 }
 
+function getAttachmentName(path: string): string | null {
+  const parts = path.split('/')
+  const name = parts[parts.length - 1]?.trim() ?? ''
+  return name.length > 0 ? name : null
+}
+
 function getAttachmentUploadName(request: NextRequest): string | null {
   const filename = new URL(request.url).searchParams.get('filename')
   if (!filename || filename.trim().length === 0) return null
@@ -181,16 +187,11 @@ export const POST = withAuth(
     const uniqueName = ensureUniqueAttachmentFilename(filename, usedNames)
     const path = `${WORKSPACE_ATTACHMENTS_DIR}/${uniqueName}`
     const contentType = request.headers.get('content-type')?.trim() ?? ''
-    const mime =
-      contentType.length > 0 && contentType !== 'application/octet-stream'
-        ? contentType
-        : inferAttachmentMimeType(uniqueName)
-
     const headers = new Headers({
       Accept: 'application/json',
       Authorization: auth.agent.authHeader,
     })
-    if (contentType) {
+    if (contentType && contentType !== 'application/octet-stream') {
       headers.set('Content-Type', contentType)
     }
 
@@ -220,20 +221,26 @@ export const POST = withAuth(
       return jsonResponse(502, { error: data?.error ?? 'upload_failed' })
     }
 
-    if (
-      !data?.ok ||
-      typeof data.path !== 'string' ||
-      typeof data.size !== 'number' ||
-      typeof data.modifiedAt !== 'number'
-    ) {
+    const attachmentPath = normalizeAndValidateAttachmentPath(data?.path)
+    if (!data?.ok || !attachmentPath || typeof data.size !== 'number' || typeof data.modifiedAt !== 'number') {
       return jsonResponse(502, { error: 'upload_failed' })
     }
 
+    const attachmentName = getAttachmentName(attachmentPath)
+    if (!attachmentName) {
+      return jsonResponse(502, { error: 'upload_failed' })
+    }
+
+    const mime =
+      contentType.length > 0 && contentType !== 'application/octet-stream'
+        ? contentType
+        : inferAttachmentMimeType(attachmentName)
+
     return jsonResponse(201, {
       attachment: {
-        id: data.path,
-        path: data.path,
-        name: uniqueName,
+        id: attachmentPath,
+        path: attachmentPath,
+        name: attachmentName,
         mime,
         size: data.size,
         uploadedAt: data.modifiedAt,

--- a/apps/web/src/components/workspace/__tests__/chat-panel-textarea.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/chat-panel-textarea.test.tsx
@@ -230,31 +230,28 @@ describe("ChatPanel textarea", () => {
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       if (init?.method === "POST") {
         const requestBody = init.body;
-        if (!(requestBody instanceof FormData)) {
-          throw new Error("Expected upload request body to be FormData");
+        if (!(requestBody instanceof File)) {
+          throw new Error("Expected upload request body to be a File");
         }
 
-        const files = requestBody.getAll("files");
-        expect(files).toHaveLength(1);
-
-        const uploadedFile = files[0];
-        if (!(uploadedFile instanceof File)) {
-          throw new Error("Expected uploaded file in FormData");
-        }
-
-        expect(uploadedFile.type).toBe("image/png");
-        expect(uploadedFile.name).toBe("clipboard-image.png");
+        expect(requestBody.type).toBe("image/png");
+        expect(requestBody.name).toBe("clipboard-image.png");
+        expect(String(_input)).toBe(
+          "/api/w/alice/attachments?filename=clipboard-image.png"
+        );
 
         attachmentStore.push(uploadedAttachment);
 
         return {
           ok: true,
-          json: async () => ({ uploaded: [uploadedAttachment], failed: [] }),
+          status: 201,
+          json: async () => ({ attachment: uploadedAttachment }),
         };
       }
 
       return {
         ok: true,
+        status: 200,
         json: async () => ({ attachments: attachmentStore }),
       };
     });
@@ -562,13 +559,15 @@ describe("ChatPanel textarea", () => {
     let resolveUpload: (() => void) | null = null;
     const uploadResponse = new Promise<{
       ok: boolean;
-      json: () => Promise<{ uploaded: MockAttachment[]; failed: [] }>;
+      status: number;
+      json: () => Promise<{ attachment: MockAttachment }>;
     }>((resolve) => {
       resolveUpload = () => {
         attachmentStore.push(uploadedAttachment);
         resolve({
           ok: true,
-          json: async () => ({ uploaded: [uploadedAttachment], failed: [] }),
+          status: 201,
+          json: async () => ({ attachment: uploadedAttachment }),
         });
       };
     });
@@ -580,6 +579,7 @@ describe("ChatPanel textarea", () => {
 
       return {
         ok: true,
+        status: 200,
         json: async () => ({ attachments: attachmentStore }),
       };
     });
@@ -611,6 +611,95 @@ describe("ChatPanel textarea", () => {
     await waitFor(() => {
       expect(sendButton.disabled).toBe(false);
     });
+  });
+
+  it("uploads multiple files sequentially and reports partial failures", async () => {
+    const attachmentStore: MockAttachment[] = [];
+    const firstAttachment: MockAttachment = {
+      id: ".arche/attachments/first.png",
+      path: ".arche/attachments/first.png",
+      name: "first.png",
+      mime: "image/png",
+      size: 5,
+      uploadedAt: 10,
+    };
+
+    const uploadOrder: string[] = [];
+    let resolveFirstUpload: (() => void) | null = null;
+
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        const body = init.body;
+        if (!(body instanceof File)) {
+          throw new Error("Expected upload request body to be a File");
+        }
+
+        uploadOrder.push(body.name);
+
+        if (body.name === "first.png") {
+          return await new Promise<{
+            ok: boolean;
+            status: number;
+            json: () => Promise<{ attachment: MockAttachment }>;
+          }>((resolve) => {
+            resolveFirstUpload = () => {
+              attachmentStore.push(firstAttachment);
+              resolve({
+                ok: true,
+                status: 201,
+                json: async () => ({ attachment: firstAttachment }),
+              });
+            };
+          });
+        }
+
+        return {
+          ok: false,
+          status: 500,
+          json: async () => ({ error: "upload_failed" }),
+        };
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ attachments: attachmentStore }),
+      };
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderChatPanel();
+
+    const input = document.querySelector('input[type="file"]');
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error("Expected attachment file input");
+    }
+
+    fireEvent.change(input, {
+      target: {
+        files: [
+          new File(["first"], "first.png", { type: "image/png" }),
+          new File(["second"], "second.png", { type: "image/png" }),
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(uploadOrder).toEqual(["first.png"]);
+    });
+
+    if (!resolveFirstUpload) {
+      throw new Error("Expected first upload resolver");
+    }
+    resolveFirstUpload();
+
+    await waitFor(() => {
+      expect(uploadOrder).toEqual(["first.png", "second.png"]);
+    });
+
+    expect(await screen.findByText("Some files couldn't be uploaded.")).toBeTruthy();
+    expect(await screen.findByText("first.png")).toBeTruthy();
   });
 
   it("does not send a model override when only the agent default is selected", async () => {

--- a/apps/web/src/components/workspace/__tests__/chat-panel-textarea.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/chat-panel-textarea.test.tsx
@@ -699,6 +699,7 @@ describe("ChatPanel textarea", () => {
     });
 
     expect(await screen.findByText("Some files couldn't be uploaded.")).toBeTruthy();
+    expect(await screen.findByText("second.png: Couldn't upload the selected file.")).toBeTruthy();
     expect(await screen.findByText("first.png")).toBeTruthy();
   });
 

--- a/apps/web/src/components/workspace/chat-panel.tsx
+++ b/apps/web/src/components/workspace/chat-panel.tsx
@@ -557,44 +557,55 @@ export function ChatPanel({
       return;
     }
 
-    if (files.some((file) => file.size > MAX_ATTACHMENT_UPLOAD_BYTES)) {
-      setAttachmentsError("file_too_large");
-      return;
-    }
-
-    const formData = new FormData();
-    files.forEach((file) => {
-      formData.append("files", file);
-    });
-
     setIsUploadingAttachment(true);
     setAttachmentsError(null);
 
+    let nextError: string | null = null;
+    let shouldRefreshAttachments = false;
+
     try {
-      const response = await fetch(`/api/w/${slug}/attachments`, {
-        method: "POST",
-        body: formData,
-      });
+      const uploaded: WorkspaceAttachment[] = [];
+      let firstError: string | null = null;
 
-      const data = (await response
-        .json()
-        .catch(() => null)) as {
-        uploaded?: WorkspaceAttachment[];
-        failed?: Array<{ name: string; error: string }>;
-        error?: string;
-      } | null;
+      for (const file of files) {
+        if (file.size > MAX_ATTACHMENT_UPLOAD_BYTES) {
+          firstError ??= "file_too_large";
+          continue;
+        }
 
-      if (response.status === 413) {
-        setAttachmentsError("file_too_large");
-        return;
+        const headers = file.type ? { "Content-Type": file.type } : undefined;
+
+        try {
+          shouldRefreshAttachments = true;
+          const response = await fetch(
+            `/api/w/${slug}/attachments?filename=${encodeURIComponent(file.name)}`,
+            {
+              method: "POST",
+              headers,
+              body: file,
+            }
+          );
+
+          const data = (await response
+            .json()
+            .catch(() => null)) as { attachment?: WorkspaceAttachment; error?: string } | null;
+
+          if (response.status === 413) {
+            firstError ??= "file_too_large";
+            continue;
+          }
+
+          if (!response.ok || !data?.attachment) {
+            firstError ??= data?.error ?? "upload_failed";
+            continue;
+          }
+
+          uploaded.push(data.attachment);
+        } catch {
+          firstError ??= "upload_failed";
+        }
       }
 
-      if (!response.ok || !data?.uploaded) {
-        setAttachmentsError(data?.error ?? "upload_failed");
-        return;
-      }
-
-      const uploaded = data.uploaded;
       setAttachments((previous) => {
         const indexed = new Map(previous.map((attachment) => [attachment.path, attachment]));
         uploaded.forEach((attachment) => indexed.set(attachment.path, attachment));
@@ -605,15 +616,23 @@ export function ChatPanel({
         uploaded.forEach((attachment) => selected.add(attachment.path));
         return [...selected];
       });
-      if ((data.failed?.length ?? 0) > 0) {
-        setAttachmentsError("upload_partial_failure");
-      } else {
-        setAttachmentsError(null);
-      }
+
+      nextError = firstError
+        ? uploaded.length > 0
+          ? "upload_partial_failure"
+          : firstError
+        : null;
     } catch {
-      setAttachmentsError("upload_failed");
+      nextError = "upload_failed";
     } finally {
-      await refreshAttachments();
+      if (shouldRefreshAttachments) {
+        await refreshAttachments();
+      }
+
+      if (nextError !== null || !shouldRefreshAttachments) {
+        setAttachmentsError(nextError);
+      }
+
       setIsUploadingAttachment(false);
     }
   }, [attachmentsEnabled, refreshAttachments, slug]);

--- a/apps/web/src/components/workspace/chat-panel.tsx
+++ b/apps/web/src/components/workspace/chat-panel.tsx
@@ -110,6 +110,11 @@ type ConnectorSummary = {
   name: string;
 };
 
+type AttachmentUploadFailure = {
+  name: string;
+  error: string;
+};
+
 const MAX_CONTEXT_PATHS_PER_MESSAGE = 20;
 
 function getAttachmentErrorMessage(error: string): string {
@@ -208,6 +213,7 @@ export function ChatPanel({
   const [isLoadingAttachments, setIsLoadingAttachments] = useState(false);
   const [isUploadingAttachment, setIsUploadingAttachment] = useState(false);
   const [attachmentsError, setAttachmentsError] = useState<string | null>(null);
+  const [attachmentUploadFailures, setAttachmentUploadFailures] = useState<AttachmentUploadFailure[]>([]);
   const [isAttachmentMenuOpen, setIsAttachmentMenuOpen] = useState(false);
   const [isManageAttachmentsOpen, setIsManageAttachmentsOpen] = useState(false);
   const [attachmentSearch, setAttachmentSearch] = useState("");
@@ -503,6 +509,7 @@ export function ChatPanel({
       setAttachments([]);
       setSelectedAttachmentPaths([]);
       setAttachmentsError(null);
+      setAttachmentUploadFailures([]);
       setIsLoadingAttachments(false);
       return;
     }
@@ -518,6 +525,7 @@ export function ChatPanel({
 
       if (!response.ok || !data?.attachments) {
         setAttachmentsError(data?.error ?? "attachments_load_failed");
+        setAttachmentUploadFailures([]);
         return;
       }
 
@@ -529,8 +537,10 @@ export function ChatPanel({
         )
       );
       setAttachmentsError(null);
+      setAttachmentUploadFailures([]);
     } catch {
       setAttachmentsError("attachments_load_failed");
+      setAttachmentUploadFailures([]);
     } finally {
       setIsLoadingAttachments(false);
     }
@@ -553,13 +563,16 @@ export function ChatPanel({
     if (!attachmentsEnabled || files.length === 0) return;
 
     if (files.length > MAX_ATTACHMENTS_PER_UPLOAD) {
+      setAttachmentUploadFailures([]);
       setAttachmentsError("too_many_files");
       return;
     }
 
     setIsUploadingAttachment(true);
     setAttachmentsError(null);
+    setAttachmentUploadFailures([]);
 
+    const failedUploads: AttachmentUploadFailure[] = [];
     let nextError: string | null = null;
     let shouldRefreshAttachments = false;
 
@@ -569,6 +582,7 @@ export function ChatPanel({
 
       for (const file of files) {
         if (file.size > MAX_ATTACHMENT_UPLOAD_BYTES) {
+          failedUploads.push({ name: file.name, error: "file_too_large" });
           firstError ??= "file_too_large";
           continue;
         }
@@ -591,17 +605,21 @@ export function ChatPanel({
             .catch(() => null)) as { attachment?: WorkspaceAttachment; error?: string } | null;
 
           if (response.status === 413) {
+            failedUploads.push({ name: file.name, error: "file_too_large" });
             firstError ??= "file_too_large";
             continue;
           }
 
           if (!response.ok || !data?.attachment) {
-            firstError ??= data?.error ?? "upload_failed";
+            const error = data?.error ?? "upload_failed";
+            failedUploads.push({ name: file.name, error });
+            firstError ??= error;
             continue;
           }
 
           uploaded.push(data.attachment);
         } catch {
+          failedUploads.push({ name: file.name, error: "upload_failed" });
           firstError ??= "upload_failed";
         }
       }
@@ -629,6 +647,8 @@ export function ChatPanel({
         await refreshAttachments();
       }
 
+      setAttachmentUploadFailures(failedUploads);
+
       if (nextError !== null || !shouldRefreshAttachments) {
         setAttachmentsError(nextError);
       }
@@ -648,6 +668,7 @@ export function ChatPanel({
   const handleRevealAttachmentsDirectory = useCallback(async () => {
     if (!desktopBridge) return;
 
+    setAttachmentUploadFailures([]);
     setAttachmentsError(null);
     const result = await desktopBridge.revealAttachmentsDirectory();
     if (!result.ok) {
@@ -709,6 +730,7 @@ export function ChatPanel({
       if (!trimmedName || trimmedName === attachment.name) return;
 
       setIsMutatingAttachments(true);
+      setAttachmentUploadFailures([]);
       setAttachmentsError(null);
 
       try {
@@ -757,6 +779,7 @@ export function ChatPanel({
       if (!confirmed) return;
 
       setIsMutatingAttachments(true);
+      setAttachmentUploadFailures([]);
       setAttachmentsError(null);
 
       try {
@@ -1245,9 +1268,14 @@ export function ChatPanel({
         )}
 
         {attachmentsEnabled && attachmentsError && (
-          <p className="mb-3 text-xs text-destructive">
-            {getAttachmentErrorMessage(attachmentsError)}
-          </p>
+          <div className="mb-3 space-y-1 text-xs text-destructive">
+            <p>{getAttachmentErrorMessage(attachmentsError)}</p>
+            {attachmentUploadFailures.map((failure) => (
+              <p key={`${failure.name}:${failure.error}`}>
+                {`${failure.name}: ${getAttachmentErrorMessage(failure.error)}`}
+              </p>
+            ))}
+          </div>
         )}
         
         <div className="relative flex items-end gap-1.5 rounded-xl border border-white/10 bg-foreground/5 px-2 py-2">

--- a/apps/web/tests/attachments-routes.test.ts
+++ b/apps/web/tests/attachments-routes.test.ts
@@ -34,32 +34,34 @@ async function callGetAttachments(slug = 'alice') {
 
 async function callPostAttachments(options: {
   slug?: string
-  files: File[]
+  file: File
+  filename?: string
   includeOrigin?: boolean
-  formDataOverride?: FormData
+  contentLength?: number
 }) {
   const { POST } = await import('@/app/api/w/[slug]/attachments/route')
   const slug = options.slug ?? 'alice'
-
-  const formData = new FormData()
-  options.files.forEach((file) => formData.append('files', file))
+  const filename = options.filename ?? options.file.name
 
   const headers = new Headers({ host: 'localhost' })
   if (options.includeOrigin !== false) {
     headers.set('origin', 'http://localhost')
   }
-
-  const req = new Request(`http://localhost/api/w/${slug}/attachments`, {
-    method: 'POST',
-    headers,
-    body: formData,
-  })
-
-  if (options.formDataOverride) {
-    Object.defineProperty(req, 'formData', {
-      value: async () => options.formDataOverride,
-    })
+  if (options.file.type) {
+    headers.set('content-type', options.file.type)
   }
+  if (typeof options.contentLength === 'number') {
+    headers.set('content-length', String(options.contentLength))
+  }
+
+  const req = new Request(
+    `http://localhost/api/w/${slug}/attachments?filename=${encodeURIComponent(filename)}`,
+    {
+      method: 'POST',
+      headers,
+      body: options.file,
+    },
+  )
 
   const res = await POST(req as never, { params: Promise.resolve({ slug }) })
   return { status: res.status, body: await res.json() }
@@ -193,7 +195,7 @@ describe('workspace attachments route', () => {
     mockGetAuthenticatedUser.mockResolvedValue(session('alice'))
 
     const { status, body } = await callPostAttachments({
-      files: [new File(['x'], 'a.txt', { type: 'text/plain' })],
+      file: new File(['x'], 'a.txt', { type: 'text/plain' }),
       includeOrigin: false,
     })
 
@@ -201,7 +203,7 @@ describe('workspace attachments route', () => {
     expect(body.error).toBe('forbidden')
   })
 
-  it('POST uploads files using base64 encoding and resolves name conflicts', async () => {
+  it('POST proxies a raw file upload to /files/upload and resolves name conflicts', async () => {
     mockGetAuthenticatedUser.mockResolvedValue(session('alice'))
     const fetchMock = vi
       .fn()
@@ -223,13 +225,13 @@ describe('workspace attachments route', () => {
         ),
       )
       .mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: true, hash: 'h1' }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: true, hash: 'h2' }), {
+        new Response(JSON.stringify({
+          ok: true,
+          path: '.arche/attachments/report (1).pdf',
+          hash: 'h1',
+          size: 8,
+          modifiedAt: 123,
+        }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         }),
@@ -237,41 +239,36 @@ describe('workspace attachments route', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const { status, body } = await callPostAttachments({
-      files: [
-        new File(['pdf-data'], 'report.pdf', { type: 'application/pdf' }),
-        new File(['img-data'], 'diagram.png', { type: 'image/png' }),
-      ],
+      file: new File(['pdf-data'], 'report.pdf', { type: 'application/pdf' }),
     })
 
     expect(status).toBe(201)
-    expect(body.uploaded).toHaveLength(2)
-    expect(body.failed).toEqual([])
-    expect(body.uploaded[0].name).toBe('report (1).pdf')
-    expect(body.uploaded[1].name).toBe('diagram.png')
+    expect(body.attachment).toMatchObject({
+      id: '.arche/attachments/report (1).pdf',
+      path: '.arche/attachments/report (1).pdf',
+      name: 'report (1).pdf',
+      mime: 'application/pdf',
+      size: 8,
+      uploadedAt: 123,
+    })
 
-    const firstWriteBody = JSON.parse(String(fetchMock.mock.calls[1][1]?.body))
-    expect(firstWriteBody.path).toBe('.arche/attachments/report (1).pdf')
-    expect(firstWriteBody.encoding).toBe('base64')
-    expect(typeof firstWriteBody.content).toBe('string')
-    expect(firstWriteBody.content.length).toBeGreaterThan(0)
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      'http://agent/files/upload?path=.arche%2Fattachments%2Freport%20(1).pdf',
+    )
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      method: 'POST',
+      duplex: 'half',
+    })
   })
 
-  it('POST rejects files larger than the upload limit', async () => {
+  it('POST rejects files larger than the upload limit before proxying', async () => {
     mockGetAuthenticatedUser.mockResolvedValue(session('alice'))
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
 
-    const oversizedFile = new File(['x'], 'huge.bin', { type: 'application/octet-stream' })
-    Object.defineProperty(oversizedFile, 'size', {
-      value: MAX_ATTACHMENT_UPLOAD_BYTES + 1,
-    })
-
-    const formData = new FormData()
-    formData.append('files', oversizedFile)
-
     const { status, body } = await callPostAttachments({
-      files: [oversizedFile],
-      formDataOverride: formData,
+      file: new File(['x'], 'huge.bin', { type: 'application/octet-stream' }),
+      contentLength: MAX_ATTACHMENT_UPLOAD_BYTES + 1,
     })
 
     expect(status).toBe(413)
@@ -283,7 +280,7 @@ describe('workspace attachments route', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('POST returns per-file failures without losing successes', async () => {
+  it('POST maps an upstream 413 to file_too_large', async () => {
     mockGetAuthenticatedUser.mockResolvedValue(session('alice'))
     const fetchMock = vi
       .fn()
@@ -297,31 +294,23 @@ describe('workspace attachments route', () => {
         ),
       )
       .mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: true, hash: 'h1' }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: false, error: 'write_failed' }), {
-          status: 500,
+        new Response(JSON.stringify({ ok: false, error: 'file_too_large' }), {
+          status: 413,
           headers: { 'Content-Type': 'application/json' },
         }),
       )
     vi.stubGlobal('fetch', fetchMock)
 
     const { status, body } = await callPostAttachments({
-      files: [
-        new File(['ok'], 'ok.txt', { type: 'text/plain' }),
-        new File(['bad'], 'bad.txt', { type: 'text/plain' }),
-      ],
+      file: new File(['bad'], 'bad.txt', { type: 'text/plain' }),
     })
 
-    expect(status).toBe(207)
-    expect(body.uploaded).toHaveLength(1)
-    expect(body.failed).toHaveLength(1)
-    expect(body.failed[0].name).toBe('bad.txt')
-    expect(body.failed[0].error).toBe('write_failed')
+    expect(status).toBe(413)
+    expect(body).toEqual({
+      error: 'file_too_large',
+      maxBytes: MAX_ATTACHMENT_UPLOAD_BYTES,
+      maxMegabytes: MAX_ATTACHMENT_UPLOAD_MEGABYTES,
+    })
   })
 
   it('PATCH renames a workspace attachment', async () => {

--- a/apps/web/tests/attachments-routes.test.ts
+++ b/apps/web/tests/attachments-routes.test.ts
@@ -313,6 +313,68 @@ describe('workspace attachments route', () => {
     })
   })
 
+  it('POST passes through upstream upload errors from the workspace agent', async () => {
+    mockGetAuthenticatedUser.mockResolvedValue(session('alice'))
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            entries: [],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: false, error: 'write_failed' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { status, body } = await callPostAttachments({
+      file: new File(['bad'], 'bad.txt', { type: 'text/plain' }),
+    })
+
+    expect(status).toBe(502)
+    expect(body).toEqual({ error: 'write_failed' })
+  })
+
+  it('POST rejects malformed upload metadata from the workspace agent', async () => {
+    mockGetAuthenticatedUser.mockResolvedValue(session('alice'))
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            entries: [],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          ok: true,
+          path: '.arche/attachments/bad.txt',
+          size: 3,
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { status, body } = await callPostAttachments({
+      file: new File(['bad'], 'bad.txt', { type: 'text/plain' }),
+    })
+
+    expect(status).toBe(502)
+    expect(body).toEqual({ error: 'upload_failed' })
+  })
+
   it('PATCH renames a workspace attachment', async () => {
     mockGetAuthenticatedUser.mockResolvedValue(session('alice'))
     const fetchMock = vi

--- a/infra/workspace-image/workspace-agent/main.go
+++ b/infra/workspace-image/workspace-agent/main.go
@@ -5,15 +5,15 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
-  "encoding/hex"
-  "encoding/json"
-  "errors"
-  "flag"
-  "io"
-  "log"
-  "net/http"
-  "os"
-  "os/exec"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -23,73 +23,74 @@ import (
 )
 
 const (
-  defaultAddr      = "0.0.0.0:4097"
-  defaultWorkspace = "/workspace"
-  maxBodyBytes     = 20 << 20
+	defaultAddr        = "0.0.0.0:4097"
+	defaultWorkspace   = "/workspace"
+	maxBodyBytes       = 20 << 20
+	maxUploadBodyBytes = 100 << 20
 )
 
 type server struct {
-  workspace string
-  username  string
-  password  string
+	workspace string
+	username  string
+	password  string
 }
 
 type errorResponse struct {
-  Ok    bool   `json:"ok"`
-  Error string `json:"error"`
+	Ok    bool   `json:"ok"`
+	Error string `json:"error"`
 }
 
 type gitDiffEntry struct {
-  Path      string `json:"path"`
-  Status    string `json:"status"`
-  Additions int    `json:"additions"`
-  Deletions int    `json:"deletions"`
-  Diff      string `json:"diff"`
-  Conflicted bool  `json:"conflicted"`
+	Path       string `json:"path"`
+	Status     string `json:"status"`
+	Additions  int    `json:"additions"`
+	Deletions  int    `json:"deletions"`
+	Diff       string `json:"diff"`
+	Conflicted bool   `json:"conflicted"`
 }
 
 type gitDiffResponse struct {
-  Ok    bool          `json:"ok"`
-  Diffs []gitDiffEntry `json:"diffs"`
+	Ok    bool           `json:"ok"`
+	Diffs []gitDiffEntry `json:"diffs"`
 }
 
 type gitConflictRequest struct {
-  Path string `json:"path"`
+	Path string `json:"path"`
 }
 
 type gitConflictResponse struct {
-  Ok      bool   `json:"ok"`
-  Path    string `json:"path"`
-  Ours    string `json:"ours"`
-  Theirs  string `json:"theirs"`
-  Base    string `json:"base,omitempty"`
-  Working string `json:"working,omitempty"`
+	Ok      bool   `json:"ok"`
+	Path    string `json:"path"`
+	Ours    string `json:"ours"`
+	Theirs  string `json:"theirs"`
+	Base    string `json:"base,omitempty"`
+	Working string `json:"working,omitempty"`
 }
 
 type gitResolveRequest struct {
-  Path     string `json:"path"`
-  Strategy string `json:"strategy"`
-  Content  string `json:"content,omitempty"`
+	Path     string `json:"path"`
+	Strategy string `json:"strategy"`
+	Content  string `json:"content,omitempty"`
 }
 
 type gitResolveResponse struct {
-  Ok       bool   `json:"ok"`
-  Path     string `json:"path"`
-  Strategy string `json:"strategy"`
-  Message  string `json:"message,omitempty"`
+	Ok       bool   `json:"ok"`
+	Path     string `json:"path"`
+	Strategy string `json:"strategy"`
+	Message  string `json:"message,omitempty"`
 }
 
 type gitDiscardRequest struct {
-  Path string `json:"path"`
+	Path string `json:"path"`
 }
 
 type gitDiscardResponse struct {
-  Ok   bool   `json:"ok"`
-  Path string `json:"path"`
+	Ok   bool   `json:"ok"`
+	Path string `json:"path"`
 }
 
 type fileReadRequest struct {
-  Path string `json:"path"`
+	Path string `json:"path"`
 }
 
 type fileReadResponse struct {
@@ -126,19 +127,27 @@ type fileWriteRequest struct {
 }
 
 type fileWriteResponse struct {
-  Ok   bool   `json:"ok"`
-  Path string `json:"path"`
-  Hash string `json:"hash"`
+	Ok   bool   `json:"ok"`
+	Path string `json:"path"`
+	Hash string `json:"hash"`
+}
+
+type fileUploadResponse struct {
+	Ok         bool   `json:"ok"`
+	Path       string `json:"path"`
+	Hash       string `json:"hash"`
+	Size       int64  `json:"size"`
+	ModifiedAt int64  `json:"modifiedAt"`
 }
 
 type fileDeleteRequest struct {
-  Path string `json:"path"`
+	Path string `json:"path"`
 }
 
 type fileDeleteResponse struct {
-  Ok      bool   `json:"ok"`
-  Path    string `json:"path"`
-  Deleted bool   `json:"deleted"`
+	Ok      bool   `json:"ok"`
+	Path    string `json:"path"`
+	Deleted bool   `json:"deleted"`
 }
 
 type fileRenameRequest struct {
@@ -153,464 +162,465 @@ type fileRenameResponse struct {
 }
 
 type fileApplyPatchRequest struct {
-  Patch string `json:"patch"`
+	Patch string `json:"patch"`
 }
 
 type fileApplyPatchResponse struct {
-  Ok bool `json:"ok"`
+	Ok bool `json:"ok"`
 }
 
 type syncKbResponse struct {
-  Ok        bool     `json:"ok"`
-  Status    string   `json:"status"`
-  Message   string   `json:"message,omitempty"`
-  Conflicts []string `json:"conflicts,omitempty"`
+	Ok        bool     `json:"ok"`
+	Status    string   `json:"status"`
+	Message   string   `json:"message,omitempty"`
+	Conflicts []string `json:"conflicts,omitempty"`
 }
 
 type syncStatusResponse struct {
-  Ok           bool     `json:"ok"`
-  HasConflicts bool     `json:"hasConflicts"`
-  Conflicts    []string `json:"conflicts,omitempty"`
+	Ok           bool     `json:"ok"`
+	HasConflicts bool     `json:"hasConflicts"`
+	Conflicts    []string `json:"conflicts,omitempty"`
 }
 
 type publishKbResponse struct {
-  Ok         bool     `json:"ok"`
-  Status     string   `json:"status"`
-  CommitHash string   `json:"commitHash,omitempty"`
-  Files      []string `json:"files,omitempty"`
-  Message    string   `json:"message,omitempty"`
+	Ok         bool     `json:"ok"`
+	Status     string   `json:"status"`
+	CommitHash string   `json:"commitHash,omitempty"`
+	Files      []string `json:"files,omitempty"`
+	Message    string   `json:"message,omitempty"`
 }
 
 func main() {
-  addr := flag.String("addr", getenv("WORKSPACE_AGENT_ADDR", defaultAddr), "listen address")
-  workspace := flag.String("workspace", getenv("WORKSPACE_DIR", defaultWorkspace), "workspace root")
-  flag.Parse()
+	addr := flag.String("addr", getenv("WORKSPACE_AGENT_ADDR", defaultAddr), "listen address")
+	workspace := flag.String("workspace", getenv("WORKSPACE_DIR", defaultWorkspace), "workspace root")
+	flag.Parse()
 
-  username := getenv("WORKSPACE_AGENT_USERNAME", "opencode")
-  password := os.Getenv("WORKSPACE_AGENT_PASSWORD")
-  if password == "" {
-    password = os.Getenv("OPENCODE_SERVER_PASSWORD")
-  }
+	username := getenv("WORKSPACE_AGENT_USERNAME", "opencode")
+	password := os.Getenv("WORKSPACE_AGENT_PASSWORD")
+	if password == "" {
+		password = os.Getenv("OPENCODE_SERVER_PASSWORD")
+	}
 
-  if password == "" {
-    log.Printf("workspace-agent: missing OPENCODE_SERVER_PASSWORD")
-    os.Exit(1)
-  }
+	if password == "" {
+		log.Printf("workspace-agent: missing OPENCODE_SERVER_PASSWORD")
+		os.Exit(1)
+	}
 
-  s := &server{
-    workspace: *workspace,
-    username:  username,
-    password:  password,
-  }
+	s := &server{
+		workspace: *workspace,
+		username:  username,
+		password:  password,
+	}
 
-  mux := http.NewServeMux()
-  mux.HandleFunc("/health", s.withAuth(s.handleHealth))
-  mux.HandleFunc("/git/diffs", s.withAuth(s.handleGitDiffs))
-  mux.HandleFunc("/git/conflict", s.withAuth(s.handleGitConflict))
-  mux.HandleFunc("/git/resolve", s.withAuth(s.handleGitResolve))
-  mux.HandleFunc("/git/discard", s.withAuth(s.handleGitDiscard))
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", s.withAuth(s.handleHealth))
+	mux.HandleFunc("/git/diffs", s.withAuth(s.handleGitDiffs))
+	mux.HandleFunc("/git/conflict", s.withAuth(s.handleGitConflict))
+	mux.HandleFunc("/git/resolve", s.withAuth(s.handleGitResolve))
+	mux.HandleFunc("/git/discard", s.withAuth(s.handleGitDiscard))
 	mux.HandleFunc("/files/read", s.withAuth(s.handleFileRead))
 	mux.HandleFunc("/files/list", s.withAuth(s.handleFileList))
+	mux.HandleFunc("/files/upload", s.withAuth(s.handleFileUpload))
 	mux.HandleFunc("/files/write", s.withAuth(s.handleFileWrite))
 	mux.HandleFunc("/files/delete", s.withAuth(s.handleFileDelete))
 	mux.HandleFunc("/files/rename", s.withAuth(s.handleFileRename))
 	mux.HandleFunc("/files/apply_patch", s.withAuth(s.handleApplyPatch))
-  mux.HandleFunc("/kb/sync", s.withAuth(s.handleKbSync))
-  mux.HandleFunc("/kb/status", s.withAuth(s.handleKbStatus))
-  mux.HandleFunc("/kb/publish", s.withAuth(s.handleKbPublish))
+	mux.HandleFunc("/kb/sync", s.withAuth(s.handleKbSync))
+	mux.HandleFunc("/kb/status", s.withAuth(s.handleKbStatus))
+	mux.HandleFunc("/kb/publish", s.withAuth(s.handleKbPublish))
 
-  server := &http.Server{
-    Addr:              *addr,
-    Handler:           logRequests(mux),
-    ReadHeaderTimeout: 5 * time.Second,
-    ReadTimeout:       15 * time.Second,
-    WriteTimeout:      30 * time.Second,
-    IdleTimeout:       60 * time.Second,
-  }
+	server := &http.Server{
+		Addr:              *addr,
+		Handler:           logRequests(mux),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
 
-  log.Printf("workspace-agent listening on http://%s", *addr)
-  if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-    log.Fatalf("workspace-agent failed: %v", err)
-  }
+	log.Printf("workspace-agent listening on http://%s", *addr)
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("workspace-agent failed: %v", err)
+	}
 }
 
 func (s *server) withAuth(next http.HandlerFunc) http.HandlerFunc {
-  return func(w http.ResponseWriter, r *http.Request) {
-    username, password, ok := r.BasicAuth()
-    if !ok || username != s.username || password != s.password {
-      w.Header().Set("WWW-Authenticate", "Basic")
-      writeError(w, http.StatusUnauthorized, "unauthorized")
-      return
-    }
-    next(w, r)
-  }
+	return func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != s.username || password != s.password {
+			w.Header().Set("WWW-Authenticate", "Basic")
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		next(w, r)
+	}
 }
 
 func (s *server) handleHealth(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodGet {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
-  writeJSON(w, http.StatusOK, map[string]any{
-    "ok":      true,
-    "service": "workspace-agent",
-  })
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":      true,
+		"service": "workspace-agent",
+	})
 }
 
 func (s *server) handleGitDiffs(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodGet {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  entries, err := s.gitStatusEntries(r.Context())
-  if err != nil {
-    writeError(w, http.StatusBadGateway, err.Error())
-    return
-  }
-  if len(entries) == 0 {
-    writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: []gitDiffEntry{}})
-    return
-  }
-  diffs := make([]gitDiffEntry, 0, len(entries))
+	entries, err := s.gitStatusEntries(r.Context())
+	if err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	if len(entries) == 0 {
+		writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: []gitDiffEntry{}})
+		return
+	}
+	diffs := make([]gitDiffEntry, 0, len(entries))
 
-  for _, entry := range entries {
-    diffArgs := []string{"git", "diff", "--no-color", "HEAD", "--", entry.Path}
-    numstatArgs := []string{"git", "diff", "--numstat", "HEAD", "--", entry.Path}
-    if entry.Untracked {
-      diffArgs = []string{"git", "diff", "--no-color", "--no-index", "--", "/dev/null", entry.Path}
-      numstatArgs = []string{"git", "diff", "--numstat", "--no-index", "--", "/dev/null", entry.Path}
-    }
+	for _, entry := range entries {
+		diffArgs := []string{"git", "diff", "--no-color", "HEAD", "--", entry.Path}
+		numstatArgs := []string{"git", "diff", "--numstat", "HEAD", "--", entry.Path}
+		if entry.Untracked {
+			diffArgs = []string{"git", "diff", "--no-color", "--no-index", "--", "/dev/null", entry.Path}
+			numstatArgs = []string{"git", "diff", "--numstat", "--no-index", "--", "/dev/null", entry.Path}
+		}
 
-    diffOut, diffErr, diffCode, diffExecErr := runCmd(r.Context(), s.workspace, diffArgs)
-    if diffExecErr != nil || diffCode > 1 {
-      msg := strings.TrimSpace(diffErr)
-      if msg == "" {
-        msg = "git_diff_failed"
-      }
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
+		diffOut, diffErr, diffCode, diffExecErr := runCmd(r.Context(), s.workspace, diffArgs)
+		if diffExecErr != nil || diffCode > 1 {
+			msg := strings.TrimSpace(diffErr)
+			if msg == "" {
+				msg = "git_diff_failed"
+			}
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
 
-    numstatOut, numstatErr, numstatCode, numstatExecErr := runCmd(r.Context(), s.workspace, numstatArgs)
-    if numstatExecErr != nil || numstatCode > 1 {
-      msg := strings.TrimSpace(numstatErr)
-      if msg == "" {
-        msg = "git_numstat_failed"
-      }
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
+		numstatOut, numstatErr, numstatCode, numstatExecErr := runCmd(r.Context(), s.workspace, numstatArgs)
+		if numstatExecErr != nil || numstatCode > 1 {
+			msg := strings.TrimSpace(numstatErr)
+			if msg == "" {
+				msg = "git_numstat_failed"
+			}
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
 
-    additions, deletions := parseNumstat(numstatOut)
-    diffs = append(diffs, gitDiffEntry{
-      Path:      entry.Path,
-      Status:    entry.Status,
-      Additions: additions,
-      Deletions: deletions,
-      Diff:      strings.TrimSpace(diffOut),
-      Conflicted: entry.Conflicted,
-    })
-  }
+		additions, deletions := parseNumstat(numstatOut)
+		diffs = append(diffs, gitDiffEntry{
+			Path:       entry.Path,
+			Status:     entry.Status,
+			Additions:  additions,
+			Deletions:  deletions,
+			Diff:       strings.TrimSpace(diffOut),
+			Conflicted: entry.Conflicted,
+		})
+	}
 
-  writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: diffs})
+	writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: diffs})
 }
 
 func (s *server) handleGitConflict(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req gitConflictRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req gitConflictRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  relPath, absPath, err := s.resolveRelPath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
+	relPath, absPath, err := s.resolveRelPath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
-  entries, _ := s.gitStatusEntries(r.Context(), relPath)
-  conflicted := false
-  for _, e := range entries {
-    if e.Conflicted {
-      conflicted = true
-      break
-    }
-  }
-  if !conflicted {
-    writeError(w, http.StatusNotFound, "not_conflicted")
-    return
-  }
+	entries, _ := s.gitStatusEntries(r.Context(), relPath)
+	conflicted := false
+	for _, e := range entries {
+		if e.Conflicted {
+			conflicted = true
+			break
+		}
+	}
+	if !conflicted {
+		writeError(w, http.StatusNotFound, "not_conflicted")
+		return
+	}
 
-  ours, err := s.readGitStage(r.Context(), 2, relPath)
-  if err != nil {
-    writeError(w, http.StatusBadGateway, "git_show_failed")
-    return
-  }
+	ours, err := s.readGitStage(r.Context(), 2, relPath)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "git_show_failed")
+		return
+	}
 
-  theirs, err := s.readGitStage(r.Context(), 3, relPath)
-  if err != nil {
-    writeError(w, http.StatusBadGateway, "git_show_failed")
-    return
-  }
+	theirs, err := s.readGitStage(r.Context(), 3, relPath)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "git_show_failed")
+		return
+	}
 
-  base, err := s.readGitStage(r.Context(), 1, relPath)
-  if err != nil {
-    writeError(w, http.StatusBadGateway, "git_show_failed")
-    return
-  }
+	base, err := s.readGitStage(r.Context(), 1, relPath)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "git_show_failed")
+		return
+	}
 
-  working := ""
-  if data, err := os.ReadFile(absPath); err == nil {
-    working = string(data)
-  }
+	working := ""
+	if data, err := os.ReadFile(absPath); err == nil {
+		working = string(data)
+	}
 
-  writeJSON(w, http.StatusOK, gitConflictResponse{
-    Ok:      true,
-    Path:    req.Path,
-    Ours:    ours,
-    Theirs:  theirs,
-    Base:    base,
-    Working: working,
-  })
+	writeJSON(w, http.StatusOK, gitConflictResponse{
+		Ok:      true,
+		Path:    req.Path,
+		Ours:    ours,
+		Theirs:  theirs,
+		Base:    base,
+		Working: working,
+	})
 }
 
 func (s *server) handleGitResolve(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req gitResolveRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req gitResolveRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  relPath, absPath, err := s.resolveRelPath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
+	relPath, absPath, err := s.resolveRelPath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
-  switch req.Strategy {
-  case "ours":
-    _, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
-      "git", "checkout", "--ours", "--", relPath,
-    })
-    if checkoutExecErr != nil || checkoutCode != 0 {
-      msg := strings.TrimSpace(checkoutErr)
-      if msg == "" {
-        msg = "git_checkout_failed"
-      }
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
-  case "theirs":
-    _, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
-      "git", "checkout", "--theirs", "--", relPath,
-    })
-    if checkoutExecErr != nil || checkoutCode != 0 {
-      msg := strings.TrimSpace(checkoutErr)
-      if msg == "" {
-        msg = "git_checkout_failed"
-      }
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
-  case "manual":
-    if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
-      writeError(w, http.StatusInternalServerError, "mkdir_failed")
-      return
-    }
-    if err := writeFileAtomic(absPath, []byte(req.Content), 0o644); err != nil {
-      writeError(w, http.StatusInternalServerError, "write_failed")
-      return
-    }
-  default:
-    writeError(w, http.StatusBadRequest, "invalid_strategy")
-    return
-  }
+	switch req.Strategy {
+	case "ours":
+		_, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
+			"git", "checkout", "--ours", "--", relPath,
+		})
+		if checkoutExecErr != nil || checkoutCode != 0 {
+			msg := strings.TrimSpace(checkoutErr)
+			if msg == "" {
+				msg = "git_checkout_failed"
+			}
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
+	case "theirs":
+		_, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
+			"git", "checkout", "--theirs", "--", relPath,
+		})
+		if checkoutExecErr != nil || checkoutCode != 0 {
+			msg := strings.TrimSpace(checkoutErr)
+			if msg == "" {
+				msg = "git_checkout_failed"
+			}
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
+	case "manual":
+		if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+			writeError(w, http.StatusInternalServerError, "mkdir_failed")
+			return
+		}
+		if err := writeFileAtomic(absPath, []byte(req.Content), 0o644); err != nil {
+			writeError(w, http.StatusInternalServerError, "write_failed")
+			return
+		}
+	default:
+		writeError(w, http.StatusBadRequest, "invalid_strategy")
+		return
+	}
 
-  _, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "add", "--", relPath,
-  })
-  if addExecErr != nil || addCode != 0 {
-    msg := strings.TrimSpace(addErr)
-    if msg == "" {
-      msg = "git_add_failed"
-    }
-    writeError(w, http.StatusBadGateway, msg)
-    return
-  }
+	_, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "add", "--", relPath,
+	})
+	if addExecErr != nil || addCode != 0 {
+		msg := strings.TrimSpace(addErr)
+		if msg == "" {
+			msg = "git_add_failed"
+		}
+		writeError(w, http.StatusBadGateway, msg)
+		return
+	}
 
-  writeJSON(w, http.StatusOK, gitResolveResponse{
-    Ok:       true,
-    Path:     req.Path,
-    Strategy: req.Strategy,
-  })
+	writeJSON(w, http.StatusOK, gitResolveResponse{
+		Ok:       true,
+		Path:     req.Path,
+		Strategy: req.Strategy,
+	})
 }
 
 func (s *server) handleGitDiscard(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req gitDiscardRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req gitDiscardRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  relPath, absPath, err := s.resolveRelPath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
+	relPath, absPath, err := s.resolveRelPath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
-  entries, statusErr := s.gitStatusEntries(r.Context(), relPath)
-  if statusErr != nil {
-    writeError(w, http.StatusBadGateway, statusErr.Error())
-    return
-  }
+	entries, statusErr := s.gitStatusEntries(r.Context(), relPath)
+	if statusErr != nil {
+		writeError(w, http.StatusBadGateway, statusErr.Error())
+		return
+	}
 
-  var entry *gitStatusEntry
-  for i := range entries {
-    if entries[i].Path == relPath {
-      entry = &entries[i]
-      break
-    }
-  }
-  if entry == nil {
-    writeError(w, http.StatusNotFound, "not_modified")
-    return
-  }
+	var entry *gitStatusEntry
+	for i := range entries {
+		if entries[i].Path == relPath {
+			entry = &entries[i]
+			break
+		}
+	}
+	if entry == nil {
+		writeError(w, http.StatusNotFound, "not_modified")
+		return
+	}
 
-  // Untracked files can be safely removed without involving git.
-  if entry.Untracked {
-    if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-      writeError(w, http.StatusInternalServerError, "delete_failed")
-      return
-    }
-    writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
-    return
-  }
+	// Untracked files can be safely removed without involving git.
+	if entry.Untracked {
+		if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			writeError(w, http.StatusInternalServerError, "delete_failed")
+			return
+		}
+		writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
+		return
+	}
 
-  // Best-effort: clear index state for this path (helps with conflict stages).
-  _, resetErrOut, resetCode, resetExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "reset", "-q", "--", relPath,
-  })
-  if resetExecErr != nil {
-    writeError(w, http.StatusBadGateway, "git_reset_failed")
-    return
-  }
-  if resetCode != 0 {
-    msg := strings.TrimSpace(resetErrOut)
-    // Ignore common "pathspec" errors (e.g. when the path only exists in the index).
-    if msg != "" && !strings.Contains(strings.ToLower(msg), "pathspec") {
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
-  }
+	// Best-effort: clear index state for this path (helps with conflict stages).
+	_, resetErrOut, resetCode, resetExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "reset", "-q", "--", relPath,
+	})
+	if resetExecErr != nil {
+		writeError(w, http.StatusBadGateway, "git_reset_failed")
+		return
+	}
+	if resetCode != 0 {
+		msg := strings.TrimSpace(resetErrOut)
+		// Ignore common "pathspec" errors (e.g. when the path only exists in the index).
+		if msg != "" && !strings.Contains(strings.ToLower(msg), "pathspec") {
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
+	}
 
-  // If the path exists in HEAD, restore it. Otherwise, drop it from the index and delete it.
-  _, _, catCode, _ := runCmd(r.Context(), s.workspace, []string{
-    "git", "cat-file", "-e", "HEAD:" + relPath,
-  })
+	// If the path exists in HEAD, restore it. Otherwise, drop it from the index and delete it.
+	_, _, catCode, _ := runCmd(r.Context(), s.workspace, []string{
+		"git", "cat-file", "-e", "HEAD:" + relPath,
+	})
 
-  if catCode == 0 {
-    _, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
-      "git", "checkout", "--", relPath,
-    })
-    if checkoutExecErr != nil || checkoutCode != 0 {
-      msg := strings.TrimSpace(checkoutErr)
-      if msg == "" {
-        msg = "git_checkout_failed"
-      }
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
+	if catCode == 0 {
+		_, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
+			"git", "checkout", "--", relPath,
+		})
+		if checkoutExecErr != nil || checkoutCode != 0 {
+			msg := strings.TrimSpace(checkoutErr)
+			if msg == "" {
+				msg = "git_checkout_failed"
+			}
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
 
-    writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
-    return
-  }
+		writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
+		return
+	}
 
-  // New tracked file (not in HEAD).
-  _, rmErr, rmCode, rmExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "rm", "-f", "--cached", "--", relPath,
-  })
-  if rmExecErr != nil {
-    writeError(w, http.StatusBadGateway, "git_rm_failed")
-    return
-  }
-  if rmCode != 0 {
-    // If it wasn't in the index, keep going.
-    _ = rmErr
-  }
+	// New tracked file (not in HEAD).
+	_, rmErr, rmCode, rmExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "rm", "-f", "--cached", "--", relPath,
+	})
+	if rmExecErr != nil {
+		writeError(w, http.StatusBadGateway, "git_rm_failed")
+		return
+	}
+	if rmCode != 0 {
+		// If it wasn't in the index, keep going.
+		_ = rmErr
+	}
 
-  if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-    writeError(w, http.StatusInternalServerError, "delete_failed")
-    return
-  }
-  writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
+	if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		writeError(w, http.StatusInternalServerError, "delete_failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
 }
 
 func (s *server) handleFileRead(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req fileReadRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req fileReadRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  path, err := s.resolvePath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
-  if err := s.ensurePathWithinWorkspace(path); err != nil {
-    writeError(w, http.StatusForbidden, err.Error())
-    return
-  }
+	path, err := s.resolvePath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := s.ensurePathWithinWorkspace(path); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
 
-  info, err := os.Stat(path)
-  if err != nil {
-    if os.IsNotExist(err) {
-      writeError(w, http.StatusNotFound, "not_found")
-      return
-    }
-    writeError(w, http.StatusInternalServerError, "stat_failed")
-    return
-  }
-  if info.IsDir() {
-    writeError(w, http.StatusBadRequest, "is_directory")
-    return
-  }
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeError(w, http.StatusNotFound, "not_found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "stat_failed")
+		return
+	}
+	if info.IsDir() {
+		writeError(w, http.StatusBadRequest, "is_directory")
+		return
+	}
 
-  data, err := os.ReadFile(path)
-  if err != nil {
-    writeError(w, http.StatusInternalServerError, "read_failed")
-    return
-  }
+	data, err := os.ReadFile(path)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "read_failed")
+		return
+	}
 
-  content, encoding := encodeContent(data)
-  writeJSON(w, http.StatusOK, fileReadResponse{
-    Ok:       true,
-    Path:     req.Path,
-    Content:  content,
-    Encoding: encoding,
-    Hash:     hashBytes(data),
-  })
+	content, encoding := encodeContent(data)
+	writeJSON(w, http.StatusOK, fileReadResponse{
+		Ok:       true,
+		Path:     req.Path,
+		Content:  content,
+		Encoding: encoding,
+		Hash:     hashBytes(data),
+	})
 }
 
 func (s *server) handleFileList(w http.ResponseWriter, r *http.Request) {
@@ -732,46 +742,46 @@ func (s *server) handleFileList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleFileWrite(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req fileWriteRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req fileWriteRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  path, err := s.resolvePath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
-  if err := s.ensurePathWithinWorkspace(path); err != nil {
-    writeError(w, http.StatusForbidden, err.Error())
-    return
-  }
+	path, err := s.resolvePath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := s.ensurePathWithinWorkspace(path); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
 
-  if req.ExpectedHash != "" {
-    currentHash, ok, err := verifyExpectedHash(path, req.ExpectedHash)
-    if err != nil {
-      if errors.Is(err, os.ErrNotExist) {
-        writeError(w, http.StatusNotFound, "not_found")
-        return
-      }
-      writeError(w, http.StatusInternalServerError, "hash_check_failed")
-      return
-    }
-    if !ok {
-      writeJSON(w, http.StatusConflict, map[string]any{
-        "ok":          false,
-        "error":       "conflict",
-        "currentHash": currentHash,
-      })
-      return
-    }
-  }
+	if req.ExpectedHash != "" {
+		currentHash, ok, err := verifyExpectedHash(path, req.ExpectedHash)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				writeError(w, http.StatusNotFound, "not_found")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "hash_check_failed")
+			return
+		}
+		if !ok {
+			writeJSON(w, http.StatusConflict, map[string]any{
+				"ok":          false,
+				"error":       "conflict",
+				"currentHash": currentHash,
+			})
+			return
+		}
+	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		writeError(w, http.StatusInternalServerError, "mkdir_failed")
@@ -798,59 +808,104 @@ func (s *server) handleFileWrite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-  data, err := os.ReadFile(path)
-  if err != nil {
-    writeError(w, http.StatusInternalServerError, "read_failed")
-    return
-  }
+	data, err := os.ReadFile(path)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "read_failed")
+		return
+	}
 
-  writeJSON(w, http.StatusOK, fileWriteResponse{
-    Ok:   true,
-    Path: req.Path,
-    Hash: hashBytes(data),
-  })
+	writeJSON(w, http.StatusOK, fileWriteResponse{
+		Ok:   true,
+		Path: req.Path,
+		Hash: hashBytes(data),
+	})
+}
+
+func (s *server) handleFileUpload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
+
+	relPath, absPath, err := s.resolveRelPath(r.URL.Query().Get("path"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		writeError(w, http.StatusInternalServerError, "mkdir_failed")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxUploadBodyBytes)
+	uploadResult, err := writeStreamFileAtomic(absPath, r.Body, 0o644)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "file_too_large")
+			return
+		}
+
+		writeError(w, http.StatusInternalServerError, "write_failed")
+		return
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "stat_failed")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, fileUploadResponse{
+		Ok:         true,
+		Path:       relPath,
+		Hash:       uploadResult.Hash,
+		Size:       uploadResult.Size,
+		ModifiedAt: info.ModTime().UnixMilli(),
+	})
 }
 
 func (s *server) handleFileDelete(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req fileDeleteRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req fileDeleteRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  path, err := s.resolvePath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
-  if err := s.ensurePathWithinWorkspace(path); err != nil {
-    writeError(w, http.StatusForbidden, err.Error())
-    return
-  }
+	path, err := s.resolvePath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := s.ensurePathWithinWorkspace(path); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
 
-  info, err := os.Stat(path)
-  if err != nil {
-    if os.IsNotExist(err) {
-      writeError(w, http.StatusNotFound, "not_found")
-      return
-    }
-    writeError(w, http.StatusInternalServerError, "stat_failed")
-    return
-  }
-  if info.IsDir() {
-    writeError(w, http.StatusBadRequest, "is_directory")
-    return
-  }
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeError(w, http.StatusNotFound, "not_found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "stat_failed")
+		return
+	}
+	if info.IsDir() {
+		writeError(w, http.StatusBadRequest, "is_directory")
+		return
+	}
 
-  if err := os.Remove(path); err != nil {
-    writeError(w, http.StatusInternalServerError, "delete_failed")
-    return
-  }
+	if err := os.Remove(path); err != nil {
+		writeError(w, http.StatusInternalServerError, "delete_failed")
+		return
+	}
 
 	writeJSON(w, http.StatusOK, fileDeleteResponse{
 		Ok:      true,
@@ -939,43 +994,43 @@ func (s *server) handleFileRename(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleApplyPatch(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req fileApplyPatchRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
-  if strings.TrimSpace(req.Patch) == "" {
-    writeError(w, http.StatusBadRequest, "empty_patch")
-    return
-  }
+	var req fileApplyPatchRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
+	if strings.TrimSpace(req.Patch) == "" {
+		writeError(w, http.StatusBadRequest, "empty_patch")
+		return
+	}
 
-  cmd := exec.CommandContext(r.Context(), "git", "apply", "--whitespace=nowarn", "--")
-  cmd.Dir = s.workspace
-  cmd.Stdin = strings.NewReader(req.Patch)
-  var stdout bytes.Buffer
-  var stderr bytes.Buffer
-  cmd.Stdout = &stdout
-  cmd.Stderr = &stderr
+	cmd := exec.CommandContext(r.Context(), "git", "apply", "--whitespace=nowarn", "--")
+	cmd.Dir = s.workspace
+	cmd.Stdin = strings.NewReader(req.Patch)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
-  err := cmd.Run()
-  if err != nil {
-    msg := strings.TrimSpace(stderr.String())
-    if msg == "" {
-      msg = "apply_patch_failed"
-    }
-    writeJSON(w, http.StatusConflict, map[string]any{
-      "ok":    false,
-      "error": msg,
-    })
-    return
-  }
+	err := cmd.Run()
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = "apply_patch_failed"
+		}
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"ok":    false,
+			"error": msg,
+		})
+		return
+	}
 
-  writeJSON(w, http.StatusOK, fileApplyPatchResponse{Ok: true})
+	writeJSON(w, http.StatusOK, fileApplyPatchResponse{Ok: true})
 }
 
 // fetchAndMergeKb fetches from the kb remote and merges the remote branch.
@@ -983,351 +1038,351 @@ func (s *server) handleApplyPatch(w http.ResponseWriter, r *http.Request) {
 // was no remote branch yet). If ok is false and conflicts is non-empty the merge
 // produced conflicts. Otherwise errMsg describes the failure.
 func (s *server) fetchAndMergeKb(ctx context.Context) (bool, []string, string) {
-  _, fetchErr, fetchCode, fetchExecErr := runCmd(ctx, s.workspace, []string{
-    "git", "fetch", "kb",
-  })
-  if fetchExecErr != nil || fetchCode != 0 {
-    msg := strings.TrimSpace(fetchErr)
-    if msg == "" {
-      msg = "fetch_failed"
-    }
-    return false, nil, "Fetch failed: " + msg
-  }
+	_, fetchErr, fetchCode, fetchExecErr := runCmd(ctx, s.workspace, []string{
+		"git", "fetch", "kb",
+	})
+	if fetchExecErr != nil || fetchCode != 0 {
+		msg := strings.TrimSpace(fetchErr)
+		if msg == "" {
+			msg = "fetch_failed"
+		}
+		return false, nil, "Fetch failed: " + msg
+	}
 
-  kbBranch := s.resolveKbBranch(ctx)
+	kbBranch := s.resolveKbBranch(ctx)
 
-  if !s.remoteBranchExists(ctx, kbBranch) {
-    // First publish — nothing to merge.
-    return true, nil, ""
-  }
+	if !s.remoteBranchExists(ctx, kbBranch) {
+		// First publish — nothing to merge.
+		return true, nil, ""
+	}
 
-  _, mergeErr, mergeCode, mergeExecErr := runCmd(ctx, s.workspace, []string{
-    "git", "merge", "kb/" + kbBranch, "--no-edit",
-  })
-  if mergeExecErr == nil && mergeCode == 0 {
-    return true, nil, ""
-  }
+	_, mergeErr, mergeCode, mergeExecErr := runCmd(ctx, s.workspace, []string{
+		"git", "merge", "kb/" + kbBranch, "--no-edit",
+	})
+	if mergeExecErr == nil && mergeCode == 0 {
+		return true, nil, ""
+	}
 
-  if isUnrelatedHistoryError(mergeErr) {
-    _, mergeErrAllow, mergeCodeAllow, mergeExecErrAllow := runCmd(ctx, s.workspace, []string{
-      "git", "merge", "kb/" + kbBranch, "--no-edit", "--allow-unrelated-histories",
-    })
-    if mergeExecErrAllow == nil && mergeCodeAllow == 0 {
-      return true, nil, ""
-    }
+	if isUnrelatedHistoryError(mergeErr) {
+		_, mergeErrAllow, mergeCodeAllow, mergeExecErrAllow := runCmd(ctx, s.workspace, []string{
+			"git", "merge", "kb/" + kbBranch, "--no-edit", "--allow-unrelated-histories",
+		})
+		if mergeExecErrAllow == nil && mergeCodeAllow == 0 {
+			return true, nil, ""
+		}
 
-    conflicts := s.listConflictFiles(ctx)
-    if len(conflicts) > 0 {
-      return false, conflicts, "Merge has conflicts that need to be resolved"
-    }
+		conflicts := s.listConflictFiles(ctx)
+		if len(conflicts) > 0 {
+			return false, conflicts, "Merge has conflicts that need to be resolved"
+		}
 
-    msg := strings.TrimSpace(mergeErrAllow)
-    if msg == "" {
-      msg = "merge_failed"
-    }
-    return false, nil, "Merge failed: " + msg
-  }
+		msg := strings.TrimSpace(mergeErrAllow)
+		if msg == "" {
+			msg = "merge_failed"
+		}
+		return false, nil, "Merge failed: " + msg
+	}
 
-  conflicts := s.listConflictFiles(ctx)
-  if len(conflicts) > 0 {
-    return false, conflicts, "Merge has conflicts that need to be resolved"
-  }
+	conflicts := s.listConflictFiles(ctx)
+	if len(conflicts) > 0 {
+		return false, conflicts, "Merge has conflicts that need to be resolved"
+	}
 
-  msg := strings.TrimSpace(mergeErr)
-  if msg == "" {
-    msg = "merge_failed"
-  }
-  return false, nil, "Merge failed: " + msg
+	msg := strings.TrimSpace(mergeErr)
+	if msg == "" {
+		msg = "merge_failed"
+	}
+	return false, nil, "Merge failed: " + msg
 }
 
 func (s *server) handleKbSync(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  _, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "remote", "get-url", "kb",
-  })
-  if remoteExecErr != nil || remoteCode != 0 {
-    writeJSON(w, http.StatusOK, syncKbResponse{
-      Ok:      false,
-      Status:  "no_remote",
-      Message: "KB remote not configured. Workspace may not have been initialized with KB.",
-    })
-    return
-  }
+	_, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "remote", "get-url", "kb",
+	})
+	if remoteExecErr != nil || remoteCode != 0 {
+		writeJSON(w, http.StatusOK, syncKbResponse{
+			Ok:      false,
+			Status:  "no_remote",
+			Message: "KB remote not configured. Workspace may not have been initialized with KB.",
+		})
+		return
+	}
 
-  mergeOk, conflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
-  if mergeOk {
-    writeJSON(w, http.StatusOK, syncKbResponse{
-      Ok:      true,
-      Status:  "synced",
-      Message: "KB synchronized successfully",
-    })
-    return
-  }
+	mergeOk, conflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
+	if mergeOk {
+		writeJSON(w, http.StatusOK, syncKbResponse{
+			Ok:      true,
+			Status:  "synced",
+			Message: "KB synchronized successfully",
+		})
+		return
+	}
 
-  if len(conflicts) > 0 {
-    writeJSON(w, http.StatusOK, syncKbResponse{
-      Ok:        true,
-      Status:    "conflicts",
-      Message:   "Merge has conflicts that need to be resolved",
-      Conflicts: conflicts,
-    })
-    return
-  }
+	if len(conflicts) > 0 {
+		writeJSON(w, http.StatusOK, syncKbResponse{
+			Ok:        true,
+			Status:    "conflicts",
+			Message:   "Merge has conflicts that need to be resolved",
+			Conflicts: conflicts,
+		})
+		return
+	}
 
-  writeJSON(w, http.StatusOK, syncKbResponse{
-    Ok:      false,
-    Status:  "error",
-    Message: mergeErrMsg,
-  })
+	writeJSON(w, http.StatusOK, syncKbResponse{
+		Ok:      false,
+		Status:  "error",
+		Message: mergeErrMsg,
+	})
 }
 
 func (s *server) handleKbStatus(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodGet {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  conflicts := s.listConflictFiles(r.Context())
-  writeJSON(w, http.StatusOK, syncStatusResponse{
-    Ok:           true,
-    HasConflicts: len(conflicts) > 0,
-    Conflicts:    conflicts,
-  })
+	conflicts := s.listConflictFiles(r.Context())
+	writeJSON(w, http.StatusOK, syncStatusResponse{
+		Ok:           true,
+		HasConflicts: len(conflicts) > 0,
+		Conflicts:    conflicts,
+	})
 }
 
 func (s *server) handleKbPublish(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  _, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "remote", "get-url", "kb",
-  })
-  if remoteExecErr != nil || remoteCode != 0 {
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "no_remote",
-      Message: "KB remote not configured.",
-    })
-    return
-  }
+	_, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "remote", "get-url", "kb",
+	})
+	if remoteExecErr != nil || remoteCode != 0 {
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "no_remote",
+			Message: "KB remote not configured.",
+		})
+		return
+	}
 
-  conflicts := s.listConflictFiles(r.Context())
-  if len(conflicts) > 0 {
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "conflicts",
-      Files:   conflicts,
-      Message: "Resolve conflicts before publishing.",
-    })
-    return
-  }
+	conflicts := s.listConflictFiles(r.Context())
+	if len(conflicts) > 0 {
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "conflicts",
+			Files:   conflicts,
+			Message: "Resolve conflicts before publishing.",
+		})
+		return
+	}
 
-  entries, statusErr := s.gitStatusEntries(r.Context())
-  if statusErr != nil {
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "error",
-      Message: statusErr.Error(),
-    })
-    return
-  }
+	entries, statusErr := s.gitStatusEntries(r.Context())
+	if statusErr != nil {
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "error",
+			Message: statusErr.Error(),
+		})
+		return
+	}
 
-  if len(entries) == 0 {
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      true,
-      Status:  "nothing_to_publish",
-      Message: "Nothing to publish.",
-    })
-    return
-  }
+	if len(entries) == 0 {
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      true,
+			Status:  "nothing_to_publish",
+			Message: "Nothing to publish.",
+		})
+		return
+	}
 
-  _, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "add", "-A",
-  })
-  if addExecErr != nil || addCode != 0 {
-    msg := strings.TrimSpace(addErr)
-    if msg == "" {
-      msg = "git_add_failed"
-    }
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "error",
-      Message: "git add failed: " + msg,
-    })
-    return
-  }
+	_, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "add", "-A",
+	})
+	if addExecErr != nil || addCode != 0 {
+		msg := strings.TrimSpace(addErr)
+		if msg == "" {
+			msg = "git_add_failed"
+		}
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "error",
+			Message: "git add failed: " + msg,
+		})
+		return
+	}
 
-  statOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
-    "git", "diff", "--cached", "--stat",
-  })
-  commitMessage := generateCommitMessage(statOut)
+	statOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
+		"git", "diff", "--cached", "--stat",
+	})
+	commitMessage := generateCommitMessage(statOut)
 
-  _, commitErr, commitCode, commitExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "commit", "-m", commitMessage,
-  })
-  if commitExecErr != nil || commitCode != 0 {
-    msg := strings.TrimSpace(commitErr)
-    if msg == "" {
-      msg = "git_commit_failed"
-    }
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "error",
-      Message: "git commit failed: " + msg,
-    })
-    return
-  }
+	_, commitErr, commitCode, commitExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "commit", "-m", commitMessage,
+	})
+	if commitExecErr != nil || commitCode != 0 {
+		msg := strings.TrimSpace(commitErr)
+		if msg == "" {
+			msg = "git_commit_failed"
+		}
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "error",
+			Message: "git commit failed: " + msg,
+		})
+		return
+	}
 
-  hashOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
-    "git", "rev-parse", "--short", "HEAD",
-  })
-  commitHash := strings.TrimSpace(hashOut)
+	hashOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
+		"git", "rev-parse", "--short", "HEAD",
+	})
+	commitHash := strings.TrimSpace(hashOut)
 
-  filesOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
-    "git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD",
-  })
-  files := splitLines(filesOut)
+	filesOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
+		"git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD",
+	})
+	files := splitLines(filesOut)
 
-  // Fetch and merge remote before pushing to avoid rejected pushes.
-  mergeOk, mergeConflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
-  if !mergeOk {
-    if len(mergeConflicts) > 0 {
-      writeJSON(w, http.StatusOK, publishKbResponse{
-        Ok:      false,
-        Status:  "conflicts",
-        Files:   mergeConflicts,
-        Message: "Merge conflicts during publish. Resolve and retry.",
-      })
-      return
-    }
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "error",
-      Message: mergeErrMsg,
-    })
-    return
-  }
+	// Fetch and merge remote before pushing to avoid rejected pushes.
+	mergeOk, mergeConflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
+	if !mergeOk {
+		if len(mergeConflicts) > 0 {
+			writeJSON(w, http.StatusOK, publishKbResponse{
+				Ok:      false,
+				Status:  "conflicts",
+				Files:   mergeConflicts,
+				Message: "Merge conflicts during publish. Resolve and retry.",
+			})
+			return
+		}
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "error",
+			Message: mergeErrMsg,
+		})
+		return
+	}
 
-  kbBranch := s.resolveKbBranch(r.Context())
-  _, pushErr, pushCode, pushExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "push", "kb", "HEAD:refs/heads/" + kbBranch,
-  })
-  if pushExecErr != nil || pushCode != 0 {
-    msg := strings.TrimSpace(pushErr)
-    if msg == "" {
-      msg = "git_push_failed"
-    }
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:         false,
-      Status:     "push_rejected",
-      CommitHash: commitHash,
-      Files:      files,
-      Message:    msg,
-    })
-    return
-  }
+	kbBranch := s.resolveKbBranch(r.Context())
+	_, pushErr, pushCode, pushExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "push", "kb", "HEAD:refs/heads/" + kbBranch,
+	})
+	if pushExecErr != nil || pushCode != 0 {
+		msg := strings.TrimSpace(pushErr)
+		if msg == "" {
+			msg = "git_push_failed"
+		}
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:         false,
+			Status:     "push_rejected",
+			CommitHash: commitHash,
+			Files:      files,
+			Message:    msg,
+		})
+		return
+	}
 
-  writeJSON(w, http.StatusOK, publishKbResponse{
-    Ok:         true,
-    Status:     "published",
-    CommitHash: commitHash,
-    Files:      files,
-  })
+	writeJSON(w, http.StatusOK, publishKbResponse{
+		Ok:         true,
+		Status:     "published",
+		CommitHash: commitHash,
+		Files:      files,
+	})
 }
 
 func (s *server) gitStatusEntries(ctx context.Context, paths ...string) ([]gitStatusEntry, error) {
-  args := []string{"git", "-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=all"}
-  if len(paths) > 0 {
-    args = append(args, "--")
-    args = append(args, paths...)
-  }
-  out, stderr, code, err := runCmd(ctx, s.workspace, args)
-  if err != nil || code != 0 {
-    msg := strings.TrimSpace(stderr)
-    if msg == "" {
-      msg = "git_status_failed"
-    }
-    return nil, errors.New(msg)
-  }
-  return parseGitStatus(out), nil
+	args := []string{"git", "-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=all"}
+	if len(paths) > 0 {
+		args = append(args, "--")
+		args = append(args, paths...)
+	}
+	out, stderr, code, err := runCmd(ctx, s.workspace, args)
+	if err != nil || code != 0 {
+		msg := strings.TrimSpace(stderr)
+		if msg == "" {
+			msg = "git_status_failed"
+		}
+		return nil, errors.New(msg)
+	}
+	return parseGitStatus(out), nil
 }
 
 func (s *server) listConflictFiles(ctx context.Context) []string {
-  entries, _ := s.gitStatusEntries(ctx)
-  var result []string
-  for _, e := range entries {
-    if e.Conflicted {
-      result = append(result, e.Path)
-    }
-  }
-  return result
+	entries, _ := s.gitStatusEntries(ctx)
+	var result []string
+	for _, e := range entries {
+		if e.Conflicted {
+			result = append(result, e.Path)
+		}
+	}
+	return result
 }
 
 func isUnrelatedHistoryError(message string) bool {
-  msg := strings.ToLower(message)
-  return strings.Contains(msg, "unrelated histories")
+	msg := strings.ToLower(message)
+	return strings.Contains(msg, "unrelated histories")
 }
 
 func (s *server) resolveKbBranch(ctx context.Context) string {
-  _, _, _, _ = runCmd(ctx, s.workspace, []string{
-    "git", "remote", "set-head", "kb", "-a",
-  })
+	_, _, _, _ = runCmd(ctx, s.workspace, []string{
+		"git", "remote", "set-head", "kb", "-a",
+	})
 
-  headOut, _, headCode, _ := runCmd(ctx, s.workspace, []string{
-    "git", "symbolic-ref", "-q", "--short", "refs/remotes/kb/HEAD",
-  })
-  headRef := strings.TrimSpace(headOut)
-  if headCode == 0 && strings.HasPrefix(headRef, "kb/") {
-    branch := strings.TrimPrefix(headRef, "kb/")
-    if branch != "" {
-      return branch
-    }
-  }
+	headOut, _, headCode, _ := runCmd(ctx, s.workspace, []string{
+		"git", "symbolic-ref", "-q", "--short", "refs/remotes/kb/HEAD",
+	})
+	headRef := strings.TrimSpace(headOut)
+	if headCode == 0 && strings.HasPrefix(headRef, "kb/") {
+		branch := strings.TrimPrefix(headRef, "kb/")
+		if branch != "" {
+			return branch
+		}
+	}
 
-  if s.remoteBranchExists(ctx, "main") {
-    return "main"
-  }
+	if s.remoteBranchExists(ctx, "main") {
+		return "main"
+	}
 
-  current := s.currentBranch(ctx)
-  if current != "" && s.remoteBranchExists(ctx, current) {
-    return current
-  }
+	current := s.currentBranch(ctx)
+	if current != "" && s.remoteBranchExists(ctx, current) {
+		return current
+	}
 
-  return "main"
+	return "main"
 }
 
 func (s *server) remoteBranchExists(ctx context.Context, branch string) bool {
-  _, _, code, _ := runCmd(ctx, s.workspace, []string{
-    "git", "show-ref", "--verify", "--quiet", "refs/remotes/kb/" + branch,
-  })
-  return code == 0
+	_, _, code, _ := runCmd(ctx, s.workspace, []string{
+		"git", "show-ref", "--verify", "--quiet", "refs/remotes/kb/" + branch,
+	})
+	return code == 0
 }
 
 func (s *server) currentBranch(ctx context.Context) string {
-  out, _, code, _ := runCmd(ctx, s.workspace, []string{
-    "git", "rev-parse", "--abbrev-ref", "HEAD",
-  })
-  if code != 0 {
-    return ""
-  }
-  branch := strings.TrimSpace(out)
-  if branch == "" || branch == "HEAD" {
-    return ""
-  }
-  return branch
+	out, _, code, _ := runCmd(ctx, s.workspace, []string{
+		"git", "rev-parse", "--abbrev-ref", "HEAD",
+	})
+	if code != 0 {
+		return ""
+	}
+	branch := strings.TrimSpace(out)
+	if branch == "" || branch == "HEAD" {
+		return ""
+	}
+	return branch
 }
 
 type gitStatusEntry struct {
-  Path      string
-  Status    string
-  Untracked bool
-  Conflicted bool
+	Path       string
+	Status     string
+	Untracked  bool
+	Conflicted bool
 }
 
 func isInternalWorkspacePath(path string) bool {
@@ -1343,290 +1398,326 @@ func isInternalWorkspacePath(path string) bool {
 }
 
 func parseGitStatus(output string) []gitStatusEntry {
-  raw := []byte(output)
-  if len(raw) == 0 {
-    return nil
-  }
-  parts := bytes.Split(raw, []byte{0})
-  results := make([]gitStatusEntry, 0, len(parts))
-  for i := 0; i < len(parts); i++ {
-    entry := parts[i]
-    if len(entry) == 0 {
-      continue
-    }
-    // git status --porcelain=v1 -z output is:
-    //   XY<space>PATH\0
-    // where X and Y can be spaces. Do NOT split on the first space.
-    if len(entry) < 4 {
-      continue
-    }
-    statusField := string(entry[:2])
-    if statusField == "!!" {
-      continue
-    }
+	raw := []byte(output)
+	if len(raw) == 0 {
+		return nil
+	}
+	parts := bytes.Split(raw, []byte{0})
+	results := make([]gitStatusEntry, 0, len(parts))
+	for i := 0; i < len(parts); i++ {
+		entry := parts[i]
+		if len(entry) == 0 {
+			continue
+		}
+		// git status --porcelain=v1 -z output is:
+		//   XY<space>PATH\0
+		// where X and Y can be spaces. Do NOT split on the first space.
+		if len(entry) < 4 {
+			continue
+		}
+		statusField := string(entry[:2])
+		if statusField == "!!" {
+			continue
+		}
 
-    // After the two status characters there is a single space.
-    // We keep the raw path as-is (no TrimSpace) because it is a filename.
-    path := string(entry[3:])
+		// After the two status characters there is a single space.
+		// We keep the raw path as-is (no TrimSpace) because it is a filename.
+		path := string(entry[3:])
 
-    // For renames/copies, git status -z provides a second NUL-separated path.
-    // The first path is the source; the second is the destination.
-    if len(statusField) > 0 && (statusField[0] == 'R' || statusField[0] == 'C') {
-      if i+1 < len(parts) && len(parts[i+1]) > 0 {
-        path = string(parts[i+1])
-        i++
-      }
-    }
+		// For renames/copies, git status -z provides a second NUL-separated path.
+		// The first path is the source; the second is the destination.
+		if len(statusField) > 0 && (statusField[0] == 'R' || statusField[0] == 'C') {
+			if i+1 < len(parts) && len(parts[i+1]) > 0 {
+				path = string(parts[i+1])
+				i++
+			}
+		}
 
-    if path == "" {
-      continue
-    }
-    if isInternalWorkspacePath(path) {
-      continue
-    }
+		if path == "" {
+			continue
+		}
+		if isInternalWorkspacePath(path) {
+			continue
+		}
 
-    untracked := statusField == "??"
-    conflicted := strings.Contains(statusField, "U") || statusField == "AA" || statusField == "DD"
-    fileStatus := "modified"
-    if untracked || strings.Contains(statusField, "A") || (len(statusField) > 0 && statusField[0] == 'C') {
-      fileStatus = "added"
-    } else if strings.Contains(statusField, "D") {
-      fileStatus = "deleted"
-    }
+		untracked := statusField == "??"
+		conflicted := strings.Contains(statusField, "U") || statusField == "AA" || statusField == "DD"
+		fileStatus := "modified"
+		if untracked || strings.Contains(statusField, "A") || (len(statusField) > 0 && statusField[0] == 'C') {
+			fileStatus = "added"
+		} else if strings.Contains(statusField, "D") {
+			fileStatus = "deleted"
+		}
 
-    results = append(results, gitStatusEntry{
-      Path:      path,
-      Status:    fileStatus,
-      Untracked: untracked,
-      Conflicted: conflicted,
-    })
-  }
-  return results
+		results = append(results, gitStatusEntry{
+			Path:       path,
+			Status:     fileStatus,
+			Untracked:  untracked,
+			Conflicted: conflicted,
+		})
+	}
+	return results
 }
 
 func parseNumstat(output string) (int, int) {
-  line := ""
-  for _, candidate := range strings.Split(strings.TrimSpace(output), "\n") {
-    if strings.TrimSpace(candidate) != "" {
-      line = candidate
-      break
-    }
-  }
-  if line == "" {
-    return 0, 0
-  }
-  fields := strings.Split(line, "\t")
-  if len(fields) < 2 {
-    return 0, 0
-  }
-  add := parseNum(fields[0])
-  del := parseNum(fields[1])
-  return add, del
+	line := ""
+	for _, candidate := range strings.Split(strings.TrimSpace(output), "\n") {
+		if strings.TrimSpace(candidate) != "" {
+			line = candidate
+			break
+		}
+	}
+	if line == "" {
+		return 0, 0
+	}
+	fields := strings.Split(line, "\t")
+	if len(fields) < 2 {
+		return 0, 0
+	}
+	add := parseNum(fields[0])
+	del := parseNum(fields[1])
+	return add, del
 }
 
 func parseNum(value string) int {
-  if value == "-" {
-    return 0
-  }
-  parsed, err := strconv.Atoi(value)
-  if err != nil {
-    return 0
-  }
-  return parsed
+	if value == "-" {
+		return 0
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0
+	}
+	return parsed
 }
 
 func splitLines(output string) []string {
-  lines := strings.Split(output, "\n")
-  result := make([]string, 0, len(lines))
-  for _, line := range lines {
-    trimmed := strings.TrimSpace(line)
-    if trimmed != "" {
-      result = append(result, trimmed)
-    }
-  }
-  return result
+	lines := strings.Split(output, "\n")
+	result := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }
 
 func generateCommitMessage(statOutput string) string {
-  lines := splitLines(statOutput)
-  fileNames := make([]string, 0, len(lines))
+	lines := splitLines(statOutput)
+	fileNames := make([]string, 0, len(lines))
 
-  for _, line := range lines {
-    if !strings.Contains(line, "|") {
-      continue
-    }
-    parts := strings.Split(line, "|")
-    if len(parts) == 0 {
-      continue
-    }
-    name := strings.TrimSpace(parts[0])
-    if name != "" {
-      fileNames = append(fileNames, name)
-    }
-  }
+	for _, line := range lines {
+		if !strings.Contains(line, "|") {
+			continue
+		}
+		parts := strings.Split(line, "|")
+		if len(parts) == 0 {
+			continue
+		}
+		name := strings.TrimSpace(parts[0])
+		if name != "" {
+			fileNames = append(fileNames, name)
+		}
+	}
 
-  if len(fileNames) == 0 {
-    return "Update files"
-  }
-  if len(fileNames) <= 3 {
-    return "Update " + strings.Join(fileNames, ", ")
-  }
-  return "Update " + strconv.Itoa(len(fileNames)) + " files"
+	if len(fileNames) == 0 {
+		return "Update files"
+	}
+	if len(fileNames) <= 3 {
+		return "Update " + strings.Join(fileNames, ", ")
+	}
+	return "Update " + strconv.Itoa(len(fileNames)) + " files"
 }
 
 func runCmd(ctx context.Context, dir string, args []string) (string, string, int, error) {
-  if len(args) == 0 {
-    return "", "", 1, errors.New("no_command")
-  }
-  cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-  cmd.Dir = dir
-  var stdout bytes.Buffer
-  var stderr bytes.Buffer
-  cmd.Stdout = &stdout
-  cmd.Stderr = &stderr
-  err := cmd.Run()
-  if err != nil {
-    var exitErr *exec.ExitError
-    if errors.As(err, &exitErr) {
-      return stdout.String(), stderr.String(), exitErr.ExitCode(), nil
-    }
-    return stdout.String(), stderr.String(), 1, err
-  }
-  return stdout.String(), stderr.String(), 0, nil
+	if len(args) == 0 {
+		return "", "", 1, errors.New("no_command")
+	}
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Dir = dir
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return stdout.String(), stderr.String(), exitErr.ExitCode(), nil
+		}
+		return stdout.String(), stderr.String(), 1, err
+	}
+	return stdout.String(), stderr.String(), 0, nil
 }
 
 func (s *server) readGitStage(ctx context.Context, stage int, relPath string) (string, error) {
-  spec := ":" + strconv.Itoa(stage) + ":" + relPath
-  out, _, code, execErr := runCmd(ctx, s.workspace, []string{
-    "git", "show", spec,
-  })
-  if execErr != nil {
-    return "", execErr
-  }
-  if code != 0 {
-    return "", nil
-  }
-  return out, nil
+	spec := ":" + strconv.Itoa(stage) + ":" + relPath
+	out, _, code, execErr := runCmd(ctx, s.workspace, []string{
+		"git", "show", spec,
+	})
+	if execErr != nil {
+		return "", execErr
+	}
+	if code != 0 {
+		return "", nil
+	}
+	return out, nil
 }
 
 func (s *server) resolveRelPath(rel string) (string, string, error) {
-  abs, err := s.resolvePath(rel)
-  if err != nil {
-    return "", "", err
-  }
-  workspaceAbs, err := filepath.Abs(s.workspace)
-  if err != nil {
-    return "", "", errors.New("workspace_invalid")
-  }
-  relPath, err := filepath.Rel(workspaceAbs, abs)
-  if err != nil {
-    return "", "", errors.New("invalid_path")
-  }
-  if relPath == "." || relPath == "" {
-    return "", "", errors.New("invalid_path")
-  }
-  return filepath.ToSlash(relPath), abs, nil
+	abs, err := s.resolvePath(rel)
+	if err != nil {
+		return "", "", err
+	}
+	workspaceAbs, err := filepath.Abs(s.workspace)
+	if err != nil {
+		return "", "", errors.New("workspace_invalid")
+	}
+	relPath, err := filepath.Rel(workspaceAbs, abs)
+	if err != nil {
+		return "", "", errors.New("invalid_path")
+	}
+	if relPath == "." || relPath == "" {
+		return "", "", errors.New("invalid_path")
+	}
+	return filepath.ToSlash(relPath), abs, nil
 }
 
 func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
-  dir := filepath.Dir(path)
-  temp, err := os.CreateTemp(dir, ".tmp-*")
-  if err != nil {
-    return err
-  }
-  tempName := temp.Name()
-  defer os.Remove(tempName)
+	dir := filepath.Dir(path)
+	temp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempName := temp.Name()
+	defer os.Remove(tempName)
 
-  if _, err := temp.Write(data); err != nil {
-    temp.Close()
-    return err
-  }
-  if err := temp.Chmod(perm); err != nil {
-    temp.Close()
-    return err
-  }
-  if err := temp.Close(); err != nil {
-    return err
-  }
-  return os.Rename(tempName, path)
+	if _, err := temp.Write(data); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Chmod(perm); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempName, path)
+}
+
+type streamedFileResult struct {
+	Size int64
+	Hash string
+}
+
+func writeStreamFileAtomic(path string, reader io.Reader, perm os.FileMode) (streamedFileResult, error) {
+	dir := filepath.Dir(path)
+	temp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return streamedFileResult{}, err
+	}
+	tempName := temp.Name()
+	defer os.Remove(tempName)
+	defer temp.Close()
+
+	hasher := sha256.New()
+	size, err := io.Copy(io.MultiWriter(temp, hasher), reader)
+	if err != nil {
+		return streamedFileResult{}, err
+	}
+	if err := temp.Chmod(perm); err != nil {
+		return streamedFileResult{}, err
+	}
+	if err := temp.Close(); err != nil {
+		return streamedFileResult{}, err
+	}
+	if err := os.Rename(tempName, path); err != nil {
+		return streamedFileResult{}, err
+	}
+
+	return streamedFileResult{
+		Size: size,
+		Hash: "sha256:" + hex.EncodeToString(hasher.Sum(nil)),
+	}, nil
 }
 
 func verifyExpectedHash(path string, expected string) (string, bool, error) {
-  data, err := os.ReadFile(path)
-  if err != nil {
-    return "", false, err
-  }
-  currentHash := hashBytes(data)
-  return currentHash, expected == currentHash, nil
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false, err
+	}
+	currentHash := hashBytes(data)
+	return currentHash, expected == currentHash, nil
 }
 
 func hashBytes(data []byte) string {
-  sum := sha256.Sum256(data)
-  return "sha256:" + hex.EncodeToString(sum[:])
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func encodeContent(data []byte) (string, string) {
-  if utf8.Valid(data) {
-    return string(data), "utf-8"
-  }
-  return base64.StdEncoding.EncodeToString(data), "base64"
+	if utf8.Valid(data) {
+		return string(data), "utf-8"
+	}
+	return base64.StdEncoding.EncodeToString(data), "base64"
 }
 
 func decodeJSON(w http.ResponseWriter, r *http.Request, target any) error {
-  r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
-  decoder := json.NewDecoder(r.Body)
-  if err := decoder.Decode(target); err != nil {
-    return err
-  }
-  if err := decoder.Decode(&struct{}{}); err != nil && !errors.Is(err, io.EOF) {
-    return errors.New("unexpected_data")
-  }
-  return nil
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != nil && !errors.Is(err, io.EOF) {
+		return errors.New("unexpected_data")
+	}
+	return nil
 }
 
 func writeJSON(w http.ResponseWriter, status int, payload any) {
-  w.Header().Set("Content-Type", "application/json")
-  w.WriteHeader(status)
-  encoder := json.NewEncoder(w)
-  encoder.SetEscapeHTML(false)
-  _ = encoder.Encode(payload)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	_ = encoder.Encode(payload)
 }
 
 func writeError(w http.ResponseWriter, status int, message string) {
-  writeJSON(w, status, errorResponse{Ok: false, Error: message})
+	writeJSON(w, status, errorResponse{Ok: false, Error: message})
 }
 
 func (s *server) resolvePath(rel string) (string, error) {
-  if strings.TrimSpace(rel) == "" {
-    return "", errors.New("path_required")
-  }
-  if strings.Contains(rel, "\x00") {
-    return "", errors.New("invalid_path")
-  }
-  if filepath.IsAbs(rel) {
-    return "", errors.New("absolute_paths_not_allowed")
-  }
+	if strings.TrimSpace(rel) == "" {
+		return "", errors.New("path_required")
+	}
+	if strings.Contains(rel, "\x00") {
+		return "", errors.New("invalid_path")
+	}
+	if filepath.IsAbs(rel) {
+		return "", errors.New("absolute_paths_not_allowed")
+	}
 
-  cleaned := filepath.Clean(rel)
-  if cleaned == "." || cleaned == "" {
-    return "", errors.New("invalid_path")
-  }
-  if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(os.PathSeparator)) {
-    return "", errors.New("path_outside_workspace")
-  }
-  if cleaned == ".git" || strings.HasPrefix(cleaned, ".git"+string(os.PathSeparator)) {
-    return "", errors.New("git_dir_not_allowed")
-  }
+	cleaned := filepath.Clean(rel)
+	if cleaned == "." || cleaned == "" {
+		return "", errors.New("invalid_path")
+	}
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(os.PathSeparator)) {
+		return "", errors.New("path_outside_workspace")
+	}
+	if cleaned == ".git" || strings.HasPrefix(cleaned, ".git"+string(os.PathSeparator)) {
+		return "", errors.New("git_dir_not_allowed")
+	}
 
-  workspaceAbs, err := filepath.Abs(s.workspace)
-  if err != nil {
-    return "", errors.New("workspace_invalid")
-  }
-  abs := filepath.Join(workspaceAbs, cleaned)
-  abs, err = filepath.Abs(abs)
-  if err != nil {
-    return "", errors.New("invalid_path")
-  }
+	workspaceAbs, err := filepath.Abs(s.workspace)
+	if err != nil {
+		return "", errors.New("workspace_invalid")
+	}
+	abs := filepath.Join(workspaceAbs, cleaned)
+	abs, err = filepath.Abs(abs)
+	if err != nil {
+		return "", errors.New("invalid_path")
+	}
 
 	if !strings.HasPrefix(abs+string(os.PathSeparator), workspaceAbs+string(os.PathSeparator)) && abs != workspaceAbs {
 		return "", errors.New("path_outside_workspace")
@@ -1651,17 +1742,17 @@ func (s *server) ensurePathWithinWorkspace(absPath string) error {
 }
 
 func getenv(key, fallback string) string {
-  value := os.Getenv(key)
-  if value == "" {
-    return fallback
-  }
-  return value
+	value := os.Getenv(key)
+	if value == "" {
+		return fallback
+	}
+	return value
 }
 
 func logRequests(next http.Handler) http.Handler {
-  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-    start := time.Now()
-    next.ServeHTTP(w, r)
-    log.Printf("%s %s %s", r.Method, r.URL.Path, time.Since(start))
-  })
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		next.ServeHTTP(w, r)
+		log.Printf("%s %s %s", r.Method, r.URL.Path, time.Since(start))
+	})
 }

--- a/infra/workspace-image/workspace-agent/main.go
+++ b/infra/workspace-image/workspace-agent/main.go
@@ -5,15 +5,15 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
-	"encoding/json"
-	"errors"
-	"flag"
-	"io"
-	"log"
-	"net/http"
-	"os"
-	"os/exec"
+  "encoding/hex"
+  "encoding/json"
+  "errors"
+  "flag"
+  "io"
+  "log"
+  "net/http"
+  "os"
+  "os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -23,74 +23,74 @@ import (
 )
 
 const (
-	defaultAddr        = "0.0.0.0:4097"
-	defaultWorkspace   = "/workspace"
-	maxBodyBytes       = 20 << 20
+  defaultAddr      = "0.0.0.0:4097"
+  defaultWorkspace = "/workspace"
+  maxBodyBytes     = 20 << 20
 	maxUploadBodyBytes = 100 << 20
 )
 
 type server struct {
-	workspace string
-	username  string
-	password  string
+  workspace string
+  username  string
+  password  string
 }
 
 type errorResponse struct {
-	Ok    bool   `json:"ok"`
-	Error string `json:"error"`
+  Ok    bool   `json:"ok"`
+  Error string `json:"error"`
 }
 
 type gitDiffEntry struct {
-	Path       string `json:"path"`
-	Status     string `json:"status"`
-	Additions  int    `json:"additions"`
-	Deletions  int    `json:"deletions"`
-	Diff       string `json:"diff"`
-	Conflicted bool   `json:"conflicted"`
+  Path      string `json:"path"`
+  Status    string `json:"status"`
+  Additions int    `json:"additions"`
+  Deletions int    `json:"deletions"`
+  Diff      string `json:"diff"`
+  Conflicted bool  `json:"conflicted"`
 }
 
 type gitDiffResponse struct {
-	Ok    bool           `json:"ok"`
-	Diffs []gitDiffEntry `json:"diffs"`
+  Ok    bool          `json:"ok"`
+  Diffs []gitDiffEntry `json:"diffs"`
 }
 
 type gitConflictRequest struct {
-	Path string `json:"path"`
+  Path string `json:"path"`
 }
 
 type gitConflictResponse struct {
-	Ok      bool   `json:"ok"`
-	Path    string `json:"path"`
-	Ours    string `json:"ours"`
-	Theirs  string `json:"theirs"`
-	Base    string `json:"base,omitempty"`
-	Working string `json:"working,omitempty"`
+  Ok      bool   `json:"ok"`
+  Path    string `json:"path"`
+  Ours    string `json:"ours"`
+  Theirs  string `json:"theirs"`
+  Base    string `json:"base,omitempty"`
+  Working string `json:"working,omitempty"`
 }
 
 type gitResolveRequest struct {
-	Path     string `json:"path"`
-	Strategy string `json:"strategy"`
-	Content  string `json:"content,omitempty"`
+  Path     string `json:"path"`
+  Strategy string `json:"strategy"`
+  Content  string `json:"content,omitempty"`
 }
 
 type gitResolveResponse struct {
-	Ok       bool   `json:"ok"`
-	Path     string `json:"path"`
-	Strategy string `json:"strategy"`
-	Message  string `json:"message,omitempty"`
+  Ok       bool   `json:"ok"`
+  Path     string `json:"path"`
+  Strategy string `json:"strategy"`
+  Message  string `json:"message,omitempty"`
 }
 
 type gitDiscardRequest struct {
-	Path string `json:"path"`
+  Path string `json:"path"`
 }
 
 type gitDiscardResponse struct {
-	Ok   bool   `json:"ok"`
-	Path string `json:"path"`
+  Ok   bool   `json:"ok"`
+  Path string `json:"path"`
 }
 
 type fileReadRequest struct {
-	Path string `json:"path"`
+  Path string `json:"path"`
 }
 
 type fileReadResponse struct {
@@ -127,9 +127,9 @@ type fileWriteRequest struct {
 }
 
 type fileWriteResponse struct {
-	Ok   bool   `json:"ok"`
-	Path string `json:"path"`
-	Hash string `json:"hash"`
+  Ok   bool   `json:"ok"`
+  Path string `json:"path"`
+  Hash string `json:"hash"`
 }
 
 type fileUploadResponse struct {
@@ -141,13 +141,13 @@ type fileUploadResponse struct {
 }
 
 type fileDeleteRequest struct {
-	Path string `json:"path"`
+  Path string `json:"path"`
 }
 
 type fileDeleteResponse struct {
-	Ok      bool   `json:"ok"`
-	Path    string `json:"path"`
-	Deleted bool   `json:"deleted"`
+  Ok      bool   `json:"ok"`
+  Path    string `json:"path"`
+  Deleted bool   `json:"deleted"`
 }
 
 type fileRenameRequest struct {
@@ -162,62 +162,62 @@ type fileRenameResponse struct {
 }
 
 type fileApplyPatchRequest struct {
-	Patch string `json:"patch"`
+  Patch string `json:"patch"`
 }
 
 type fileApplyPatchResponse struct {
-	Ok bool `json:"ok"`
+  Ok bool `json:"ok"`
 }
 
 type syncKbResponse struct {
-	Ok        bool     `json:"ok"`
-	Status    string   `json:"status"`
-	Message   string   `json:"message,omitempty"`
-	Conflicts []string `json:"conflicts,omitempty"`
+  Ok        bool     `json:"ok"`
+  Status    string   `json:"status"`
+  Message   string   `json:"message,omitempty"`
+  Conflicts []string `json:"conflicts,omitempty"`
 }
 
 type syncStatusResponse struct {
-	Ok           bool     `json:"ok"`
-	HasConflicts bool     `json:"hasConflicts"`
-	Conflicts    []string `json:"conflicts,omitempty"`
+  Ok           bool     `json:"ok"`
+  HasConflicts bool     `json:"hasConflicts"`
+  Conflicts    []string `json:"conflicts,omitempty"`
 }
 
 type publishKbResponse struct {
-	Ok         bool     `json:"ok"`
-	Status     string   `json:"status"`
-	CommitHash string   `json:"commitHash,omitempty"`
-	Files      []string `json:"files,omitempty"`
-	Message    string   `json:"message,omitempty"`
+  Ok         bool     `json:"ok"`
+  Status     string   `json:"status"`
+  CommitHash string   `json:"commitHash,omitempty"`
+  Files      []string `json:"files,omitempty"`
+  Message    string   `json:"message,omitempty"`
 }
 
 func main() {
-	addr := flag.String("addr", getenv("WORKSPACE_AGENT_ADDR", defaultAddr), "listen address")
-	workspace := flag.String("workspace", getenv("WORKSPACE_DIR", defaultWorkspace), "workspace root")
-	flag.Parse()
+  addr := flag.String("addr", getenv("WORKSPACE_AGENT_ADDR", defaultAddr), "listen address")
+  workspace := flag.String("workspace", getenv("WORKSPACE_DIR", defaultWorkspace), "workspace root")
+  flag.Parse()
 
-	username := getenv("WORKSPACE_AGENT_USERNAME", "opencode")
-	password := os.Getenv("WORKSPACE_AGENT_PASSWORD")
-	if password == "" {
-		password = os.Getenv("OPENCODE_SERVER_PASSWORD")
-	}
+  username := getenv("WORKSPACE_AGENT_USERNAME", "opencode")
+  password := os.Getenv("WORKSPACE_AGENT_PASSWORD")
+  if password == "" {
+    password = os.Getenv("OPENCODE_SERVER_PASSWORD")
+  }
 
-	if password == "" {
-		log.Printf("workspace-agent: missing OPENCODE_SERVER_PASSWORD")
-		os.Exit(1)
-	}
+  if password == "" {
+    log.Printf("workspace-agent: missing OPENCODE_SERVER_PASSWORD")
+    os.Exit(1)
+  }
 
-	s := &server{
-		workspace: *workspace,
-		username:  username,
-		password:  password,
-	}
+  s := &server{
+    workspace: *workspace,
+    username:  username,
+    password:  password,
+  }
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/health", s.withAuth(s.handleHealth))
-	mux.HandleFunc("/git/diffs", s.withAuth(s.handleGitDiffs))
-	mux.HandleFunc("/git/conflict", s.withAuth(s.handleGitConflict))
-	mux.HandleFunc("/git/resolve", s.withAuth(s.handleGitResolve))
-	mux.HandleFunc("/git/discard", s.withAuth(s.handleGitDiscard))
+  mux := http.NewServeMux()
+  mux.HandleFunc("/health", s.withAuth(s.handleHealth))
+  mux.HandleFunc("/git/diffs", s.withAuth(s.handleGitDiffs))
+  mux.HandleFunc("/git/conflict", s.withAuth(s.handleGitConflict))
+  mux.HandleFunc("/git/resolve", s.withAuth(s.handleGitResolve))
+  mux.HandleFunc("/git/discard", s.withAuth(s.handleGitDiscard))
 	mux.HandleFunc("/files/read", s.withAuth(s.handleFileRead))
 	mux.HandleFunc("/files/list", s.withAuth(s.handleFileList))
 	mux.HandleFunc("/files/upload", s.withAuth(s.handleFileUpload))
@@ -225,402 +225,402 @@ func main() {
 	mux.HandleFunc("/files/delete", s.withAuth(s.handleFileDelete))
 	mux.HandleFunc("/files/rename", s.withAuth(s.handleFileRename))
 	mux.HandleFunc("/files/apply_patch", s.withAuth(s.handleApplyPatch))
-	mux.HandleFunc("/kb/sync", s.withAuth(s.handleKbSync))
-	mux.HandleFunc("/kb/status", s.withAuth(s.handleKbStatus))
-	mux.HandleFunc("/kb/publish", s.withAuth(s.handleKbPublish))
+  mux.HandleFunc("/kb/sync", s.withAuth(s.handleKbSync))
+  mux.HandleFunc("/kb/status", s.withAuth(s.handleKbStatus))
+  mux.HandleFunc("/kb/publish", s.withAuth(s.handleKbPublish))
 
-	server := &http.Server{
-		Addr:              *addr,
-		Handler:           logRequests(mux),
-		ReadHeaderTimeout: 5 * time.Second,
-		ReadTimeout:       15 * time.Second,
-		WriteTimeout:      30 * time.Second,
-		IdleTimeout:       60 * time.Second,
-	}
+  server := &http.Server{
+    Addr:              *addr,
+    Handler:           logRequests(mux),
+    ReadHeaderTimeout: 5 * time.Second,
+    ReadTimeout:       15 * time.Second,
+    WriteTimeout:      30 * time.Second,
+    IdleTimeout:       60 * time.Second,
+  }
 
-	log.Printf("workspace-agent listening on http://%s", *addr)
-	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		log.Fatalf("workspace-agent failed: %v", err)
-	}
+  log.Printf("workspace-agent listening on http://%s", *addr)
+  if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+    log.Fatalf("workspace-agent failed: %v", err)
+  }
 }
 
 func (s *server) withAuth(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		username, password, ok := r.BasicAuth()
-		if !ok || username != s.username || password != s.password {
-			w.Header().Set("WWW-Authenticate", "Basic")
-			writeError(w, http.StatusUnauthorized, "unauthorized")
-			return
-		}
-		next(w, r)
-	}
+  return func(w http.ResponseWriter, r *http.Request) {
+    username, password, ok := r.BasicAuth()
+    if !ok || username != s.username || password != s.password {
+      w.Header().Set("WWW-Authenticate", "Basic")
+      writeError(w, http.StatusUnauthorized, "unauthorized")
+      return
+    }
+    next(w, r)
+  }
 }
 
 func (s *server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]any{
-		"ok":      true,
-		"service": "workspace-agent",
-	})
+  if r.Method != http.MethodGet {
+    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+    return
+  }
+  writeJSON(w, http.StatusOK, map[string]any{
+    "ok":      true,
+    "service": "workspace-agent",
+  })
 }
 
 func (s *server) handleGitDiffs(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-		return
-	}
+  if r.Method != http.MethodGet {
+    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+    return
+  }
 
-	entries, err := s.gitStatusEntries(r.Context())
-	if err != nil {
-		writeError(w, http.StatusBadGateway, err.Error())
-		return
-	}
-	if len(entries) == 0 {
-		writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: []gitDiffEntry{}})
-		return
-	}
-	diffs := make([]gitDiffEntry, 0, len(entries))
+  entries, err := s.gitStatusEntries(r.Context())
+  if err != nil {
+    writeError(w, http.StatusBadGateway, err.Error())
+    return
+  }
+  if len(entries) == 0 {
+    writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: []gitDiffEntry{}})
+    return
+  }
+  diffs := make([]gitDiffEntry, 0, len(entries))
 
-	for _, entry := range entries {
-		diffArgs := []string{"git", "diff", "--no-color", "HEAD", "--", entry.Path}
-		numstatArgs := []string{"git", "diff", "--numstat", "HEAD", "--", entry.Path}
-		if entry.Untracked {
-			diffArgs = []string{"git", "diff", "--no-color", "--no-index", "--", "/dev/null", entry.Path}
-			numstatArgs = []string{"git", "diff", "--numstat", "--no-index", "--", "/dev/null", entry.Path}
-		}
+  for _, entry := range entries {
+    diffArgs := []string{"git", "diff", "--no-color", "HEAD", "--", entry.Path}
+    numstatArgs := []string{"git", "diff", "--numstat", "HEAD", "--", entry.Path}
+    if entry.Untracked {
+      diffArgs = []string{"git", "diff", "--no-color", "--no-index", "--", "/dev/null", entry.Path}
+      numstatArgs = []string{"git", "diff", "--numstat", "--no-index", "--", "/dev/null", entry.Path}
+    }
 
-		diffOut, diffErr, diffCode, diffExecErr := runCmd(r.Context(), s.workspace, diffArgs)
-		if diffExecErr != nil || diffCode > 1 {
-			msg := strings.TrimSpace(diffErr)
-			if msg == "" {
-				msg = "git_diff_failed"
-			}
-			writeError(w, http.StatusBadGateway, msg)
-			return
-		}
+    diffOut, diffErr, diffCode, diffExecErr := runCmd(r.Context(), s.workspace, diffArgs)
+    if diffExecErr != nil || diffCode > 1 {
+      msg := strings.TrimSpace(diffErr)
+      if msg == "" {
+        msg = "git_diff_failed"
+      }
+      writeError(w, http.StatusBadGateway, msg)
+      return
+    }
 
-		numstatOut, numstatErr, numstatCode, numstatExecErr := runCmd(r.Context(), s.workspace, numstatArgs)
-		if numstatExecErr != nil || numstatCode > 1 {
-			msg := strings.TrimSpace(numstatErr)
-			if msg == "" {
-				msg = "git_numstat_failed"
-			}
-			writeError(w, http.StatusBadGateway, msg)
-			return
-		}
+    numstatOut, numstatErr, numstatCode, numstatExecErr := runCmd(r.Context(), s.workspace, numstatArgs)
+    if numstatExecErr != nil || numstatCode > 1 {
+      msg := strings.TrimSpace(numstatErr)
+      if msg == "" {
+        msg = "git_numstat_failed"
+      }
+      writeError(w, http.StatusBadGateway, msg)
+      return
+    }
 
-		additions, deletions := parseNumstat(numstatOut)
-		diffs = append(diffs, gitDiffEntry{
-			Path:       entry.Path,
-			Status:     entry.Status,
-			Additions:  additions,
-			Deletions:  deletions,
-			Diff:       strings.TrimSpace(diffOut),
-			Conflicted: entry.Conflicted,
-		})
-	}
+    additions, deletions := parseNumstat(numstatOut)
+    diffs = append(diffs, gitDiffEntry{
+      Path:      entry.Path,
+      Status:    entry.Status,
+      Additions: additions,
+      Deletions: deletions,
+      Diff:      strings.TrimSpace(diffOut),
+      Conflicted: entry.Conflicted,
+    })
+  }
 
-	writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: diffs})
+  writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: diffs})
 }
 
 func (s *server) handleGitConflict(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-		return
-	}
+  if r.Method != http.MethodPost {
+    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+    return
+  }
 
-	var req gitConflictRequest
-	if err := decodeJSON(w, r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_json")
-		return
-	}
+  var req gitConflictRequest
+  if err := decodeJSON(w, r, &req); err != nil {
+    writeError(w, http.StatusBadRequest, "invalid_json")
+    return
+  }
 
-	relPath, absPath, err := s.resolveRelPath(req.Path)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
+  relPath, absPath, err := s.resolveRelPath(req.Path)
+  if err != nil {
+    writeError(w, http.StatusBadRequest, err.Error())
+    return
+  }
 
-	entries, _ := s.gitStatusEntries(r.Context(), relPath)
-	conflicted := false
-	for _, e := range entries {
-		if e.Conflicted {
-			conflicted = true
-			break
-		}
-	}
-	if !conflicted {
-		writeError(w, http.StatusNotFound, "not_conflicted")
-		return
-	}
+  entries, _ := s.gitStatusEntries(r.Context(), relPath)
+  conflicted := false
+  for _, e := range entries {
+    if e.Conflicted {
+      conflicted = true
+      break
+    }
+  }
+  if !conflicted {
+    writeError(w, http.StatusNotFound, "not_conflicted")
+    return
+  }
 
-	ours, err := s.readGitStage(r.Context(), 2, relPath)
-	if err != nil {
-		writeError(w, http.StatusBadGateway, "git_show_failed")
-		return
-	}
+  ours, err := s.readGitStage(r.Context(), 2, relPath)
+  if err != nil {
+    writeError(w, http.StatusBadGateway, "git_show_failed")
+    return
+  }
 
-	theirs, err := s.readGitStage(r.Context(), 3, relPath)
-	if err != nil {
-		writeError(w, http.StatusBadGateway, "git_show_failed")
-		return
-	}
+  theirs, err := s.readGitStage(r.Context(), 3, relPath)
+  if err != nil {
+    writeError(w, http.StatusBadGateway, "git_show_failed")
+    return
+  }
 
-	base, err := s.readGitStage(r.Context(), 1, relPath)
-	if err != nil {
-		writeError(w, http.StatusBadGateway, "git_show_failed")
-		return
-	}
+  base, err := s.readGitStage(r.Context(), 1, relPath)
+  if err != nil {
+    writeError(w, http.StatusBadGateway, "git_show_failed")
+    return
+  }
 
-	working := ""
-	if data, err := os.ReadFile(absPath); err == nil {
-		working = string(data)
-	}
+  working := ""
+  if data, err := os.ReadFile(absPath); err == nil {
+    working = string(data)
+  }
 
-	writeJSON(w, http.StatusOK, gitConflictResponse{
-		Ok:      true,
-		Path:    req.Path,
-		Ours:    ours,
-		Theirs:  theirs,
-		Base:    base,
-		Working: working,
-	})
+  writeJSON(w, http.StatusOK, gitConflictResponse{
+    Ok:      true,
+    Path:    req.Path,
+    Ours:    ours,
+    Theirs:  theirs,
+    Base:    base,
+    Working: working,
+  })
 }
 
 func (s *server) handleGitResolve(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-		return
-	}
+  if r.Method != http.MethodPost {
+    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+    return
+  }
 
-	var req gitResolveRequest
-	if err := decodeJSON(w, r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_json")
-		return
-	}
+  var req gitResolveRequest
+  if err := decodeJSON(w, r, &req); err != nil {
+    writeError(w, http.StatusBadRequest, "invalid_json")
+    return
+  }
 
-	relPath, absPath, err := s.resolveRelPath(req.Path)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
+  relPath, absPath, err := s.resolveRelPath(req.Path)
+  if err != nil {
+    writeError(w, http.StatusBadRequest, err.Error())
+    return
+  }
 
-	switch req.Strategy {
-	case "ours":
-		_, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
-			"git", "checkout", "--ours", "--", relPath,
-		})
-		if checkoutExecErr != nil || checkoutCode != 0 {
-			msg := strings.TrimSpace(checkoutErr)
-			if msg == "" {
-				msg = "git_checkout_failed"
-			}
-			writeError(w, http.StatusBadGateway, msg)
-			return
-		}
-	case "theirs":
-		_, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
-			"git", "checkout", "--theirs", "--", relPath,
-		})
-		if checkoutExecErr != nil || checkoutCode != 0 {
-			msg := strings.TrimSpace(checkoutErr)
-			if msg == "" {
-				msg = "git_checkout_failed"
-			}
-			writeError(w, http.StatusBadGateway, msg)
-			return
-		}
-	case "manual":
-		if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
-			writeError(w, http.StatusInternalServerError, "mkdir_failed")
-			return
-		}
-		if err := writeFileAtomic(absPath, []byte(req.Content), 0o644); err != nil {
-			writeError(w, http.StatusInternalServerError, "write_failed")
-			return
-		}
-	default:
-		writeError(w, http.StatusBadRequest, "invalid_strategy")
-		return
-	}
+  switch req.Strategy {
+  case "ours":
+    _, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
+      "git", "checkout", "--ours", "--", relPath,
+    })
+    if checkoutExecErr != nil || checkoutCode != 0 {
+      msg := strings.TrimSpace(checkoutErr)
+      if msg == "" {
+        msg = "git_checkout_failed"
+      }
+      writeError(w, http.StatusBadGateway, msg)
+      return
+    }
+  case "theirs":
+    _, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
+      "git", "checkout", "--theirs", "--", relPath,
+    })
+    if checkoutExecErr != nil || checkoutCode != 0 {
+      msg := strings.TrimSpace(checkoutErr)
+      if msg == "" {
+        msg = "git_checkout_failed"
+      }
+      writeError(w, http.StatusBadGateway, msg)
+      return
+    }
+  case "manual":
+    if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+      writeError(w, http.StatusInternalServerError, "mkdir_failed")
+      return
+    }
+    if err := writeFileAtomic(absPath, []byte(req.Content), 0o644); err != nil {
+      writeError(w, http.StatusInternalServerError, "write_failed")
+      return
+    }
+  default:
+    writeError(w, http.StatusBadRequest, "invalid_strategy")
+    return
+  }
 
-	_, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
-		"git", "add", "--", relPath,
-	})
-	if addExecErr != nil || addCode != 0 {
-		msg := strings.TrimSpace(addErr)
-		if msg == "" {
-			msg = "git_add_failed"
-		}
-		writeError(w, http.StatusBadGateway, msg)
-		return
-	}
+  _, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
+    "git", "add", "--", relPath,
+  })
+  if addExecErr != nil || addCode != 0 {
+    msg := strings.TrimSpace(addErr)
+    if msg == "" {
+      msg = "git_add_failed"
+    }
+    writeError(w, http.StatusBadGateway, msg)
+    return
+  }
 
-	writeJSON(w, http.StatusOK, gitResolveResponse{
-		Ok:       true,
-		Path:     req.Path,
-		Strategy: req.Strategy,
-	})
+  writeJSON(w, http.StatusOK, gitResolveResponse{
+    Ok:       true,
+    Path:     req.Path,
+    Strategy: req.Strategy,
+  })
 }
 
 func (s *server) handleGitDiscard(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-		return
-	}
+  if r.Method != http.MethodPost {
+    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+    return
+  }
 
-	var req gitDiscardRequest
-	if err := decodeJSON(w, r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_json")
-		return
-	}
+  var req gitDiscardRequest
+  if err := decodeJSON(w, r, &req); err != nil {
+    writeError(w, http.StatusBadRequest, "invalid_json")
+    return
+  }
 
-	relPath, absPath, err := s.resolveRelPath(req.Path)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
+  relPath, absPath, err := s.resolveRelPath(req.Path)
+  if err != nil {
+    writeError(w, http.StatusBadRequest, err.Error())
+    return
+  }
 
-	entries, statusErr := s.gitStatusEntries(r.Context(), relPath)
-	if statusErr != nil {
-		writeError(w, http.StatusBadGateway, statusErr.Error())
-		return
-	}
+  entries, statusErr := s.gitStatusEntries(r.Context(), relPath)
+  if statusErr != nil {
+    writeError(w, http.StatusBadGateway, statusErr.Error())
+    return
+  }
 
-	var entry *gitStatusEntry
-	for i := range entries {
-		if entries[i].Path == relPath {
-			entry = &entries[i]
-			break
-		}
-	}
-	if entry == nil {
-		writeError(w, http.StatusNotFound, "not_modified")
-		return
-	}
+  var entry *gitStatusEntry
+  for i := range entries {
+    if entries[i].Path == relPath {
+      entry = &entries[i]
+      break
+    }
+  }
+  if entry == nil {
+    writeError(w, http.StatusNotFound, "not_modified")
+    return
+  }
 
-	// Untracked files can be safely removed without involving git.
-	if entry.Untracked {
-		if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			writeError(w, http.StatusInternalServerError, "delete_failed")
-			return
-		}
-		writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
-		return
-	}
+  // Untracked files can be safely removed without involving git.
+  if entry.Untracked {
+    if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+      writeError(w, http.StatusInternalServerError, "delete_failed")
+      return
+    }
+    writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
+    return
+  }
 
-	// Best-effort: clear index state for this path (helps with conflict stages).
-	_, resetErrOut, resetCode, resetExecErr := runCmd(r.Context(), s.workspace, []string{
-		"git", "reset", "-q", "--", relPath,
-	})
-	if resetExecErr != nil {
-		writeError(w, http.StatusBadGateway, "git_reset_failed")
-		return
-	}
-	if resetCode != 0 {
-		msg := strings.TrimSpace(resetErrOut)
-		// Ignore common "pathspec" errors (e.g. when the path only exists in the index).
-		if msg != "" && !strings.Contains(strings.ToLower(msg), "pathspec") {
-			writeError(w, http.StatusBadGateway, msg)
-			return
-		}
-	}
+  // Best-effort: clear index state for this path (helps with conflict stages).
+  _, resetErrOut, resetCode, resetExecErr := runCmd(r.Context(), s.workspace, []string{
+    "git", "reset", "-q", "--", relPath,
+  })
+  if resetExecErr != nil {
+    writeError(w, http.StatusBadGateway, "git_reset_failed")
+    return
+  }
+  if resetCode != 0 {
+    msg := strings.TrimSpace(resetErrOut)
+    // Ignore common "pathspec" errors (e.g. when the path only exists in the index).
+    if msg != "" && !strings.Contains(strings.ToLower(msg), "pathspec") {
+      writeError(w, http.StatusBadGateway, msg)
+      return
+    }
+  }
 
-	// If the path exists in HEAD, restore it. Otherwise, drop it from the index and delete it.
-	_, _, catCode, _ := runCmd(r.Context(), s.workspace, []string{
-		"git", "cat-file", "-e", "HEAD:" + relPath,
-	})
+  // If the path exists in HEAD, restore it. Otherwise, drop it from the index and delete it.
+  _, _, catCode, _ := runCmd(r.Context(), s.workspace, []string{
+    "git", "cat-file", "-e", "HEAD:" + relPath,
+  })
 
-	if catCode == 0 {
-		_, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
-			"git", "checkout", "--", relPath,
-		})
-		if checkoutExecErr != nil || checkoutCode != 0 {
-			msg := strings.TrimSpace(checkoutErr)
-			if msg == "" {
-				msg = "git_checkout_failed"
-			}
-			writeError(w, http.StatusBadGateway, msg)
-			return
-		}
+  if catCode == 0 {
+    _, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
+      "git", "checkout", "--", relPath,
+    })
+    if checkoutExecErr != nil || checkoutCode != 0 {
+      msg := strings.TrimSpace(checkoutErr)
+      if msg == "" {
+        msg = "git_checkout_failed"
+      }
+      writeError(w, http.StatusBadGateway, msg)
+      return
+    }
 
-		writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
-		return
-	}
+    writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
+    return
+  }
 
-	// New tracked file (not in HEAD).
-	_, rmErr, rmCode, rmExecErr := runCmd(r.Context(), s.workspace, []string{
-		"git", "rm", "-f", "--cached", "--", relPath,
-	})
-	if rmExecErr != nil {
-		writeError(w, http.StatusBadGateway, "git_rm_failed")
-		return
-	}
-	if rmCode != 0 {
-		// If it wasn't in the index, keep going.
-		_ = rmErr
-	}
+  // New tracked file (not in HEAD).
+  _, rmErr, rmCode, rmExecErr := runCmd(r.Context(), s.workspace, []string{
+    "git", "rm", "-f", "--cached", "--", relPath,
+  })
+  if rmExecErr != nil {
+    writeError(w, http.StatusBadGateway, "git_rm_failed")
+    return
+  }
+  if rmCode != 0 {
+    // If it wasn't in the index, keep going.
+    _ = rmErr
+  }
 
-	if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		writeError(w, http.StatusInternalServerError, "delete_failed")
-		return
-	}
-	writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
+  if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+    writeError(w, http.StatusInternalServerError, "delete_failed")
+    return
+  }
+  writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
 }
 
 func (s *server) handleFileRead(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-		return
-	}
+  if r.Method != http.MethodPost {
+    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+    return
+  }
 
-	var req fileReadRequest
-	if err := decodeJSON(w, r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_json")
-		return
-	}
+  var req fileReadRequest
+  if err := decodeJSON(w, r, &req); err != nil {
+    writeError(w, http.StatusBadRequest, "invalid_json")
+    return
+  }
 
-	path, err := s.resolvePath(req.Path)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	if err := s.ensurePathWithinWorkspace(path); err != nil {
-		writeError(w, http.StatusForbidden, err.Error())
-		return
-	}
+  path, err := s.resolvePath(req.Path)
+  if err != nil {
+    writeError(w, http.StatusBadRequest, err.Error())
+    return
+  }
+  if err := s.ensurePathWithinWorkspace(path); err != nil {
+    writeError(w, http.StatusForbidden, err.Error())
+    return
+  }
 
-	info, err := os.Stat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			writeError(w, http.StatusNotFound, "not_found")
-			return
-		}
-		writeError(w, http.StatusInternalServerError, "stat_failed")
-		return
-	}
-	if info.IsDir() {
-		writeError(w, http.StatusBadRequest, "is_directory")
-		return
-	}
+  info, err := os.Stat(path)
+  if err != nil {
+    if os.IsNotExist(err) {
+      writeError(w, http.StatusNotFound, "not_found")
+      return
+    }
+    writeError(w, http.StatusInternalServerError, "stat_failed")
+    return
+  }
+  if info.IsDir() {
+    writeError(w, http.StatusBadRequest, "is_directory")
+    return
+  }
 
-	data, err := os.ReadFile(path)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "read_failed")
-		return
-	}
+  data, err := os.ReadFile(path)
+  if err != nil {
+    writeError(w, http.StatusInternalServerError, "read_failed")
+    return
+  }
 
-	content, encoding := encodeContent(data)
-	writeJSON(w, http.StatusOK, fileReadResponse{
-		Ok:       true,
-		Path:     req.Path,
-		Content:  content,
-		Encoding: encoding,
-		Hash:     hashBytes(data),
-	})
+  content, encoding := encodeContent(data)
+  writeJSON(w, http.StatusOK, fileReadResponse{
+    Ok:       true,
+    Path:     req.Path,
+    Content:  content,
+    Encoding: encoding,
+    Hash:     hashBytes(data),
+  })
 }
 
 func (s *server) handleFileList(w http.ResponseWriter, r *http.Request) {
@@ -742,46 +742,46 @@ func (s *server) handleFileList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleFileWrite(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-		return
-	}
+  if r.Method != http.MethodPost {
+    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+    return
+  }
 
-	var req fileWriteRequest
-	if err := decodeJSON(w, r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_json")
-		return
-	}
+  var req fileWriteRequest
+  if err := decodeJSON(w, r, &req); err != nil {
+    writeError(w, http.StatusBadRequest, "invalid_json")
+    return
+  }
 
-	path, err := s.resolvePath(req.Path)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	if err := s.ensurePathWithinWorkspace(path); err != nil {
-		writeError(w, http.StatusForbidden, err.Error())
-		return
-	}
+  path, err := s.resolvePath(req.Path)
+  if err != nil {
+    writeError(w, http.StatusBadRequest, err.Error())
+    return
+  }
+  if err := s.ensurePathWithinWorkspace(path); err != nil {
+    writeError(w, http.StatusForbidden, err.Error())
+    return
+  }
 
-	if req.ExpectedHash != "" {
-		currentHash, ok, err := verifyExpectedHash(path, req.ExpectedHash)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				writeError(w, http.StatusNotFound, "not_found")
-				return
-			}
-			writeError(w, http.StatusInternalServerError, "hash_check_failed")
-			return
-		}
-		if !ok {
-			writeJSON(w, http.StatusConflict, map[string]any{
-				"ok":          false,
-				"error":       "conflict",
-				"currentHash": currentHash,
-			})
-			return
-		}
-	}
+  if req.ExpectedHash != "" {
+    currentHash, ok, err := verifyExpectedHash(path, req.ExpectedHash)
+    if err != nil {
+      if errors.Is(err, os.ErrNotExist) {
+        writeError(w, http.StatusNotFound, "not_found")
+        return
+      }
+      writeError(w, http.StatusInternalServerError, "hash_check_failed")
+      return
+    }
+    if !ok {
+      writeJSON(w, http.StatusConflict, map[string]any{
+        "ok":          false,
+        "error":       "conflict",
+        "currentHash": currentHash,
+      })
+      return
+    }
+  }
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		writeError(w, http.StatusInternalServerError, "mkdir_failed")
@@ -808,17 +808,17 @@ func (s *server) handleFileWrite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := os.ReadFile(path)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "read_failed")
-		return
-	}
+  data, err := os.ReadFile(path)
+  if err != nil {
+    writeError(w, http.StatusInternalServerError, "read_failed")
+    return
+  }
 
-	writeJSON(w, http.StatusOK, fileWriteResponse{
-		Ok:   true,
-		Path: req.Path,
-		Hash: hashBytes(data),
-	})
+  writeJSON(w, http.StatusOK, fileWriteResponse{
+    Ok:   true,
+    Path: req.Path,
+    Hash: hashBytes(data),
+  })
 }
 
 func (s *server) handleFileUpload(w http.ResponseWriter, r *http.Request) {
@@ -867,45 +867,45 @@ func (s *server) handleFileUpload(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleFileDelete(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-		return
-	}
+  if r.Method != http.MethodPost {
+    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+    return
+  }
 
-	var req fileDeleteRequest
-	if err := decodeJSON(w, r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_json")
-		return
-	}
+  var req fileDeleteRequest
+  if err := decodeJSON(w, r, &req); err != nil {
+    writeError(w, http.StatusBadRequest, "invalid_json")
+    return
+  }
 
-	path, err := s.resolvePath(req.Path)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	if err := s.ensurePathWithinWorkspace(path); err != nil {
-		writeError(w, http.StatusForbidden, err.Error())
-		return
-	}
+  path, err := s.resolvePath(req.Path)
+  if err != nil {
+    writeError(w, http.StatusBadRequest, err.Error())
+    return
+  }
+  if err := s.ensurePathWithinWorkspace(path); err != nil {
+    writeError(w, http.StatusForbidden, err.Error())
+    return
+  }
 
-	info, err := os.Stat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			writeError(w, http.StatusNotFound, "not_found")
-			return
-		}
-		writeError(w, http.StatusInternalServerError, "stat_failed")
-		return
-	}
-	if info.IsDir() {
-		writeError(w, http.StatusBadRequest, "is_directory")
-		return
-	}
+  info, err := os.Stat(path)
+  if err != nil {
+    if os.IsNotExist(err) {
+      writeError(w, http.StatusNotFound, "not_found")
+      return
+    }
+    writeError(w, http.StatusInternalServerError, "stat_failed")
+    return
+  }
+  if info.IsDir() {
+    writeError(w, http.StatusBadRequest, "is_directory")
+    return
+  }
 
-	if err := os.Remove(path); err != nil {
-		writeError(w, http.StatusInternalServerError, "delete_failed")
-		return
-	}
+  if err := os.Remove(path); err != nil {
+    writeError(w, http.StatusInternalServerError, "delete_failed")
+    return
+  }
 
 	writeJSON(w, http.StatusOK, fileDeleteResponse{
 		Ok:      true,
@@ -994,43 +994,43 @@ func (s *server) handleFileRename(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleApplyPatch(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-		return
-	}
+  if r.Method != http.MethodPost {
+    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+    return
+  }
 
-	var req fileApplyPatchRequest
-	if err := decodeJSON(w, r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_json")
-		return
-	}
-	if strings.TrimSpace(req.Patch) == "" {
-		writeError(w, http.StatusBadRequest, "empty_patch")
-		return
-	}
+  var req fileApplyPatchRequest
+  if err := decodeJSON(w, r, &req); err != nil {
+    writeError(w, http.StatusBadRequest, "invalid_json")
+    return
+  }
+  if strings.TrimSpace(req.Patch) == "" {
+    writeError(w, http.StatusBadRequest, "empty_patch")
+    return
+  }
 
-	cmd := exec.CommandContext(r.Context(), "git", "apply", "--whitespace=nowarn", "--")
-	cmd.Dir = s.workspace
-	cmd.Stdin = strings.NewReader(req.Patch)
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+  cmd := exec.CommandContext(r.Context(), "git", "apply", "--whitespace=nowarn", "--")
+  cmd.Dir = s.workspace
+  cmd.Stdin = strings.NewReader(req.Patch)
+  var stdout bytes.Buffer
+  var stderr bytes.Buffer
+  cmd.Stdout = &stdout
+  cmd.Stderr = &stderr
 
-	err := cmd.Run()
-	if err != nil {
-		msg := strings.TrimSpace(stderr.String())
-		if msg == "" {
-			msg = "apply_patch_failed"
-		}
-		writeJSON(w, http.StatusConflict, map[string]any{
-			"ok":    false,
-			"error": msg,
-		})
-		return
-	}
+  err := cmd.Run()
+  if err != nil {
+    msg := strings.TrimSpace(stderr.String())
+    if msg == "" {
+      msg = "apply_patch_failed"
+    }
+    writeJSON(w, http.StatusConflict, map[string]any{
+      "ok":    false,
+      "error": msg,
+    })
+    return
+  }
 
-	writeJSON(w, http.StatusOK, fileApplyPatchResponse{Ok: true})
+  writeJSON(w, http.StatusOK, fileApplyPatchResponse{Ok: true})
 }
 
 // fetchAndMergeKb fetches from the kb remote and merges the remote branch.
@@ -1038,351 +1038,351 @@ func (s *server) handleApplyPatch(w http.ResponseWriter, r *http.Request) {
 // was no remote branch yet). If ok is false and conflicts is non-empty the merge
 // produced conflicts. Otherwise errMsg describes the failure.
 func (s *server) fetchAndMergeKb(ctx context.Context) (bool, []string, string) {
-	_, fetchErr, fetchCode, fetchExecErr := runCmd(ctx, s.workspace, []string{
-		"git", "fetch", "kb",
-	})
-	if fetchExecErr != nil || fetchCode != 0 {
-		msg := strings.TrimSpace(fetchErr)
-		if msg == "" {
-			msg = "fetch_failed"
-		}
-		return false, nil, "Fetch failed: " + msg
-	}
+  _, fetchErr, fetchCode, fetchExecErr := runCmd(ctx, s.workspace, []string{
+    "git", "fetch", "kb",
+  })
+  if fetchExecErr != nil || fetchCode != 0 {
+    msg := strings.TrimSpace(fetchErr)
+    if msg == "" {
+      msg = "fetch_failed"
+    }
+    return false, nil, "Fetch failed: " + msg
+  }
 
-	kbBranch := s.resolveKbBranch(ctx)
+  kbBranch := s.resolveKbBranch(ctx)
 
-	if !s.remoteBranchExists(ctx, kbBranch) {
-		// First publish — nothing to merge.
-		return true, nil, ""
-	}
+  if !s.remoteBranchExists(ctx, kbBranch) {
+    // First publish — nothing to merge.
+    return true, nil, ""
+  }
 
-	_, mergeErr, mergeCode, mergeExecErr := runCmd(ctx, s.workspace, []string{
-		"git", "merge", "kb/" + kbBranch, "--no-edit",
-	})
-	if mergeExecErr == nil && mergeCode == 0 {
-		return true, nil, ""
-	}
+  _, mergeErr, mergeCode, mergeExecErr := runCmd(ctx, s.workspace, []string{
+    "git", "merge", "kb/" + kbBranch, "--no-edit",
+  })
+  if mergeExecErr == nil && mergeCode == 0 {
+    return true, nil, ""
+  }
 
-	if isUnrelatedHistoryError(mergeErr) {
-		_, mergeErrAllow, mergeCodeAllow, mergeExecErrAllow := runCmd(ctx, s.workspace, []string{
-			"git", "merge", "kb/" + kbBranch, "--no-edit", "--allow-unrelated-histories",
-		})
-		if mergeExecErrAllow == nil && mergeCodeAllow == 0 {
-			return true, nil, ""
-		}
+  if isUnrelatedHistoryError(mergeErr) {
+    _, mergeErrAllow, mergeCodeAllow, mergeExecErrAllow := runCmd(ctx, s.workspace, []string{
+      "git", "merge", "kb/" + kbBranch, "--no-edit", "--allow-unrelated-histories",
+    })
+    if mergeExecErrAllow == nil && mergeCodeAllow == 0 {
+      return true, nil, ""
+    }
 
-		conflicts := s.listConflictFiles(ctx)
-		if len(conflicts) > 0 {
-			return false, conflicts, "Merge has conflicts that need to be resolved"
-		}
+    conflicts := s.listConflictFiles(ctx)
+    if len(conflicts) > 0 {
+      return false, conflicts, "Merge has conflicts that need to be resolved"
+    }
 
-		msg := strings.TrimSpace(mergeErrAllow)
-		if msg == "" {
-			msg = "merge_failed"
-		}
-		return false, nil, "Merge failed: " + msg
-	}
+    msg := strings.TrimSpace(mergeErrAllow)
+    if msg == "" {
+      msg = "merge_failed"
+    }
+    return false, nil, "Merge failed: " + msg
+  }
 
-	conflicts := s.listConflictFiles(ctx)
-	if len(conflicts) > 0 {
-		return false, conflicts, "Merge has conflicts that need to be resolved"
-	}
+  conflicts := s.listConflictFiles(ctx)
+  if len(conflicts) > 0 {
+    return false, conflicts, "Merge has conflicts that need to be resolved"
+  }
 
-	msg := strings.TrimSpace(mergeErr)
-	if msg == "" {
-		msg = "merge_failed"
-	}
-	return false, nil, "Merge failed: " + msg
+  msg := strings.TrimSpace(mergeErr)
+  if msg == "" {
+    msg = "merge_failed"
+  }
+  return false, nil, "Merge failed: " + msg
 }
 
 func (s *server) handleKbSync(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-		return
-	}
+  if r.Method != http.MethodPost {
+    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+    return
+  }
 
-	_, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
-		"git", "remote", "get-url", "kb",
-	})
-	if remoteExecErr != nil || remoteCode != 0 {
-		writeJSON(w, http.StatusOK, syncKbResponse{
-			Ok:      false,
-			Status:  "no_remote",
-			Message: "KB remote not configured. Workspace may not have been initialized with KB.",
-		})
-		return
-	}
+  _, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
+    "git", "remote", "get-url", "kb",
+  })
+  if remoteExecErr != nil || remoteCode != 0 {
+    writeJSON(w, http.StatusOK, syncKbResponse{
+      Ok:      false,
+      Status:  "no_remote",
+      Message: "KB remote not configured. Workspace may not have been initialized with KB.",
+    })
+    return
+  }
 
-	mergeOk, conflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
-	if mergeOk {
-		writeJSON(w, http.StatusOK, syncKbResponse{
-			Ok:      true,
-			Status:  "synced",
-			Message: "KB synchronized successfully",
-		})
-		return
-	}
+  mergeOk, conflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
+  if mergeOk {
+    writeJSON(w, http.StatusOK, syncKbResponse{
+      Ok:      true,
+      Status:  "synced",
+      Message: "KB synchronized successfully",
+    })
+    return
+  }
 
-	if len(conflicts) > 0 {
-		writeJSON(w, http.StatusOK, syncKbResponse{
-			Ok:        true,
-			Status:    "conflicts",
-			Message:   "Merge has conflicts that need to be resolved",
-			Conflicts: conflicts,
-		})
-		return
-	}
+  if len(conflicts) > 0 {
+    writeJSON(w, http.StatusOK, syncKbResponse{
+      Ok:        true,
+      Status:    "conflicts",
+      Message:   "Merge has conflicts that need to be resolved",
+      Conflicts: conflicts,
+    })
+    return
+  }
 
-	writeJSON(w, http.StatusOK, syncKbResponse{
-		Ok:      false,
-		Status:  "error",
-		Message: mergeErrMsg,
-	})
+  writeJSON(w, http.StatusOK, syncKbResponse{
+    Ok:      false,
+    Status:  "error",
+    Message: mergeErrMsg,
+  })
 }
 
 func (s *server) handleKbStatus(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-		return
-	}
+  if r.Method != http.MethodGet {
+    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+    return
+  }
 
-	conflicts := s.listConflictFiles(r.Context())
-	writeJSON(w, http.StatusOK, syncStatusResponse{
-		Ok:           true,
-		HasConflicts: len(conflicts) > 0,
-		Conflicts:    conflicts,
-	})
+  conflicts := s.listConflictFiles(r.Context())
+  writeJSON(w, http.StatusOK, syncStatusResponse{
+    Ok:           true,
+    HasConflicts: len(conflicts) > 0,
+    Conflicts:    conflicts,
+  })
 }
 
 func (s *server) handleKbPublish(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-		return
-	}
+  if r.Method != http.MethodPost {
+    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+    return
+  }
 
-	_, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
-		"git", "remote", "get-url", "kb",
-	})
-	if remoteExecErr != nil || remoteCode != 0 {
-		writeJSON(w, http.StatusOK, publishKbResponse{
-			Ok:      false,
-			Status:  "no_remote",
-			Message: "KB remote not configured.",
-		})
-		return
-	}
+  _, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
+    "git", "remote", "get-url", "kb",
+  })
+  if remoteExecErr != nil || remoteCode != 0 {
+    writeJSON(w, http.StatusOK, publishKbResponse{
+      Ok:      false,
+      Status:  "no_remote",
+      Message: "KB remote not configured.",
+    })
+    return
+  }
 
-	conflicts := s.listConflictFiles(r.Context())
-	if len(conflicts) > 0 {
-		writeJSON(w, http.StatusOK, publishKbResponse{
-			Ok:      false,
-			Status:  "conflicts",
-			Files:   conflicts,
-			Message: "Resolve conflicts before publishing.",
-		})
-		return
-	}
+  conflicts := s.listConflictFiles(r.Context())
+  if len(conflicts) > 0 {
+    writeJSON(w, http.StatusOK, publishKbResponse{
+      Ok:      false,
+      Status:  "conflicts",
+      Files:   conflicts,
+      Message: "Resolve conflicts before publishing.",
+    })
+    return
+  }
 
-	entries, statusErr := s.gitStatusEntries(r.Context())
-	if statusErr != nil {
-		writeJSON(w, http.StatusOK, publishKbResponse{
-			Ok:      false,
-			Status:  "error",
-			Message: statusErr.Error(),
-		})
-		return
-	}
+  entries, statusErr := s.gitStatusEntries(r.Context())
+  if statusErr != nil {
+    writeJSON(w, http.StatusOK, publishKbResponse{
+      Ok:      false,
+      Status:  "error",
+      Message: statusErr.Error(),
+    })
+    return
+  }
 
-	if len(entries) == 0 {
-		writeJSON(w, http.StatusOK, publishKbResponse{
-			Ok:      true,
-			Status:  "nothing_to_publish",
-			Message: "Nothing to publish.",
-		})
-		return
-	}
+  if len(entries) == 0 {
+    writeJSON(w, http.StatusOK, publishKbResponse{
+      Ok:      true,
+      Status:  "nothing_to_publish",
+      Message: "Nothing to publish.",
+    })
+    return
+  }
 
-	_, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
-		"git", "add", "-A",
-	})
-	if addExecErr != nil || addCode != 0 {
-		msg := strings.TrimSpace(addErr)
-		if msg == "" {
-			msg = "git_add_failed"
-		}
-		writeJSON(w, http.StatusOK, publishKbResponse{
-			Ok:      false,
-			Status:  "error",
-			Message: "git add failed: " + msg,
-		})
-		return
-	}
+  _, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
+    "git", "add", "-A",
+  })
+  if addExecErr != nil || addCode != 0 {
+    msg := strings.TrimSpace(addErr)
+    if msg == "" {
+      msg = "git_add_failed"
+    }
+    writeJSON(w, http.StatusOK, publishKbResponse{
+      Ok:      false,
+      Status:  "error",
+      Message: "git add failed: " + msg,
+    })
+    return
+  }
 
-	statOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
-		"git", "diff", "--cached", "--stat",
-	})
-	commitMessage := generateCommitMessage(statOut)
+  statOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
+    "git", "diff", "--cached", "--stat",
+  })
+  commitMessage := generateCommitMessage(statOut)
 
-	_, commitErr, commitCode, commitExecErr := runCmd(r.Context(), s.workspace, []string{
-		"git", "commit", "-m", commitMessage,
-	})
-	if commitExecErr != nil || commitCode != 0 {
-		msg := strings.TrimSpace(commitErr)
-		if msg == "" {
-			msg = "git_commit_failed"
-		}
-		writeJSON(w, http.StatusOK, publishKbResponse{
-			Ok:      false,
-			Status:  "error",
-			Message: "git commit failed: " + msg,
-		})
-		return
-	}
+  _, commitErr, commitCode, commitExecErr := runCmd(r.Context(), s.workspace, []string{
+    "git", "commit", "-m", commitMessage,
+  })
+  if commitExecErr != nil || commitCode != 0 {
+    msg := strings.TrimSpace(commitErr)
+    if msg == "" {
+      msg = "git_commit_failed"
+    }
+    writeJSON(w, http.StatusOK, publishKbResponse{
+      Ok:      false,
+      Status:  "error",
+      Message: "git commit failed: " + msg,
+    })
+    return
+  }
 
-	hashOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
-		"git", "rev-parse", "--short", "HEAD",
-	})
-	commitHash := strings.TrimSpace(hashOut)
+  hashOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
+    "git", "rev-parse", "--short", "HEAD",
+  })
+  commitHash := strings.TrimSpace(hashOut)
 
-	filesOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
-		"git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD",
-	})
-	files := splitLines(filesOut)
+  filesOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
+    "git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD",
+  })
+  files := splitLines(filesOut)
 
-	// Fetch and merge remote before pushing to avoid rejected pushes.
-	mergeOk, mergeConflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
-	if !mergeOk {
-		if len(mergeConflicts) > 0 {
-			writeJSON(w, http.StatusOK, publishKbResponse{
-				Ok:      false,
-				Status:  "conflicts",
-				Files:   mergeConflicts,
-				Message: "Merge conflicts during publish. Resolve and retry.",
-			})
-			return
-		}
-		writeJSON(w, http.StatusOK, publishKbResponse{
-			Ok:      false,
-			Status:  "error",
-			Message: mergeErrMsg,
-		})
-		return
-	}
+  // Fetch and merge remote before pushing to avoid rejected pushes.
+  mergeOk, mergeConflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
+  if !mergeOk {
+    if len(mergeConflicts) > 0 {
+      writeJSON(w, http.StatusOK, publishKbResponse{
+        Ok:      false,
+        Status:  "conflicts",
+        Files:   mergeConflicts,
+        Message: "Merge conflicts during publish. Resolve and retry.",
+      })
+      return
+    }
+    writeJSON(w, http.StatusOK, publishKbResponse{
+      Ok:      false,
+      Status:  "error",
+      Message: mergeErrMsg,
+    })
+    return
+  }
 
-	kbBranch := s.resolveKbBranch(r.Context())
-	_, pushErr, pushCode, pushExecErr := runCmd(r.Context(), s.workspace, []string{
-		"git", "push", "kb", "HEAD:refs/heads/" + kbBranch,
-	})
-	if pushExecErr != nil || pushCode != 0 {
-		msg := strings.TrimSpace(pushErr)
-		if msg == "" {
-			msg = "git_push_failed"
-		}
-		writeJSON(w, http.StatusOK, publishKbResponse{
-			Ok:         false,
-			Status:     "push_rejected",
-			CommitHash: commitHash,
-			Files:      files,
-			Message:    msg,
-		})
-		return
-	}
+  kbBranch := s.resolveKbBranch(r.Context())
+  _, pushErr, pushCode, pushExecErr := runCmd(r.Context(), s.workspace, []string{
+    "git", "push", "kb", "HEAD:refs/heads/" + kbBranch,
+  })
+  if pushExecErr != nil || pushCode != 0 {
+    msg := strings.TrimSpace(pushErr)
+    if msg == "" {
+      msg = "git_push_failed"
+    }
+    writeJSON(w, http.StatusOK, publishKbResponse{
+      Ok:         false,
+      Status:     "push_rejected",
+      CommitHash: commitHash,
+      Files:      files,
+      Message:    msg,
+    })
+    return
+  }
 
-	writeJSON(w, http.StatusOK, publishKbResponse{
-		Ok:         true,
-		Status:     "published",
-		CommitHash: commitHash,
-		Files:      files,
-	})
+  writeJSON(w, http.StatusOK, publishKbResponse{
+    Ok:         true,
+    Status:     "published",
+    CommitHash: commitHash,
+    Files:      files,
+  })
 }
 
 func (s *server) gitStatusEntries(ctx context.Context, paths ...string) ([]gitStatusEntry, error) {
-	args := []string{"git", "-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=all"}
-	if len(paths) > 0 {
-		args = append(args, "--")
-		args = append(args, paths...)
-	}
-	out, stderr, code, err := runCmd(ctx, s.workspace, args)
-	if err != nil || code != 0 {
-		msg := strings.TrimSpace(stderr)
-		if msg == "" {
-			msg = "git_status_failed"
-		}
-		return nil, errors.New(msg)
-	}
-	return parseGitStatus(out), nil
+  args := []string{"git", "-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=all"}
+  if len(paths) > 0 {
+    args = append(args, "--")
+    args = append(args, paths...)
+  }
+  out, stderr, code, err := runCmd(ctx, s.workspace, args)
+  if err != nil || code != 0 {
+    msg := strings.TrimSpace(stderr)
+    if msg == "" {
+      msg = "git_status_failed"
+    }
+    return nil, errors.New(msg)
+  }
+  return parseGitStatus(out), nil
 }
 
 func (s *server) listConflictFiles(ctx context.Context) []string {
-	entries, _ := s.gitStatusEntries(ctx)
-	var result []string
-	for _, e := range entries {
-		if e.Conflicted {
-			result = append(result, e.Path)
-		}
-	}
-	return result
+  entries, _ := s.gitStatusEntries(ctx)
+  var result []string
+  for _, e := range entries {
+    if e.Conflicted {
+      result = append(result, e.Path)
+    }
+  }
+  return result
 }
 
 func isUnrelatedHistoryError(message string) bool {
-	msg := strings.ToLower(message)
-	return strings.Contains(msg, "unrelated histories")
+  msg := strings.ToLower(message)
+  return strings.Contains(msg, "unrelated histories")
 }
 
 func (s *server) resolveKbBranch(ctx context.Context) string {
-	_, _, _, _ = runCmd(ctx, s.workspace, []string{
-		"git", "remote", "set-head", "kb", "-a",
-	})
+  _, _, _, _ = runCmd(ctx, s.workspace, []string{
+    "git", "remote", "set-head", "kb", "-a",
+  })
 
-	headOut, _, headCode, _ := runCmd(ctx, s.workspace, []string{
-		"git", "symbolic-ref", "-q", "--short", "refs/remotes/kb/HEAD",
-	})
-	headRef := strings.TrimSpace(headOut)
-	if headCode == 0 && strings.HasPrefix(headRef, "kb/") {
-		branch := strings.TrimPrefix(headRef, "kb/")
-		if branch != "" {
-			return branch
-		}
-	}
+  headOut, _, headCode, _ := runCmd(ctx, s.workspace, []string{
+    "git", "symbolic-ref", "-q", "--short", "refs/remotes/kb/HEAD",
+  })
+  headRef := strings.TrimSpace(headOut)
+  if headCode == 0 && strings.HasPrefix(headRef, "kb/") {
+    branch := strings.TrimPrefix(headRef, "kb/")
+    if branch != "" {
+      return branch
+    }
+  }
 
-	if s.remoteBranchExists(ctx, "main") {
-		return "main"
-	}
+  if s.remoteBranchExists(ctx, "main") {
+    return "main"
+  }
 
-	current := s.currentBranch(ctx)
-	if current != "" && s.remoteBranchExists(ctx, current) {
-		return current
-	}
+  current := s.currentBranch(ctx)
+  if current != "" && s.remoteBranchExists(ctx, current) {
+    return current
+  }
 
-	return "main"
+  return "main"
 }
 
 func (s *server) remoteBranchExists(ctx context.Context, branch string) bool {
-	_, _, code, _ := runCmd(ctx, s.workspace, []string{
-		"git", "show-ref", "--verify", "--quiet", "refs/remotes/kb/" + branch,
-	})
-	return code == 0
+  _, _, code, _ := runCmd(ctx, s.workspace, []string{
+    "git", "show-ref", "--verify", "--quiet", "refs/remotes/kb/" + branch,
+  })
+  return code == 0
 }
 
 func (s *server) currentBranch(ctx context.Context) string {
-	out, _, code, _ := runCmd(ctx, s.workspace, []string{
-		"git", "rev-parse", "--abbrev-ref", "HEAD",
-	})
-	if code != 0 {
-		return ""
-	}
-	branch := strings.TrimSpace(out)
-	if branch == "" || branch == "HEAD" {
-		return ""
-	}
-	return branch
+  out, _, code, _ := runCmd(ctx, s.workspace, []string{
+    "git", "rev-parse", "--abbrev-ref", "HEAD",
+  })
+  if code != 0 {
+    return ""
+  }
+  branch := strings.TrimSpace(out)
+  if branch == "" || branch == "HEAD" {
+    return ""
+  }
+  return branch
 }
 
 type gitStatusEntry struct {
-	Path       string
-	Status     string
-	Untracked  bool
-	Conflicted bool
+  Path      string
+  Status    string
+  Untracked bool
+  Conflicted bool
 }
 
 func isInternalWorkspacePath(path string) bool {
@@ -1398,212 +1398,212 @@ func isInternalWorkspacePath(path string) bool {
 }
 
 func parseGitStatus(output string) []gitStatusEntry {
-	raw := []byte(output)
-	if len(raw) == 0 {
-		return nil
-	}
-	parts := bytes.Split(raw, []byte{0})
-	results := make([]gitStatusEntry, 0, len(parts))
-	for i := 0; i < len(parts); i++ {
-		entry := parts[i]
-		if len(entry) == 0 {
-			continue
-		}
-		// git status --porcelain=v1 -z output is:
-		//   XY<space>PATH\0
-		// where X and Y can be spaces. Do NOT split on the first space.
-		if len(entry) < 4 {
-			continue
-		}
-		statusField := string(entry[:2])
-		if statusField == "!!" {
-			continue
-		}
+  raw := []byte(output)
+  if len(raw) == 0 {
+    return nil
+  }
+  parts := bytes.Split(raw, []byte{0})
+  results := make([]gitStatusEntry, 0, len(parts))
+  for i := 0; i < len(parts); i++ {
+    entry := parts[i]
+    if len(entry) == 0 {
+      continue
+    }
+    // git status --porcelain=v1 -z output is:
+    //   XY<space>PATH\0
+    // where X and Y can be spaces. Do NOT split on the first space.
+    if len(entry) < 4 {
+      continue
+    }
+    statusField := string(entry[:2])
+    if statusField == "!!" {
+      continue
+    }
 
-		// After the two status characters there is a single space.
-		// We keep the raw path as-is (no TrimSpace) because it is a filename.
-		path := string(entry[3:])
+    // After the two status characters there is a single space.
+    // We keep the raw path as-is (no TrimSpace) because it is a filename.
+    path := string(entry[3:])
 
-		// For renames/copies, git status -z provides a second NUL-separated path.
-		// The first path is the source; the second is the destination.
-		if len(statusField) > 0 && (statusField[0] == 'R' || statusField[0] == 'C') {
-			if i+1 < len(parts) && len(parts[i+1]) > 0 {
-				path = string(parts[i+1])
-				i++
-			}
-		}
+    // For renames/copies, git status -z provides a second NUL-separated path.
+    // The first path is the source; the second is the destination.
+    if len(statusField) > 0 && (statusField[0] == 'R' || statusField[0] == 'C') {
+      if i+1 < len(parts) && len(parts[i+1]) > 0 {
+        path = string(parts[i+1])
+        i++
+      }
+    }
 
-		if path == "" {
-			continue
-		}
-		if isInternalWorkspacePath(path) {
-			continue
-		}
+    if path == "" {
+      continue
+    }
+    if isInternalWorkspacePath(path) {
+      continue
+    }
 
-		untracked := statusField == "??"
-		conflicted := strings.Contains(statusField, "U") || statusField == "AA" || statusField == "DD"
-		fileStatus := "modified"
-		if untracked || strings.Contains(statusField, "A") || (len(statusField) > 0 && statusField[0] == 'C') {
-			fileStatus = "added"
-		} else if strings.Contains(statusField, "D") {
-			fileStatus = "deleted"
-		}
+    untracked := statusField == "??"
+    conflicted := strings.Contains(statusField, "U") || statusField == "AA" || statusField == "DD"
+    fileStatus := "modified"
+    if untracked || strings.Contains(statusField, "A") || (len(statusField) > 0 && statusField[0] == 'C') {
+      fileStatus = "added"
+    } else if strings.Contains(statusField, "D") {
+      fileStatus = "deleted"
+    }
 
-		results = append(results, gitStatusEntry{
-			Path:       path,
-			Status:     fileStatus,
-			Untracked:  untracked,
-			Conflicted: conflicted,
-		})
-	}
-	return results
+    results = append(results, gitStatusEntry{
+      Path:      path,
+      Status:    fileStatus,
+      Untracked: untracked,
+      Conflicted: conflicted,
+    })
+  }
+  return results
 }
 
 func parseNumstat(output string) (int, int) {
-	line := ""
-	for _, candidate := range strings.Split(strings.TrimSpace(output), "\n") {
-		if strings.TrimSpace(candidate) != "" {
-			line = candidate
-			break
-		}
-	}
-	if line == "" {
-		return 0, 0
-	}
-	fields := strings.Split(line, "\t")
-	if len(fields) < 2 {
-		return 0, 0
-	}
-	add := parseNum(fields[0])
-	del := parseNum(fields[1])
-	return add, del
+  line := ""
+  for _, candidate := range strings.Split(strings.TrimSpace(output), "\n") {
+    if strings.TrimSpace(candidate) != "" {
+      line = candidate
+      break
+    }
+  }
+  if line == "" {
+    return 0, 0
+  }
+  fields := strings.Split(line, "\t")
+  if len(fields) < 2 {
+    return 0, 0
+  }
+  add := parseNum(fields[0])
+  del := parseNum(fields[1])
+  return add, del
 }
 
 func parseNum(value string) int {
-	if value == "-" {
-		return 0
-	}
-	parsed, err := strconv.Atoi(value)
-	if err != nil {
-		return 0
-	}
-	return parsed
+  if value == "-" {
+    return 0
+  }
+  parsed, err := strconv.Atoi(value)
+  if err != nil {
+    return 0
+  }
+  return parsed
 }
 
 func splitLines(output string) []string {
-	lines := strings.Split(output, "\n")
-	result := make([]string, 0, len(lines))
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed != "" {
-			result = append(result, trimmed)
-		}
-	}
-	return result
+  lines := strings.Split(output, "\n")
+  result := make([]string, 0, len(lines))
+  for _, line := range lines {
+    trimmed := strings.TrimSpace(line)
+    if trimmed != "" {
+      result = append(result, trimmed)
+    }
+  }
+  return result
 }
 
 func generateCommitMessage(statOutput string) string {
-	lines := splitLines(statOutput)
-	fileNames := make([]string, 0, len(lines))
+  lines := splitLines(statOutput)
+  fileNames := make([]string, 0, len(lines))
 
-	for _, line := range lines {
-		if !strings.Contains(line, "|") {
-			continue
-		}
-		parts := strings.Split(line, "|")
-		if len(parts) == 0 {
-			continue
-		}
-		name := strings.TrimSpace(parts[0])
-		if name != "" {
-			fileNames = append(fileNames, name)
-		}
-	}
+  for _, line := range lines {
+    if !strings.Contains(line, "|") {
+      continue
+    }
+    parts := strings.Split(line, "|")
+    if len(parts) == 0 {
+      continue
+    }
+    name := strings.TrimSpace(parts[0])
+    if name != "" {
+      fileNames = append(fileNames, name)
+    }
+  }
 
-	if len(fileNames) == 0 {
-		return "Update files"
-	}
-	if len(fileNames) <= 3 {
-		return "Update " + strings.Join(fileNames, ", ")
-	}
-	return "Update " + strconv.Itoa(len(fileNames)) + " files"
+  if len(fileNames) == 0 {
+    return "Update files"
+  }
+  if len(fileNames) <= 3 {
+    return "Update " + strings.Join(fileNames, ", ")
+  }
+  return "Update " + strconv.Itoa(len(fileNames)) + " files"
 }
 
 func runCmd(ctx context.Context, dir string, args []string) (string, string, int, error) {
-	if len(args) == 0 {
-		return "", "", 1, errors.New("no_command")
-	}
-	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-	cmd.Dir = dir
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			return stdout.String(), stderr.String(), exitErr.ExitCode(), nil
-		}
-		return stdout.String(), stderr.String(), 1, err
-	}
-	return stdout.String(), stderr.String(), 0, nil
+  if len(args) == 0 {
+    return "", "", 1, errors.New("no_command")
+  }
+  cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+  cmd.Dir = dir
+  var stdout bytes.Buffer
+  var stderr bytes.Buffer
+  cmd.Stdout = &stdout
+  cmd.Stderr = &stderr
+  err := cmd.Run()
+  if err != nil {
+    var exitErr *exec.ExitError
+    if errors.As(err, &exitErr) {
+      return stdout.String(), stderr.String(), exitErr.ExitCode(), nil
+    }
+    return stdout.String(), stderr.String(), 1, err
+  }
+  return stdout.String(), stderr.String(), 0, nil
 }
 
 func (s *server) readGitStage(ctx context.Context, stage int, relPath string) (string, error) {
-	spec := ":" + strconv.Itoa(stage) + ":" + relPath
-	out, _, code, execErr := runCmd(ctx, s.workspace, []string{
-		"git", "show", spec,
-	})
-	if execErr != nil {
-		return "", execErr
-	}
-	if code != 0 {
-		return "", nil
-	}
-	return out, nil
+  spec := ":" + strconv.Itoa(stage) + ":" + relPath
+  out, _, code, execErr := runCmd(ctx, s.workspace, []string{
+    "git", "show", spec,
+  })
+  if execErr != nil {
+    return "", execErr
+  }
+  if code != 0 {
+    return "", nil
+  }
+  return out, nil
 }
 
 func (s *server) resolveRelPath(rel string) (string, string, error) {
-	abs, err := s.resolvePath(rel)
-	if err != nil {
-		return "", "", err
-	}
-	workspaceAbs, err := filepath.Abs(s.workspace)
-	if err != nil {
-		return "", "", errors.New("workspace_invalid")
-	}
-	relPath, err := filepath.Rel(workspaceAbs, abs)
-	if err != nil {
-		return "", "", errors.New("invalid_path")
-	}
-	if relPath == "." || relPath == "" {
-		return "", "", errors.New("invalid_path")
-	}
-	return filepath.ToSlash(relPath), abs, nil
+  abs, err := s.resolvePath(rel)
+  if err != nil {
+    return "", "", err
+  }
+  workspaceAbs, err := filepath.Abs(s.workspace)
+  if err != nil {
+    return "", "", errors.New("workspace_invalid")
+  }
+  relPath, err := filepath.Rel(workspaceAbs, abs)
+  if err != nil {
+    return "", "", errors.New("invalid_path")
+  }
+  if relPath == "." || relPath == "" {
+    return "", "", errors.New("invalid_path")
+  }
+  return filepath.ToSlash(relPath), abs, nil
 }
 
 func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	temp, err := os.CreateTemp(dir, ".tmp-*")
-	if err != nil {
-		return err
-	}
-	tempName := temp.Name()
-	defer os.Remove(tempName)
+  dir := filepath.Dir(path)
+  temp, err := os.CreateTemp(dir, ".tmp-*")
+  if err != nil {
+    return err
+  }
+  tempName := temp.Name()
+  defer os.Remove(tempName)
 
-	if _, err := temp.Write(data); err != nil {
-		temp.Close()
-		return err
-	}
-	if err := temp.Chmod(perm); err != nil {
-		temp.Close()
-		return err
-	}
-	if err := temp.Close(); err != nil {
-		return err
-	}
-	return os.Rename(tempName, path)
+  if _, err := temp.Write(data); err != nil {
+    temp.Close()
+    return err
+  }
+  if err := temp.Chmod(perm); err != nil {
+    temp.Close()
+    return err
+  }
+  if err := temp.Close(); err != nil {
+    return err
+  }
+  return os.Rename(tempName, path)
 }
 
 type streamedFileResult struct {
@@ -1643,81 +1643,81 @@ func writeStreamFileAtomic(path string, reader io.Reader, perm os.FileMode) (str
 }
 
 func verifyExpectedHash(path string, expected string) (string, bool, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", false, err
-	}
-	currentHash := hashBytes(data)
-	return currentHash, expected == currentHash, nil
+  data, err := os.ReadFile(path)
+  if err != nil {
+    return "", false, err
+  }
+  currentHash := hashBytes(data)
+  return currentHash, expected == currentHash, nil
 }
 
 func hashBytes(data []byte) string {
-	sum := sha256.Sum256(data)
-	return "sha256:" + hex.EncodeToString(sum[:])
+  sum := sha256.Sum256(data)
+  return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func encodeContent(data []byte) (string, string) {
-	if utf8.Valid(data) {
-		return string(data), "utf-8"
-	}
-	return base64.StdEncoding.EncodeToString(data), "base64"
+  if utf8.Valid(data) {
+    return string(data), "utf-8"
+  }
+  return base64.StdEncoding.EncodeToString(data), "base64"
 }
 
 func decodeJSON(w http.ResponseWriter, r *http.Request, target any) error {
-	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
-	decoder := json.NewDecoder(r.Body)
-	if err := decoder.Decode(target); err != nil {
-		return err
-	}
-	if err := decoder.Decode(&struct{}{}); err != nil && !errors.Is(err, io.EOF) {
-		return errors.New("unexpected_data")
-	}
-	return nil
+  r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+  decoder := json.NewDecoder(r.Body)
+  if err := decoder.Decode(target); err != nil {
+    return err
+  }
+  if err := decoder.Decode(&struct{}{}); err != nil && !errors.Is(err, io.EOF) {
+    return errors.New("unexpected_data")
+  }
+  return nil
 }
 
 func writeJSON(w http.ResponseWriter, status int, payload any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	encoder := json.NewEncoder(w)
-	encoder.SetEscapeHTML(false)
-	_ = encoder.Encode(payload)
+  w.Header().Set("Content-Type", "application/json")
+  w.WriteHeader(status)
+  encoder := json.NewEncoder(w)
+  encoder.SetEscapeHTML(false)
+  _ = encoder.Encode(payload)
 }
 
 func writeError(w http.ResponseWriter, status int, message string) {
-	writeJSON(w, status, errorResponse{Ok: false, Error: message})
+  writeJSON(w, status, errorResponse{Ok: false, Error: message})
 }
 
 func (s *server) resolvePath(rel string) (string, error) {
-	if strings.TrimSpace(rel) == "" {
-		return "", errors.New("path_required")
-	}
-	if strings.Contains(rel, "\x00") {
-		return "", errors.New("invalid_path")
-	}
-	if filepath.IsAbs(rel) {
-		return "", errors.New("absolute_paths_not_allowed")
-	}
+  if strings.TrimSpace(rel) == "" {
+    return "", errors.New("path_required")
+  }
+  if strings.Contains(rel, "\x00") {
+    return "", errors.New("invalid_path")
+  }
+  if filepath.IsAbs(rel) {
+    return "", errors.New("absolute_paths_not_allowed")
+  }
 
-	cleaned := filepath.Clean(rel)
-	if cleaned == "." || cleaned == "" {
-		return "", errors.New("invalid_path")
-	}
-	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(os.PathSeparator)) {
-		return "", errors.New("path_outside_workspace")
-	}
-	if cleaned == ".git" || strings.HasPrefix(cleaned, ".git"+string(os.PathSeparator)) {
-		return "", errors.New("git_dir_not_allowed")
-	}
+  cleaned := filepath.Clean(rel)
+  if cleaned == "." || cleaned == "" {
+    return "", errors.New("invalid_path")
+  }
+  if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(os.PathSeparator)) {
+    return "", errors.New("path_outside_workspace")
+  }
+  if cleaned == ".git" || strings.HasPrefix(cleaned, ".git"+string(os.PathSeparator)) {
+    return "", errors.New("git_dir_not_allowed")
+  }
 
-	workspaceAbs, err := filepath.Abs(s.workspace)
-	if err != nil {
-		return "", errors.New("workspace_invalid")
-	}
-	abs := filepath.Join(workspaceAbs, cleaned)
-	abs, err = filepath.Abs(abs)
-	if err != nil {
-		return "", errors.New("invalid_path")
-	}
+  workspaceAbs, err := filepath.Abs(s.workspace)
+  if err != nil {
+    return "", errors.New("workspace_invalid")
+  }
+  abs := filepath.Join(workspaceAbs, cleaned)
+  abs, err = filepath.Abs(abs)
+  if err != nil {
+    return "", errors.New("invalid_path")
+  }
 
 	if !strings.HasPrefix(abs+string(os.PathSeparator), workspaceAbs+string(os.PathSeparator)) && abs != workspaceAbs {
 		return "", errors.New("path_outside_workspace")
@@ -1742,17 +1742,17 @@ func (s *server) ensurePathWithinWorkspace(absPath string) error {
 }
 
 func getenv(key, fallback string) string {
-	value := os.Getenv(key)
-	if value == "" {
-		return fallback
-	}
-	return value
+  value := os.Getenv(key)
+  if value == "" {
+    return fallback
+  }
+  return value
 }
 
 func logRequests(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		start := time.Now()
-		next.ServeHTTP(w, r)
-		log.Printf("%s %s %s", r.Method, r.URL.Path, time.Since(start))
-	})
+  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    start := time.Now()
+    next.ServeHTTP(w, r)
+    log.Printf("%s %s %s", r.Method, r.URL.Path, time.Since(start))
+  })
 }

--- a/infra/workspace-image/workspace-agent/main.go
+++ b/infra/workspace-image/workspace-agent/main.go
@@ -5,15 +5,15 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
-  "encoding/hex"
-  "encoding/json"
-  "errors"
-  "flag"
-  "io"
-  "log"
-  "net/http"
-  "os"
-  "os/exec"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -23,74 +23,75 @@ import (
 )
 
 const (
-  defaultAddr      = "0.0.0.0:4097"
-  defaultWorkspace = "/workspace"
-  maxBodyBytes     = 20 << 20
+	defaultAddr        = "0.0.0.0:4097"
+	defaultWorkspace   = "/workspace"
+	maxBodyBytes       = 20 << 20
 	maxUploadBodyBytes = 100 << 20
+	uploadReadTimeout  = 10 * time.Minute
 )
 
 type server struct {
-  workspace string
-  username  string
-  password  string
+	workspace string
+	username  string
+	password  string
 }
 
 type errorResponse struct {
-  Ok    bool   `json:"ok"`
-  Error string `json:"error"`
+	Ok    bool   `json:"ok"`
+	Error string `json:"error"`
 }
 
 type gitDiffEntry struct {
-  Path      string `json:"path"`
-  Status    string `json:"status"`
-  Additions int    `json:"additions"`
-  Deletions int    `json:"deletions"`
-  Diff      string `json:"diff"`
-  Conflicted bool  `json:"conflicted"`
+	Path       string `json:"path"`
+	Status     string `json:"status"`
+	Additions  int    `json:"additions"`
+	Deletions  int    `json:"deletions"`
+	Diff       string `json:"diff"`
+	Conflicted bool   `json:"conflicted"`
 }
 
 type gitDiffResponse struct {
-  Ok    bool          `json:"ok"`
-  Diffs []gitDiffEntry `json:"diffs"`
+	Ok    bool           `json:"ok"`
+	Diffs []gitDiffEntry `json:"diffs"`
 }
 
 type gitConflictRequest struct {
-  Path string `json:"path"`
+	Path string `json:"path"`
 }
 
 type gitConflictResponse struct {
-  Ok      bool   `json:"ok"`
-  Path    string `json:"path"`
-  Ours    string `json:"ours"`
-  Theirs  string `json:"theirs"`
-  Base    string `json:"base,omitempty"`
-  Working string `json:"working,omitempty"`
+	Ok      bool   `json:"ok"`
+	Path    string `json:"path"`
+	Ours    string `json:"ours"`
+	Theirs  string `json:"theirs"`
+	Base    string `json:"base,omitempty"`
+	Working string `json:"working,omitempty"`
 }
 
 type gitResolveRequest struct {
-  Path     string `json:"path"`
-  Strategy string `json:"strategy"`
-  Content  string `json:"content,omitempty"`
+	Path     string `json:"path"`
+	Strategy string `json:"strategy"`
+	Content  string `json:"content,omitempty"`
 }
 
 type gitResolveResponse struct {
-  Ok       bool   `json:"ok"`
-  Path     string `json:"path"`
-  Strategy string `json:"strategy"`
-  Message  string `json:"message,omitempty"`
+	Ok       bool   `json:"ok"`
+	Path     string `json:"path"`
+	Strategy string `json:"strategy"`
+	Message  string `json:"message,omitempty"`
 }
 
 type gitDiscardRequest struct {
-  Path string `json:"path"`
+	Path string `json:"path"`
 }
 
 type gitDiscardResponse struct {
-  Ok   bool   `json:"ok"`
-  Path string `json:"path"`
+	Ok   bool   `json:"ok"`
+	Path string `json:"path"`
 }
 
 type fileReadRequest struct {
-  Path string `json:"path"`
+	Path string `json:"path"`
 }
 
 type fileReadResponse struct {
@@ -127,9 +128,9 @@ type fileWriteRequest struct {
 }
 
 type fileWriteResponse struct {
-  Ok   bool   `json:"ok"`
-  Path string `json:"path"`
-  Hash string `json:"hash"`
+	Ok   bool   `json:"ok"`
+	Path string `json:"path"`
+	Hash string `json:"hash"`
 }
 
 type fileUploadResponse struct {
@@ -141,13 +142,13 @@ type fileUploadResponse struct {
 }
 
 type fileDeleteRequest struct {
-  Path string `json:"path"`
+	Path string `json:"path"`
 }
 
 type fileDeleteResponse struct {
-  Ok      bool   `json:"ok"`
-  Path    string `json:"path"`
-  Deleted bool   `json:"deleted"`
+	Ok      bool   `json:"ok"`
+	Path    string `json:"path"`
+	Deleted bool   `json:"deleted"`
 }
 
 type fileRenameRequest struct {
@@ -162,62 +163,62 @@ type fileRenameResponse struct {
 }
 
 type fileApplyPatchRequest struct {
-  Patch string `json:"patch"`
+	Patch string `json:"patch"`
 }
 
 type fileApplyPatchResponse struct {
-  Ok bool `json:"ok"`
+	Ok bool `json:"ok"`
 }
 
 type syncKbResponse struct {
-  Ok        bool     `json:"ok"`
-  Status    string   `json:"status"`
-  Message   string   `json:"message,omitempty"`
-  Conflicts []string `json:"conflicts,omitempty"`
+	Ok        bool     `json:"ok"`
+	Status    string   `json:"status"`
+	Message   string   `json:"message,omitempty"`
+	Conflicts []string `json:"conflicts,omitempty"`
 }
 
 type syncStatusResponse struct {
-  Ok           bool     `json:"ok"`
-  HasConflicts bool     `json:"hasConflicts"`
-  Conflicts    []string `json:"conflicts,omitempty"`
+	Ok           bool     `json:"ok"`
+	HasConflicts bool     `json:"hasConflicts"`
+	Conflicts    []string `json:"conflicts,omitempty"`
 }
 
 type publishKbResponse struct {
-  Ok         bool     `json:"ok"`
-  Status     string   `json:"status"`
-  CommitHash string   `json:"commitHash,omitempty"`
-  Files      []string `json:"files,omitempty"`
-  Message    string   `json:"message,omitempty"`
+	Ok         bool     `json:"ok"`
+	Status     string   `json:"status"`
+	CommitHash string   `json:"commitHash,omitempty"`
+	Files      []string `json:"files,omitempty"`
+	Message    string   `json:"message,omitempty"`
 }
 
 func main() {
-  addr := flag.String("addr", getenv("WORKSPACE_AGENT_ADDR", defaultAddr), "listen address")
-  workspace := flag.String("workspace", getenv("WORKSPACE_DIR", defaultWorkspace), "workspace root")
-  flag.Parse()
+	addr := flag.String("addr", getenv("WORKSPACE_AGENT_ADDR", defaultAddr), "listen address")
+	workspace := flag.String("workspace", getenv("WORKSPACE_DIR", defaultWorkspace), "workspace root")
+	flag.Parse()
 
-  username := getenv("WORKSPACE_AGENT_USERNAME", "opencode")
-  password := os.Getenv("WORKSPACE_AGENT_PASSWORD")
-  if password == "" {
-    password = os.Getenv("OPENCODE_SERVER_PASSWORD")
-  }
+	username := getenv("WORKSPACE_AGENT_USERNAME", "opencode")
+	password := os.Getenv("WORKSPACE_AGENT_PASSWORD")
+	if password == "" {
+		password = os.Getenv("OPENCODE_SERVER_PASSWORD")
+	}
 
-  if password == "" {
-    log.Printf("workspace-agent: missing OPENCODE_SERVER_PASSWORD")
-    os.Exit(1)
-  }
+	if password == "" {
+		log.Printf("workspace-agent: missing OPENCODE_SERVER_PASSWORD")
+		os.Exit(1)
+	}
 
-  s := &server{
-    workspace: *workspace,
-    username:  username,
-    password:  password,
-  }
+	s := &server{
+		workspace: *workspace,
+		username:  username,
+		password:  password,
+	}
 
-  mux := http.NewServeMux()
-  mux.HandleFunc("/health", s.withAuth(s.handleHealth))
-  mux.HandleFunc("/git/diffs", s.withAuth(s.handleGitDiffs))
-  mux.HandleFunc("/git/conflict", s.withAuth(s.handleGitConflict))
-  mux.HandleFunc("/git/resolve", s.withAuth(s.handleGitResolve))
-  mux.HandleFunc("/git/discard", s.withAuth(s.handleGitDiscard))
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", s.withAuth(s.handleHealth))
+	mux.HandleFunc("/git/diffs", s.withAuth(s.handleGitDiffs))
+	mux.HandleFunc("/git/conflict", s.withAuth(s.handleGitConflict))
+	mux.HandleFunc("/git/resolve", s.withAuth(s.handleGitResolve))
+	mux.HandleFunc("/git/discard", s.withAuth(s.handleGitDiscard))
 	mux.HandleFunc("/files/read", s.withAuth(s.handleFileRead))
 	mux.HandleFunc("/files/list", s.withAuth(s.handleFileList))
 	mux.HandleFunc("/files/upload", s.withAuth(s.handleFileUpload))
@@ -225,402 +226,402 @@ func main() {
 	mux.HandleFunc("/files/delete", s.withAuth(s.handleFileDelete))
 	mux.HandleFunc("/files/rename", s.withAuth(s.handleFileRename))
 	mux.HandleFunc("/files/apply_patch", s.withAuth(s.handleApplyPatch))
-  mux.HandleFunc("/kb/sync", s.withAuth(s.handleKbSync))
-  mux.HandleFunc("/kb/status", s.withAuth(s.handleKbStatus))
-  mux.HandleFunc("/kb/publish", s.withAuth(s.handleKbPublish))
+	mux.HandleFunc("/kb/sync", s.withAuth(s.handleKbSync))
+	mux.HandleFunc("/kb/status", s.withAuth(s.handleKbStatus))
+	mux.HandleFunc("/kb/publish", s.withAuth(s.handleKbPublish))
 
-  server := &http.Server{
-    Addr:              *addr,
-    Handler:           logRequests(mux),
-    ReadHeaderTimeout: 5 * time.Second,
-    ReadTimeout:       15 * time.Second,
-    WriteTimeout:      30 * time.Second,
-    IdleTimeout:       60 * time.Second,
-  }
+	server := &http.Server{
+		Addr:              *addr,
+		Handler:           logRequests(mux),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       uploadReadTimeout,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
 
-  log.Printf("workspace-agent listening on http://%s", *addr)
-  if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-    log.Fatalf("workspace-agent failed: %v", err)
-  }
+	log.Printf("workspace-agent listening on http://%s", *addr)
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("workspace-agent failed: %v", err)
+	}
 }
 
 func (s *server) withAuth(next http.HandlerFunc) http.HandlerFunc {
-  return func(w http.ResponseWriter, r *http.Request) {
-    username, password, ok := r.BasicAuth()
-    if !ok || username != s.username || password != s.password {
-      w.Header().Set("WWW-Authenticate", "Basic")
-      writeError(w, http.StatusUnauthorized, "unauthorized")
-      return
-    }
-    next(w, r)
-  }
+	return func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != s.username || password != s.password {
+			w.Header().Set("WWW-Authenticate", "Basic")
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		next(w, r)
+	}
 }
 
 func (s *server) handleHealth(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodGet {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
-  writeJSON(w, http.StatusOK, map[string]any{
-    "ok":      true,
-    "service": "workspace-agent",
-  })
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":      true,
+		"service": "workspace-agent",
+	})
 }
 
 func (s *server) handleGitDiffs(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodGet {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  entries, err := s.gitStatusEntries(r.Context())
-  if err != nil {
-    writeError(w, http.StatusBadGateway, err.Error())
-    return
-  }
-  if len(entries) == 0 {
-    writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: []gitDiffEntry{}})
-    return
-  }
-  diffs := make([]gitDiffEntry, 0, len(entries))
+	entries, err := s.gitStatusEntries(r.Context())
+	if err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	if len(entries) == 0 {
+		writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: []gitDiffEntry{}})
+		return
+	}
+	diffs := make([]gitDiffEntry, 0, len(entries))
 
-  for _, entry := range entries {
-    diffArgs := []string{"git", "diff", "--no-color", "HEAD", "--", entry.Path}
-    numstatArgs := []string{"git", "diff", "--numstat", "HEAD", "--", entry.Path}
-    if entry.Untracked {
-      diffArgs = []string{"git", "diff", "--no-color", "--no-index", "--", "/dev/null", entry.Path}
-      numstatArgs = []string{"git", "diff", "--numstat", "--no-index", "--", "/dev/null", entry.Path}
-    }
+	for _, entry := range entries {
+		diffArgs := []string{"git", "diff", "--no-color", "HEAD", "--", entry.Path}
+		numstatArgs := []string{"git", "diff", "--numstat", "HEAD", "--", entry.Path}
+		if entry.Untracked {
+			diffArgs = []string{"git", "diff", "--no-color", "--no-index", "--", "/dev/null", entry.Path}
+			numstatArgs = []string{"git", "diff", "--numstat", "--no-index", "--", "/dev/null", entry.Path}
+		}
 
-    diffOut, diffErr, diffCode, diffExecErr := runCmd(r.Context(), s.workspace, diffArgs)
-    if diffExecErr != nil || diffCode > 1 {
-      msg := strings.TrimSpace(diffErr)
-      if msg == "" {
-        msg = "git_diff_failed"
-      }
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
+		diffOut, diffErr, diffCode, diffExecErr := runCmd(r.Context(), s.workspace, diffArgs)
+		if diffExecErr != nil || diffCode > 1 {
+			msg := strings.TrimSpace(diffErr)
+			if msg == "" {
+				msg = "git_diff_failed"
+			}
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
 
-    numstatOut, numstatErr, numstatCode, numstatExecErr := runCmd(r.Context(), s.workspace, numstatArgs)
-    if numstatExecErr != nil || numstatCode > 1 {
-      msg := strings.TrimSpace(numstatErr)
-      if msg == "" {
-        msg = "git_numstat_failed"
-      }
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
+		numstatOut, numstatErr, numstatCode, numstatExecErr := runCmd(r.Context(), s.workspace, numstatArgs)
+		if numstatExecErr != nil || numstatCode > 1 {
+			msg := strings.TrimSpace(numstatErr)
+			if msg == "" {
+				msg = "git_numstat_failed"
+			}
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
 
-    additions, deletions := parseNumstat(numstatOut)
-    diffs = append(diffs, gitDiffEntry{
-      Path:      entry.Path,
-      Status:    entry.Status,
-      Additions: additions,
-      Deletions: deletions,
-      Diff:      strings.TrimSpace(diffOut),
-      Conflicted: entry.Conflicted,
-    })
-  }
+		additions, deletions := parseNumstat(numstatOut)
+		diffs = append(diffs, gitDiffEntry{
+			Path:       entry.Path,
+			Status:     entry.Status,
+			Additions:  additions,
+			Deletions:  deletions,
+			Diff:       strings.TrimSpace(diffOut),
+			Conflicted: entry.Conflicted,
+		})
+	}
 
-  writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: diffs})
+	writeJSON(w, http.StatusOK, gitDiffResponse{Ok: true, Diffs: diffs})
 }
 
 func (s *server) handleGitConflict(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req gitConflictRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req gitConflictRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  relPath, absPath, err := s.resolveRelPath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
+	relPath, absPath, err := s.resolveRelPath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
-  entries, _ := s.gitStatusEntries(r.Context(), relPath)
-  conflicted := false
-  for _, e := range entries {
-    if e.Conflicted {
-      conflicted = true
-      break
-    }
-  }
-  if !conflicted {
-    writeError(w, http.StatusNotFound, "not_conflicted")
-    return
-  }
+	entries, _ := s.gitStatusEntries(r.Context(), relPath)
+	conflicted := false
+	for _, e := range entries {
+		if e.Conflicted {
+			conflicted = true
+			break
+		}
+	}
+	if !conflicted {
+		writeError(w, http.StatusNotFound, "not_conflicted")
+		return
+	}
 
-  ours, err := s.readGitStage(r.Context(), 2, relPath)
-  if err != nil {
-    writeError(w, http.StatusBadGateway, "git_show_failed")
-    return
-  }
+	ours, err := s.readGitStage(r.Context(), 2, relPath)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "git_show_failed")
+		return
+	}
 
-  theirs, err := s.readGitStage(r.Context(), 3, relPath)
-  if err != nil {
-    writeError(w, http.StatusBadGateway, "git_show_failed")
-    return
-  }
+	theirs, err := s.readGitStage(r.Context(), 3, relPath)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "git_show_failed")
+		return
+	}
 
-  base, err := s.readGitStage(r.Context(), 1, relPath)
-  if err != nil {
-    writeError(w, http.StatusBadGateway, "git_show_failed")
-    return
-  }
+	base, err := s.readGitStage(r.Context(), 1, relPath)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "git_show_failed")
+		return
+	}
 
-  working := ""
-  if data, err := os.ReadFile(absPath); err == nil {
-    working = string(data)
-  }
+	working := ""
+	if data, err := os.ReadFile(absPath); err == nil {
+		working = string(data)
+	}
 
-  writeJSON(w, http.StatusOK, gitConflictResponse{
-    Ok:      true,
-    Path:    req.Path,
-    Ours:    ours,
-    Theirs:  theirs,
-    Base:    base,
-    Working: working,
-  })
+	writeJSON(w, http.StatusOK, gitConflictResponse{
+		Ok:      true,
+		Path:    req.Path,
+		Ours:    ours,
+		Theirs:  theirs,
+		Base:    base,
+		Working: working,
+	})
 }
 
 func (s *server) handleGitResolve(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req gitResolveRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req gitResolveRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  relPath, absPath, err := s.resolveRelPath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
+	relPath, absPath, err := s.resolveRelPath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
-  switch req.Strategy {
-  case "ours":
-    _, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
-      "git", "checkout", "--ours", "--", relPath,
-    })
-    if checkoutExecErr != nil || checkoutCode != 0 {
-      msg := strings.TrimSpace(checkoutErr)
-      if msg == "" {
-        msg = "git_checkout_failed"
-      }
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
-  case "theirs":
-    _, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
-      "git", "checkout", "--theirs", "--", relPath,
-    })
-    if checkoutExecErr != nil || checkoutCode != 0 {
-      msg := strings.TrimSpace(checkoutErr)
-      if msg == "" {
-        msg = "git_checkout_failed"
-      }
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
-  case "manual":
-    if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
-      writeError(w, http.StatusInternalServerError, "mkdir_failed")
-      return
-    }
-    if err := writeFileAtomic(absPath, []byte(req.Content), 0o644); err != nil {
-      writeError(w, http.StatusInternalServerError, "write_failed")
-      return
-    }
-  default:
-    writeError(w, http.StatusBadRequest, "invalid_strategy")
-    return
-  }
+	switch req.Strategy {
+	case "ours":
+		_, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
+			"git", "checkout", "--ours", "--", relPath,
+		})
+		if checkoutExecErr != nil || checkoutCode != 0 {
+			msg := strings.TrimSpace(checkoutErr)
+			if msg == "" {
+				msg = "git_checkout_failed"
+			}
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
+	case "theirs":
+		_, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
+			"git", "checkout", "--theirs", "--", relPath,
+		})
+		if checkoutExecErr != nil || checkoutCode != 0 {
+			msg := strings.TrimSpace(checkoutErr)
+			if msg == "" {
+				msg = "git_checkout_failed"
+			}
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
+	case "manual":
+		if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+			writeError(w, http.StatusInternalServerError, "mkdir_failed")
+			return
+		}
+		if err := writeFileAtomic(absPath, []byte(req.Content), 0o644); err != nil {
+			writeError(w, http.StatusInternalServerError, "write_failed")
+			return
+		}
+	default:
+		writeError(w, http.StatusBadRequest, "invalid_strategy")
+		return
+	}
 
-  _, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "add", "--", relPath,
-  })
-  if addExecErr != nil || addCode != 0 {
-    msg := strings.TrimSpace(addErr)
-    if msg == "" {
-      msg = "git_add_failed"
-    }
-    writeError(w, http.StatusBadGateway, msg)
-    return
-  }
+	_, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "add", "--", relPath,
+	})
+	if addExecErr != nil || addCode != 0 {
+		msg := strings.TrimSpace(addErr)
+		if msg == "" {
+			msg = "git_add_failed"
+		}
+		writeError(w, http.StatusBadGateway, msg)
+		return
+	}
 
-  writeJSON(w, http.StatusOK, gitResolveResponse{
-    Ok:       true,
-    Path:     req.Path,
-    Strategy: req.Strategy,
-  })
+	writeJSON(w, http.StatusOK, gitResolveResponse{
+		Ok:       true,
+		Path:     req.Path,
+		Strategy: req.Strategy,
+	})
 }
 
 func (s *server) handleGitDiscard(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req gitDiscardRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req gitDiscardRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  relPath, absPath, err := s.resolveRelPath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
+	relPath, absPath, err := s.resolveRelPath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
-  entries, statusErr := s.gitStatusEntries(r.Context(), relPath)
-  if statusErr != nil {
-    writeError(w, http.StatusBadGateway, statusErr.Error())
-    return
-  }
+	entries, statusErr := s.gitStatusEntries(r.Context(), relPath)
+	if statusErr != nil {
+		writeError(w, http.StatusBadGateway, statusErr.Error())
+		return
+	}
 
-  var entry *gitStatusEntry
-  for i := range entries {
-    if entries[i].Path == relPath {
-      entry = &entries[i]
-      break
-    }
-  }
-  if entry == nil {
-    writeError(w, http.StatusNotFound, "not_modified")
-    return
-  }
+	var entry *gitStatusEntry
+	for i := range entries {
+		if entries[i].Path == relPath {
+			entry = &entries[i]
+			break
+		}
+	}
+	if entry == nil {
+		writeError(w, http.StatusNotFound, "not_modified")
+		return
+	}
 
-  // Untracked files can be safely removed without involving git.
-  if entry.Untracked {
-    if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-      writeError(w, http.StatusInternalServerError, "delete_failed")
-      return
-    }
-    writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
-    return
-  }
+	// Untracked files can be safely removed without involving git.
+	if entry.Untracked {
+		if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			writeError(w, http.StatusInternalServerError, "delete_failed")
+			return
+		}
+		writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
+		return
+	}
 
-  // Best-effort: clear index state for this path (helps with conflict stages).
-  _, resetErrOut, resetCode, resetExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "reset", "-q", "--", relPath,
-  })
-  if resetExecErr != nil {
-    writeError(w, http.StatusBadGateway, "git_reset_failed")
-    return
-  }
-  if resetCode != 0 {
-    msg := strings.TrimSpace(resetErrOut)
-    // Ignore common "pathspec" errors (e.g. when the path only exists in the index).
-    if msg != "" && !strings.Contains(strings.ToLower(msg), "pathspec") {
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
-  }
+	// Best-effort: clear index state for this path (helps with conflict stages).
+	_, resetErrOut, resetCode, resetExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "reset", "-q", "--", relPath,
+	})
+	if resetExecErr != nil {
+		writeError(w, http.StatusBadGateway, "git_reset_failed")
+		return
+	}
+	if resetCode != 0 {
+		msg := strings.TrimSpace(resetErrOut)
+		// Ignore common "pathspec" errors (e.g. when the path only exists in the index).
+		if msg != "" && !strings.Contains(strings.ToLower(msg), "pathspec") {
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
+	}
 
-  // If the path exists in HEAD, restore it. Otherwise, drop it from the index and delete it.
-  _, _, catCode, _ := runCmd(r.Context(), s.workspace, []string{
-    "git", "cat-file", "-e", "HEAD:" + relPath,
-  })
+	// If the path exists in HEAD, restore it. Otherwise, drop it from the index and delete it.
+	_, _, catCode, _ := runCmd(r.Context(), s.workspace, []string{
+		"git", "cat-file", "-e", "HEAD:" + relPath,
+	})
 
-  if catCode == 0 {
-    _, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
-      "git", "checkout", "--", relPath,
-    })
-    if checkoutExecErr != nil || checkoutCode != 0 {
-      msg := strings.TrimSpace(checkoutErr)
-      if msg == "" {
-        msg = "git_checkout_failed"
-      }
-      writeError(w, http.StatusBadGateway, msg)
-      return
-    }
+	if catCode == 0 {
+		_, checkoutErr, checkoutCode, checkoutExecErr := runCmd(r.Context(), s.workspace, []string{
+			"git", "checkout", "--", relPath,
+		})
+		if checkoutExecErr != nil || checkoutCode != 0 {
+			msg := strings.TrimSpace(checkoutErr)
+			if msg == "" {
+				msg = "git_checkout_failed"
+			}
+			writeError(w, http.StatusBadGateway, msg)
+			return
+		}
 
-    writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
-    return
-  }
+		writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
+		return
+	}
 
-  // New tracked file (not in HEAD).
-  _, rmErr, rmCode, rmExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "rm", "-f", "--cached", "--", relPath,
-  })
-  if rmExecErr != nil {
-    writeError(w, http.StatusBadGateway, "git_rm_failed")
-    return
-  }
-  if rmCode != 0 {
-    // If it wasn't in the index, keep going.
-    _ = rmErr
-  }
+	// New tracked file (not in HEAD).
+	_, rmErr, rmCode, rmExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "rm", "-f", "--cached", "--", relPath,
+	})
+	if rmExecErr != nil {
+		writeError(w, http.StatusBadGateway, "git_rm_failed")
+		return
+	}
+	if rmCode != 0 {
+		// If it wasn't in the index, keep going.
+		_ = rmErr
+	}
 
-  if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-    writeError(w, http.StatusInternalServerError, "delete_failed")
-    return
-  }
-  writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
+	if err := os.Remove(absPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		writeError(w, http.StatusInternalServerError, "delete_failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, gitDiscardResponse{Ok: true, Path: req.Path})
 }
 
 func (s *server) handleFileRead(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req fileReadRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req fileReadRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  path, err := s.resolvePath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
-  if err := s.ensurePathWithinWorkspace(path); err != nil {
-    writeError(w, http.StatusForbidden, err.Error())
-    return
-  }
+	path, err := s.resolvePath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := s.ensurePathWithinWorkspace(path); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
 
-  info, err := os.Stat(path)
-  if err != nil {
-    if os.IsNotExist(err) {
-      writeError(w, http.StatusNotFound, "not_found")
-      return
-    }
-    writeError(w, http.StatusInternalServerError, "stat_failed")
-    return
-  }
-  if info.IsDir() {
-    writeError(w, http.StatusBadRequest, "is_directory")
-    return
-  }
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeError(w, http.StatusNotFound, "not_found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "stat_failed")
+		return
+	}
+	if info.IsDir() {
+		writeError(w, http.StatusBadRequest, "is_directory")
+		return
+	}
 
-  data, err := os.ReadFile(path)
-  if err != nil {
-    writeError(w, http.StatusInternalServerError, "read_failed")
-    return
-  }
+	data, err := os.ReadFile(path)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "read_failed")
+		return
+	}
 
-  content, encoding := encodeContent(data)
-  writeJSON(w, http.StatusOK, fileReadResponse{
-    Ok:       true,
-    Path:     req.Path,
-    Content:  content,
-    Encoding: encoding,
-    Hash:     hashBytes(data),
-  })
+	content, encoding := encodeContent(data)
+	writeJSON(w, http.StatusOK, fileReadResponse{
+		Ok:       true,
+		Path:     req.Path,
+		Content:  content,
+		Encoding: encoding,
+		Hash:     hashBytes(data),
+	})
 }
 
 func (s *server) handleFileList(w http.ResponseWriter, r *http.Request) {
@@ -742,46 +743,46 @@ func (s *server) handleFileList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleFileWrite(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req fileWriteRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req fileWriteRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  path, err := s.resolvePath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
-  if err := s.ensurePathWithinWorkspace(path); err != nil {
-    writeError(w, http.StatusForbidden, err.Error())
-    return
-  }
+	path, err := s.resolvePath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := s.ensurePathWithinWorkspace(path); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
 
-  if req.ExpectedHash != "" {
-    currentHash, ok, err := verifyExpectedHash(path, req.ExpectedHash)
-    if err != nil {
-      if errors.Is(err, os.ErrNotExist) {
-        writeError(w, http.StatusNotFound, "not_found")
-        return
-      }
-      writeError(w, http.StatusInternalServerError, "hash_check_failed")
-      return
-    }
-    if !ok {
-      writeJSON(w, http.StatusConflict, map[string]any{
-        "ok":          false,
-        "error":       "conflict",
-        "currentHash": currentHash,
-      })
-      return
-    }
-  }
+	if req.ExpectedHash != "" {
+		currentHash, ok, err := verifyExpectedHash(path, req.ExpectedHash)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				writeError(w, http.StatusNotFound, "not_found")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "hash_check_failed")
+			return
+		}
+		if !ok {
+			writeJSON(w, http.StatusConflict, map[string]any{
+				"ok":          false,
+				"error":       "conflict",
+				"currentHash": currentHash,
+			})
+			return
+		}
+	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		writeError(w, http.StatusInternalServerError, "mkdir_failed")
@@ -808,17 +809,17 @@ func (s *server) handleFileWrite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-  data, err := os.ReadFile(path)
-  if err != nil {
-    writeError(w, http.StatusInternalServerError, "read_failed")
-    return
-  }
+	data, err := os.ReadFile(path)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "read_failed")
+		return
+	}
 
-  writeJSON(w, http.StatusOK, fileWriteResponse{
-    Ok:   true,
-    Path: req.Path,
-    Hash: hashBytes(data),
-  })
+	writeJSON(w, http.StatusOK, fileWriteResponse{
+		Ok:   true,
+		Path: req.Path,
+		Hash: hashBytes(data),
+	})
 }
 
 func (s *server) handleFileUpload(w http.ResponseWriter, r *http.Request) {
@@ -827,7 +828,7 @@ func (s *server) handleFileUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	relPath, absPath, err := s.resolveRelPath(r.URL.Query().Get("path"))
+	_, absPath, err := s.resolveRelPath(r.URL.Query().Get("path"))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -846,12 +847,22 @@ func (s *server) handleFileUpload(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusRequestEntityTooLarge, "file_too_large")
 			return
 		}
+		if errors.Is(r.Context().Err(), context.Canceled) {
+			writeError(w, http.StatusRequestTimeout, "upload_canceled")
+			return
+		}
 
 		writeError(w, http.StatusInternalServerError, "write_failed")
 		return
 	}
 
-	info, err := os.Stat(absPath)
+	uploadedRelPath, err := s.relPathForAbs(uploadResult.Path)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "stat_failed")
+		return
+	}
+
+	info, err := os.Stat(uploadResult.Path)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "stat_failed")
 		return
@@ -859,7 +870,7 @@ func (s *server) handleFileUpload(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, fileUploadResponse{
 		Ok:         true,
-		Path:       relPath,
+		Path:       uploadedRelPath,
 		Hash:       uploadResult.Hash,
 		Size:       uploadResult.Size,
 		ModifiedAt: info.ModTime().UnixMilli(),
@@ -867,45 +878,45 @@ func (s *server) handleFileUpload(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleFileDelete(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req fileDeleteRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
+	var req fileDeleteRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
 
-  path, err := s.resolvePath(req.Path)
-  if err != nil {
-    writeError(w, http.StatusBadRequest, err.Error())
-    return
-  }
-  if err := s.ensurePathWithinWorkspace(path); err != nil {
-    writeError(w, http.StatusForbidden, err.Error())
-    return
-  }
+	path, err := s.resolvePath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := s.ensurePathWithinWorkspace(path); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
 
-  info, err := os.Stat(path)
-  if err != nil {
-    if os.IsNotExist(err) {
-      writeError(w, http.StatusNotFound, "not_found")
-      return
-    }
-    writeError(w, http.StatusInternalServerError, "stat_failed")
-    return
-  }
-  if info.IsDir() {
-    writeError(w, http.StatusBadRequest, "is_directory")
-    return
-  }
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeError(w, http.StatusNotFound, "not_found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "stat_failed")
+		return
+	}
+	if info.IsDir() {
+		writeError(w, http.StatusBadRequest, "is_directory")
+		return
+	}
 
-  if err := os.Remove(path); err != nil {
-    writeError(w, http.StatusInternalServerError, "delete_failed")
-    return
-  }
+	if err := os.Remove(path); err != nil {
+		writeError(w, http.StatusInternalServerError, "delete_failed")
+		return
+	}
 
 	writeJSON(w, http.StatusOK, fileDeleteResponse{
 		Ok:      true,
@@ -994,43 +1005,43 @@ func (s *server) handleFileRename(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleApplyPatch(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  var req fileApplyPatchRequest
-  if err := decodeJSON(w, r, &req); err != nil {
-    writeError(w, http.StatusBadRequest, "invalid_json")
-    return
-  }
-  if strings.TrimSpace(req.Patch) == "" {
-    writeError(w, http.StatusBadRequest, "empty_patch")
-    return
-  }
+	var req fileApplyPatchRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
+	if strings.TrimSpace(req.Patch) == "" {
+		writeError(w, http.StatusBadRequest, "empty_patch")
+		return
+	}
 
-  cmd := exec.CommandContext(r.Context(), "git", "apply", "--whitespace=nowarn", "--")
-  cmd.Dir = s.workspace
-  cmd.Stdin = strings.NewReader(req.Patch)
-  var stdout bytes.Buffer
-  var stderr bytes.Buffer
-  cmd.Stdout = &stdout
-  cmd.Stderr = &stderr
+	cmd := exec.CommandContext(r.Context(), "git", "apply", "--whitespace=nowarn", "--")
+	cmd.Dir = s.workspace
+	cmd.Stdin = strings.NewReader(req.Patch)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
-  err := cmd.Run()
-  if err != nil {
-    msg := strings.TrimSpace(stderr.String())
-    if msg == "" {
-      msg = "apply_patch_failed"
-    }
-    writeJSON(w, http.StatusConflict, map[string]any{
-      "ok":    false,
-      "error": msg,
-    })
-    return
-  }
+	err := cmd.Run()
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = "apply_patch_failed"
+		}
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"ok":    false,
+			"error": msg,
+		})
+		return
+	}
 
-  writeJSON(w, http.StatusOK, fileApplyPatchResponse{Ok: true})
+	writeJSON(w, http.StatusOK, fileApplyPatchResponse{Ok: true})
 }
 
 // fetchAndMergeKb fetches from the kb remote and merges the remote branch.
@@ -1038,351 +1049,351 @@ func (s *server) handleApplyPatch(w http.ResponseWriter, r *http.Request) {
 // was no remote branch yet). If ok is false and conflicts is non-empty the merge
 // produced conflicts. Otherwise errMsg describes the failure.
 func (s *server) fetchAndMergeKb(ctx context.Context) (bool, []string, string) {
-  _, fetchErr, fetchCode, fetchExecErr := runCmd(ctx, s.workspace, []string{
-    "git", "fetch", "kb",
-  })
-  if fetchExecErr != nil || fetchCode != 0 {
-    msg := strings.TrimSpace(fetchErr)
-    if msg == "" {
-      msg = "fetch_failed"
-    }
-    return false, nil, "Fetch failed: " + msg
-  }
+	_, fetchErr, fetchCode, fetchExecErr := runCmd(ctx, s.workspace, []string{
+		"git", "fetch", "kb",
+	})
+	if fetchExecErr != nil || fetchCode != 0 {
+		msg := strings.TrimSpace(fetchErr)
+		if msg == "" {
+			msg = "fetch_failed"
+		}
+		return false, nil, "Fetch failed: " + msg
+	}
 
-  kbBranch := s.resolveKbBranch(ctx)
+	kbBranch := s.resolveKbBranch(ctx)
 
-  if !s.remoteBranchExists(ctx, kbBranch) {
-    // First publish — nothing to merge.
-    return true, nil, ""
-  }
+	if !s.remoteBranchExists(ctx, kbBranch) {
+		// First publish — nothing to merge.
+		return true, nil, ""
+	}
 
-  _, mergeErr, mergeCode, mergeExecErr := runCmd(ctx, s.workspace, []string{
-    "git", "merge", "kb/" + kbBranch, "--no-edit",
-  })
-  if mergeExecErr == nil && mergeCode == 0 {
-    return true, nil, ""
-  }
+	_, mergeErr, mergeCode, mergeExecErr := runCmd(ctx, s.workspace, []string{
+		"git", "merge", "kb/" + kbBranch, "--no-edit",
+	})
+	if mergeExecErr == nil && mergeCode == 0 {
+		return true, nil, ""
+	}
 
-  if isUnrelatedHistoryError(mergeErr) {
-    _, mergeErrAllow, mergeCodeAllow, mergeExecErrAllow := runCmd(ctx, s.workspace, []string{
-      "git", "merge", "kb/" + kbBranch, "--no-edit", "--allow-unrelated-histories",
-    })
-    if mergeExecErrAllow == nil && mergeCodeAllow == 0 {
-      return true, nil, ""
-    }
+	if isUnrelatedHistoryError(mergeErr) {
+		_, mergeErrAllow, mergeCodeAllow, mergeExecErrAllow := runCmd(ctx, s.workspace, []string{
+			"git", "merge", "kb/" + kbBranch, "--no-edit", "--allow-unrelated-histories",
+		})
+		if mergeExecErrAllow == nil && mergeCodeAllow == 0 {
+			return true, nil, ""
+		}
 
-    conflicts := s.listConflictFiles(ctx)
-    if len(conflicts) > 0 {
-      return false, conflicts, "Merge has conflicts that need to be resolved"
-    }
+		conflicts := s.listConflictFiles(ctx)
+		if len(conflicts) > 0 {
+			return false, conflicts, "Merge has conflicts that need to be resolved"
+		}
 
-    msg := strings.TrimSpace(mergeErrAllow)
-    if msg == "" {
-      msg = "merge_failed"
-    }
-    return false, nil, "Merge failed: " + msg
-  }
+		msg := strings.TrimSpace(mergeErrAllow)
+		if msg == "" {
+			msg = "merge_failed"
+		}
+		return false, nil, "Merge failed: " + msg
+	}
 
-  conflicts := s.listConflictFiles(ctx)
-  if len(conflicts) > 0 {
-    return false, conflicts, "Merge has conflicts that need to be resolved"
-  }
+	conflicts := s.listConflictFiles(ctx)
+	if len(conflicts) > 0 {
+		return false, conflicts, "Merge has conflicts that need to be resolved"
+	}
 
-  msg := strings.TrimSpace(mergeErr)
-  if msg == "" {
-    msg = "merge_failed"
-  }
-  return false, nil, "Merge failed: " + msg
+	msg := strings.TrimSpace(mergeErr)
+	if msg == "" {
+		msg = "merge_failed"
+	}
+	return false, nil, "Merge failed: " + msg
 }
 
 func (s *server) handleKbSync(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  _, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "remote", "get-url", "kb",
-  })
-  if remoteExecErr != nil || remoteCode != 0 {
-    writeJSON(w, http.StatusOK, syncKbResponse{
-      Ok:      false,
-      Status:  "no_remote",
-      Message: "KB remote not configured. Workspace may not have been initialized with KB.",
-    })
-    return
-  }
+	_, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "remote", "get-url", "kb",
+	})
+	if remoteExecErr != nil || remoteCode != 0 {
+		writeJSON(w, http.StatusOK, syncKbResponse{
+			Ok:      false,
+			Status:  "no_remote",
+			Message: "KB remote not configured. Workspace may not have been initialized with KB.",
+		})
+		return
+	}
 
-  mergeOk, conflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
-  if mergeOk {
-    writeJSON(w, http.StatusOK, syncKbResponse{
-      Ok:      true,
-      Status:  "synced",
-      Message: "KB synchronized successfully",
-    })
-    return
-  }
+	mergeOk, conflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
+	if mergeOk {
+		writeJSON(w, http.StatusOK, syncKbResponse{
+			Ok:      true,
+			Status:  "synced",
+			Message: "KB synchronized successfully",
+		})
+		return
+	}
 
-  if len(conflicts) > 0 {
-    writeJSON(w, http.StatusOK, syncKbResponse{
-      Ok:        true,
-      Status:    "conflicts",
-      Message:   "Merge has conflicts that need to be resolved",
-      Conflicts: conflicts,
-    })
-    return
-  }
+	if len(conflicts) > 0 {
+		writeJSON(w, http.StatusOK, syncKbResponse{
+			Ok:        true,
+			Status:    "conflicts",
+			Message:   "Merge has conflicts that need to be resolved",
+			Conflicts: conflicts,
+		})
+		return
+	}
 
-  writeJSON(w, http.StatusOK, syncKbResponse{
-    Ok:      false,
-    Status:  "error",
-    Message: mergeErrMsg,
-  })
+	writeJSON(w, http.StatusOK, syncKbResponse{
+		Ok:      false,
+		Status:  "error",
+		Message: mergeErrMsg,
+	})
 }
 
 func (s *server) handleKbStatus(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodGet {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  conflicts := s.listConflictFiles(r.Context())
-  writeJSON(w, http.StatusOK, syncStatusResponse{
-    Ok:           true,
-    HasConflicts: len(conflicts) > 0,
-    Conflicts:    conflicts,
-  })
+	conflicts := s.listConflictFiles(r.Context())
+	writeJSON(w, http.StatusOK, syncStatusResponse{
+		Ok:           true,
+		HasConflicts: len(conflicts) > 0,
+		Conflicts:    conflicts,
+	})
 }
 
 func (s *server) handleKbPublish(w http.ResponseWriter, r *http.Request) {
-  if r.Method != http.MethodPost {
-    writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
-    return
-  }
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
 
-  _, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "remote", "get-url", "kb",
-  })
-  if remoteExecErr != nil || remoteCode != 0 {
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "no_remote",
-      Message: "KB remote not configured.",
-    })
-    return
-  }
+	_, _, remoteCode, remoteExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "remote", "get-url", "kb",
+	})
+	if remoteExecErr != nil || remoteCode != 0 {
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "no_remote",
+			Message: "KB remote not configured.",
+		})
+		return
+	}
 
-  conflicts := s.listConflictFiles(r.Context())
-  if len(conflicts) > 0 {
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "conflicts",
-      Files:   conflicts,
-      Message: "Resolve conflicts before publishing.",
-    })
-    return
-  }
+	conflicts := s.listConflictFiles(r.Context())
+	if len(conflicts) > 0 {
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "conflicts",
+			Files:   conflicts,
+			Message: "Resolve conflicts before publishing.",
+		})
+		return
+	}
 
-  entries, statusErr := s.gitStatusEntries(r.Context())
-  if statusErr != nil {
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "error",
-      Message: statusErr.Error(),
-    })
-    return
-  }
+	entries, statusErr := s.gitStatusEntries(r.Context())
+	if statusErr != nil {
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "error",
+			Message: statusErr.Error(),
+		})
+		return
+	}
 
-  if len(entries) == 0 {
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      true,
-      Status:  "nothing_to_publish",
-      Message: "Nothing to publish.",
-    })
-    return
-  }
+	if len(entries) == 0 {
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      true,
+			Status:  "nothing_to_publish",
+			Message: "Nothing to publish.",
+		})
+		return
+	}
 
-  _, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "add", "-A",
-  })
-  if addExecErr != nil || addCode != 0 {
-    msg := strings.TrimSpace(addErr)
-    if msg == "" {
-      msg = "git_add_failed"
-    }
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "error",
-      Message: "git add failed: " + msg,
-    })
-    return
-  }
+	_, addErr, addCode, addExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "add", "-A",
+	})
+	if addExecErr != nil || addCode != 0 {
+		msg := strings.TrimSpace(addErr)
+		if msg == "" {
+			msg = "git_add_failed"
+		}
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "error",
+			Message: "git add failed: " + msg,
+		})
+		return
+	}
 
-  statOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
-    "git", "diff", "--cached", "--stat",
-  })
-  commitMessage := generateCommitMessage(statOut)
+	statOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
+		"git", "diff", "--cached", "--stat",
+	})
+	commitMessage := generateCommitMessage(statOut)
 
-  _, commitErr, commitCode, commitExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "commit", "-m", commitMessage,
-  })
-  if commitExecErr != nil || commitCode != 0 {
-    msg := strings.TrimSpace(commitErr)
-    if msg == "" {
-      msg = "git_commit_failed"
-    }
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "error",
-      Message: "git commit failed: " + msg,
-    })
-    return
-  }
+	_, commitErr, commitCode, commitExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "commit", "-m", commitMessage,
+	})
+	if commitExecErr != nil || commitCode != 0 {
+		msg := strings.TrimSpace(commitErr)
+		if msg == "" {
+			msg = "git_commit_failed"
+		}
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "error",
+			Message: "git commit failed: " + msg,
+		})
+		return
+	}
 
-  hashOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
-    "git", "rev-parse", "--short", "HEAD",
-  })
-  commitHash := strings.TrimSpace(hashOut)
+	hashOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
+		"git", "rev-parse", "--short", "HEAD",
+	})
+	commitHash := strings.TrimSpace(hashOut)
 
-  filesOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
-    "git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD",
-  })
-  files := splitLines(filesOut)
+	filesOut, _, _, _ := runCmd(r.Context(), s.workspace, []string{
+		"git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD",
+	})
+	files := splitLines(filesOut)
 
-  // Fetch and merge remote before pushing to avoid rejected pushes.
-  mergeOk, mergeConflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
-  if !mergeOk {
-    if len(mergeConflicts) > 0 {
-      writeJSON(w, http.StatusOK, publishKbResponse{
-        Ok:      false,
-        Status:  "conflicts",
-        Files:   mergeConflicts,
-        Message: "Merge conflicts during publish. Resolve and retry.",
-      })
-      return
-    }
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:      false,
-      Status:  "error",
-      Message: mergeErrMsg,
-    })
-    return
-  }
+	// Fetch and merge remote before pushing to avoid rejected pushes.
+	mergeOk, mergeConflicts, mergeErrMsg := s.fetchAndMergeKb(r.Context())
+	if !mergeOk {
+		if len(mergeConflicts) > 0 {
+			writeJSON(w, http.StatusOK, publishKbResponse{
+				Ok:      false,
+				Status:  "conflicts",
+				Files:   mergeConflicts,
+				Message: "Merge conflicts during publish. Resolve and retry.",
+			})
+			return
+		}
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:      false,
+			Status:  "error",
+			Message: mergeErrMsg,
+		})
+		return
+	}
 
-  kbBranch := s.resolveKbBranch(r.Context())
-  _, pushErr, pushCode, pushExecErr := runCmd(r.Context(), s.workspace, []string{
-    "git", "push", "kb", "HEAD:refs/heads/" + kbBranch,
-  })
-  if pushExecErr != nil || pushCode != 0 {
-    msg := strings.TrimSpace(pushErr)
-    if msg == "" {
-      msg = "git_push_failed"
-    }
-    writeJSON(w, http.StatusOK, publishKbResponse{
-      Ok:         false,
-      Status:     "push_rejected",
-      CommitHash: commitHash,
-      Files:      files,
-      Message:    msg,
-    })
-    return
-  }
+	kbBranch := s.resolveKbBranch(r.Context())
+	_, pushErr, pushCode, pushExecErr := runCmd(r.Context(), s.workspace, []string{
+		"git", "push", "kb", "HEAD:refs/heads/" + kbBranch,
+	})
+	if pushExecErr != nil || pushCode != 0 {
+		msg := strings.TrimSpace(pushErr)
+		if msg == "" {
+			msg = "git_push_failed"
+		}
+		writeJSON(w, http.StatusOK, publishKbResponse{
+			Ok:         false,
+			Status:     "push_rejected",
+			CommitHash: commitHash,
+			Files:      files,
+			Message:    msg,
+		})
+		return
+	}
 
-  writeJSON(w, http.StatusOK, publishKbResponse{
-    Ok:         true,
-    Status:     "published",
-    CommitHash: commitHash,
-    Files:      files,
-  })
+	writeJSON(w, http.StatusOK, publishKbResponse{
+		Ok:         true,
+		Status:     "published",
+		CommitHash: commitHash,
+		Files:      files,
+	})
 }
 
 func (s *server) gitStatusEntries(ctx context.Context, paths ...string) ([]gitStatusEntry, error) {
-  args := []string{"git", "-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=all"}
-  if len(paths) > 0 {
-    args = append(args, "--")
-    args = append(args, paths...)
-  }
-  out, stderr, code, err := runCmd(ctx, s.workspace, args)
-  if err != nil || code != 0 {
-    msg := strings.TrimSpace(stderr)
-    if msg == "" {
-      msg = "git_status_failed"
-    }
-    return nil, errors.New(msg)
-  }
-  return parseGitStatus(out), nil
+	args := []string{"git", "-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=all"}
+	if len(paths) > 0 {
+		args = append(args, "--")
+		args = append(args, paths...)
+	}
+	out, stderr, code, err := runCmd(ctx, s.workspace, args)
+	if err != nil || code != 0 {
+		msg := strings.TrimSpace(stderr)
+		if msg == "" {
+			msg = "git_status_failed"
+		}
+		return nil, errors.New(msg)
+	}
+	return parseGitStatus(out), nil
 }
 
 func (s *server) listConflictFiles(ctx context.Context) []string {
-  entries, _ := s.gitStatusEntries(ctx)
-  var result []string
-  for _, e := range entries {
-    if e.Conflicted {
-      result = append(result, e.Path)
-    }
-  }
-  return result
+	entries, _ := s.gitStatusEntries(ctx)
+	var result []string
+	for _, e := range entries {
+		if e.Conflicted {
+			result = append(result, e.Path)
+		}
+	}
+	return result
 }
 
 func isUnrelatedHistoryError(message string) bool {
-  msg := strings.ToLower(message)
-  return strings.Contains(msg, "unrelated histories")
+	msg := strings.ToLower(message)
+	return strings.Contains(msg, "unrelated histories")
 }
 
 func (s *server) resolveKbBranch(ctx context.Context) string {
-  _, _, _, _ = runCmd(ctx, s.workspace, []string{
-    "git", "remote", "set-head", "kb", "-a",
-  })
+	_, _, _, _ = runCmd(ctx, s.workspace, []string{
+		"git", "remote", "set-head", "kb", "-a",
+	})
 
-  headOut, _, headCode, _ := runCmd(ctx, s.workspace, []string{
-    "git", "symbolic-ref", "-q", "--short", "refs/remotes/kb/HEAD",
-  })
-  headRef := strings.TrimSpace(headOut)
-  if headCode == 0 && strings.HasPrefix(headRef, "kb/") {
-    branch := strings.TrimPrefix(headRef, "kb/")
-    if branch != "" {
-      return branch
-    }
-  }
+	headOut, _, headCode, _ := runCmd(ctx, s.workspace, []string{
+		"git", "symbolic-ref", "-q", "--short", "refs/remotes/kb/HEAD",
+	})
+	headRef := strings.TrimSpace(headOut)
+	if headCode == 0 && strings.HasPrefix(headRef, "kb/") {
+		branch := strings.TrimPrefix(headRef, "kb/")
+		if branch != "" {
+			return branch
+		}
+	}
 
-  if s.remoteBranchExists(ctx, "main") {
-    return "main"
-  }
+	if s.remoteBranchExists(ctx, "main") {
+		return "main"
+	}
 
-  current := s.currentBranch(ctx)
-  if current != "" && s.remoteBranchExists(ctx, current) {
-    return current
-  }
+	current := s.currentBranch(ctx)
+	if current != "" && s.remoteBranchExists(ctx, current) {
+		return current
+	}
 
-  return "main"
+	return "main"
 }
 
 func (s *server) remoteBranchExists(ctx context.Context, branch string) bool {
-  _, _, code, _ := runCmd(ctx, s.workspace, []string{
-    "git", "show-ref", "--verify", "--quiet", "refs/remotes/kb/" + branch,
-  })
-  return code == 0
+	_, _, code, _ := runCmd(ctx, s.workspace, []string{
+		"git", "show-ref", "--verify", "--quiet", "refs/remotes/kb/" + branch,
+	})
+	return code == 0
 }
 
 func (s *server) currentBranch(ctx context.Context) string {
-  out, _, code, _ := runCmd(ctx, s.workspace, []string{
-    "git", "rev-parse", "--abbrev-ref", "HEAD",
-  })
-  if code != 0 {
-    return ""
-  }
-  branch := strings.TrimSpace(out)
-  if branch == "" || branch == "HEAD" {
-    return ""
-  }
-  return branch
+	out, _, code, _ := runCmd(ctx, s.workspace, []string{
+		"git", "rev-parse", "--abbrev-ref", "HEAD",
+	})
+	if code != 0 {
+		return ""
+	}
+	branch := strings.TrimSpace(out)
+	if branch == "" || branch == "HEAD" {
+		return ""
+	}
+	return branch
 }
 
 type gitStatusEntry struct {
-  Path      string
-  Status    string
-  Untracked bool
-  Conflicted bool
+	Path       string
+	Status     string
+	Untracked  bool
+	Conflicted bool
 }
 
 func isInternalWorkspacePath(path string) bool {
@@ -1398,215 +1409,224 @@ func isInternalWorkspacePath(path string) bool {
 }
 
 func parseGitStatus(output string) []gitStatusEntry {
-  raw := []byte(output)
-  if len(raw) == 0 {
-    return nil
-  }
-  parts := bytes.Split(raw, []byte{0})
-  results := make([]gitStatusEntry, 0, len(parts))
-  for i := 0; i < len(parts); i++ {
-    entry := parts[i]
-    if len(entry) == 0 {
-      continue
-    }
-    // git status --porcelain=v1 -z output is:
-    //   XY<space>PATH\0
-    // where X and Y can be spaces. Do NOT split on the first space.
-    if len(entry) < 4 {
-      continue
-    }
-    statusField := string(entry[:2])
-    if statusField == "!!" {
-      continue
-    }
+	raw := []byte(output)
+	if len(raw) == 0 {
+		return nil
+	}
+	parts := bytes.Split(raw, []byte{0})
+	results := make([]gitStatusEntry, 0, len(parts))
+	for i := 0; i < len(parts); i++ {
+		entry := parts[i]
+		if len(entry) == 0 {
+			continue
+		}
+		// git status --porcelain=v1 -z output is:
+		//   XY<space>PATH\0
+		// where X and Y can be spaces. Do NOT split on the first space.
+		if len(entry) < 4 {
+			continue
+		}
+		statusField := string(entry[:2])
+		if statusField == "!!" {
+			continue
+		}
 
-    // After the two status characters there is a single space.
-    // We keep the raw path as-is (no TrimSpace) because it is a filename.
-    path := string(entry[3:])
+		// After the two status characters there is a single space.
+		// We keep the raw path as-is (no TrimSpace) because it is a filename.
+		path := string(entry[3:])
 
-    // For renames/copies, git status -z provides a second NUL-separated path.
-    // The first path is the source; the second is the destination.
-    if len(statusField) > 0 && (statusField[0] == 'R' || statusField[0] == 'C') {
-      if i+1 < len(parts) && len(parts[i+1]) > 0 {
-        path = string(parts[i+1])
-        i++
-      }
-    }
+		// For renames/copies, git status -z provides a second NUL-separated path.
+		// The first path is the source; the second is the destination.
+		if len(statusField) > 0 && (statusField[0] == 'R' || statusField[0] == 'C') {
+			if i+1 < len(parts) && len(parts[i+1]) > 0 {
+				path = string(parts[i+1])
+				i++
+			}
+		}
 
-    if path == "" {
-      continue
-    }
-    if isInternalWorkspacePath(path) {
-      continue
-    }
+		if path == "" {
+			continue
+		}
+		if isInternalWorkspacePath(path) {
+			continue
+		}
 
-    untracked := statusField == "??"
-    conflicted := strings.Contains(statusField, "U") || statusField == "AA" || statusField == "DD"
-    fileStatus := "modified"
-    if untracked || strings.Contains(statusField, "A") || (len(statusField) > 0 && statusField[0] == 'C') {
-      fileStatus = "added"
-    } else if strings.Contains(statusField, "D") {
-      fileStatus = "deleted"
-    }
+		untracked := statusField == "??"
+		conflicted := strings.Contains(statusField, "U") || statusField == "AA" || statusField == "DD"
+		fileStatus := "modified"
+		if untracked || strings.Contains(statusField, "A") || (len(statusField) > 0 && statusField[0] == 'C') {
+			fileStatus = "added"
+		} else if strings.Contains(statusField, "D") {
+			fileStatus = "deleted"
+		}
 
-    results = append(results, gitStatusEntry{
-      Path:      path,
-      Status:    fileStatus,
-      Untracked: untracked,
-      Conflicted: conflicted,
-    })
-  }
-  return results
+		results = append(results, gitStatusEntry{
+			Path:       path,
+			Status:     fileStatus,
+			Untracked:  untracked,
+			Conflicted: conflicted,
+		})
+	}
+	return results
 }
 
 func parseNumstat(output string) (int, int) {
-  line := ""
-  for _, candidate := range strings.Split(strings.TrimSpace(output), "\n") {
-    if strings.TrimSpace(candidate) != "" {
-      line = candidate
-      break
-    }
-  }
-  if line == "" {
-    return 0, 0
-  }
-  fields := strings.Split(line, "\t")
-  if len(fields) < 2 {
-    return 0, 0
-  }
-  add := parseNum(fields[0])
-  del := parseNum(fields[1])
-  return add, del
+	line := ""
+	for _, candidate := range strings.Split(strings.TrimSpace(output), "\n") {
+		if strings.TrimSpace(candidate) != "" {
+			line = candidate
+			break
+		}
+	}
+	if line == "" {
+		return 0, 0
+	}
+	fields := strings.Split(line, "\t")
+	if len(fields) < 2 {
+		return 0, 0
+	}
+	add := parseNum(fields[0])
+	del := parseNum(fields[1])
+	return add, del
 }
 
 func parseNum(value string) int {
-  if value == "-" {
-    return 0
-  }
-  parsed, err := strconv.Atoi(value)
-  if err != nil {
-    return 0
-  }
-  return parsed
+	if value == "-" {
+		return 0
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0
+	}
+	return parsed
 }
 
 func splitLines(output string) []string {
-  lines := strings.Split(output, "\n")
-  result := make([]string, 0, len(lines))
-  for _, line := range lines {
-    trimmed := strings.TrimSpace(line)
-    if trimmed != "" {
-      result = append(result, trimmed)
-    }
-  }
-  return result
+	lines := strings.Split(output, "\n")
+	result := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }
 
 func generateCommitMessage(statOutput string) string {
-  lines := splitLines(statOutput)
-  fileNames := make([]string, 0, len(lines))
+	lines := splitLines(statOutput)
+	fileNames := make([]string, 0, len(lines))
 
-  for _, line := range lines {
-    if !strings.Contains(line, "|") {
-      continue
-    }
-    parts := strings.Split(line, "|")
-    if len(parts) == 0 {
-      continue
-    }
-    name := strings.TrimSpace(parts[0])
-    if name != "" {
-      fileNames = append(fileNames, name)
-    }
-  }
+	for _, line := range lines {
+		if !strings.Contains(line, "|") {
+			continue
+		}
+		parts := strings.Split(line, "|")
+		if len(parts) == 0 {
+			continue
+		}
+		name := strings.TrimSpace(parts[0])
+		if name != "" {
+			fileNames = append(fileNames, name)
+		}
+	}
 
-  if len(fileNames) == 0 {
-    return "Update files"
-  }
-  if len(fileNames) <= 3 {
-    return "Update " + strings.Join(fileNames, ", ")
-  }
-  return "Update " + strconv.Itoa(len(fileNames)) + " files"
+	if len(fileNames) == 0 {
+		return "Update files"
+	}
+	if len(fileNames) <= 3 {
+		return "Update " + strings.Join(fileNames, ", ")
+	}
+	return "Update " + strconv.Itoa(len(fileNames)) + " files"
 }
 
 func runCmd(ctx context.Context, dir string, args []string) (string, string, int, error) {
-  if len(args) == 0 {
-    return "", "", 1, errors.New("no_command")
-  }
-  cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-  cmd.Dir = dir
-  var stdout bytes.Buffer
-  var stderr bytes.Buffer
-  cmd.Stdout = &stdout
-  cmd.Stderr = &stderr
-  err := cmd.Run()
-  if err != nil {
-    var exitErr *exec.ExitError
-    if errors.As(err, &exitErr) {
-      return stdout.String(), stderr.String(), exitErr.ExitCode(), nil
-    }
-    return stdout.String(), stderr.String(), 1, err
-  }
-  return stdout.String(), stderr.String(), 0, nil
+	if len(args) == 0 {
+		return "", "", 1, errors.New("no_command")
+	}
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Dir = dir
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return stdout.String(), stderr.String(), exitErr.ExitCode(), nil
+		}
+		return stdout.String(), stderr.String(), 1, err
+	}
+	return stdout.String(), stderr.String(), 0, nil
 }
 
 func (s *server) readGitStage(ctx context.Context, stage int, relPath string) (string, error) {
-  spec := ":" + strconv.Itoa(stage) + ":" + relPath
-  out, _, code, execErr := runCmd(ctx, s.workspace, []string{
-    "git", "show", spec,
-  })
-  if execErr != nil {
-    return "", execErr
-  }
-  if code != 0 {
-    return "", nil
-  }
-  return out, nil
+	spec := ":" + strconv.Itoa(stage) + ":" + relPath
+	out, _, code, execErr := runCmd(ctx, s.workspace, []string{
+		"git", "show", spec,
+	})
+	if execErr != nil {
+		return "", execErr
+	}
+	if code != 0 {
+		return "", nil
+	}
+	return out, nil
 }
 
 func (s *server) resolveRelPath(rel string) (string, string, error) {
-  abs, err := s.resolvePath(rel)
-  if err != nil {
-    return "", "", err
-  }
-  workspaceAbs, err := filepath.Abs(s.workspace)
-  if err != nil {
-    return "", "", errors.New("workspace_invalid")
-  }
-  relPath, err := filepath.Rel(workspaceAbs, abs)
-  if err != nil {
-    return "", "", errors.New("invalid_path")
-  }
-  if relPath == "." || relPath == "" {
-    return "", "", errors.New("invalid_path")
-  }
-  return filepath.ToSlash(relPath), abs, nil
+	abs, err := s.resolvePath(rel)
+	if err != nil {
+		return "", "", err
+	}
+	relPath, err := s.relPathForAbs(abs)
+	if err != nil {
+		return "", "", err
+	}
+	return relPath, abs, nil
+}
+
+func (s *server) relPathForAbs(abs string) (string, error) {
+	workspaceAbs, err := filepath.Abs(s.workspace)
+	if err != nil {
+		return "", errors.New("workspace_invalid")
+	}
+	relPath, err := filepath.Rel(workspaceAbs, abs)
+	if err != nil {
+		return "", errors.New("invalid_path")
+	}
+	if relPath == "." || relPath == "" {
+		return "", errors.New("invalid_path")
+	}
+	return filepath.ToSlash(relPath), nil
 }
 
 func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
-  dir := filepath.Dir(path)
-  temp, err := os.CreateTemp(dir, ".tmp-*")
-  if err != nil {
-    return err
-  }
-  tempName := temp.Name()
-  defer os.Remove(tempName)
+	dir := filepath.Dir(path)
+	temp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempName := temp.Name()
+	defer os.Remove(tempName)
 
-  if _, err := temp.Write(data); err != nil {
-    temp.Close()
-    return err
-  }
-  if err := temp.Chmod(perm); err != nil {
-    temp.Close()
-    return err
-  }
-  if err := temp.Close(); err != nil {
-    return err
-  }
-  return os.Rename(tempName, path)
+	if _, err := temp.Write(data); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Chmod(perm); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempName, path)
 }
 
 type streamedFileResult struct {
+	Path string
 	Size int64
 	Hash string
 }
@@ -1632,92 +1652,117 @@ func writeStreamFileAtomic(path string, reader io.Reader, perm os.FileMode) (str
 	if err := temp.Close(); err != nil {
 		return streamedFileResult{}, err
 	}
-	if err := os.Rename(tempName, path); err != nil {
+	finalPath, err := linkFileToUniquePath(tempName, path)
+	if err != nil {
 		return streamedFileResult{}, err
 	}
 
 	return streamedFileResult{
+		Path: finalPath,
 		Size: size,
 		Hash: "sha256:" + hex.EncodeToString(hasher.Sum(nil)),
 	}, nil
 }
 
+func linkFileToUniquePath(tempPath string, path string) (string, error) {
+	candidate := path
+	for attempt := 0; attempt < 10000; attempt += 1 {
+		if err := os.Link(tempPath, candidate); err == nil {
+			return candidate, nil
+		} else if !errors.Is(err, os.ErrExist) {
+			return "", err
+		}
+
+		candidate = nextUniquePath(path, attempt+1)
+	}
+
+	return "", errors.New("unique_path_exhausted")
+}
+
+func nextUniquePath(path string, index int) string {
+	dir := filepath.Dir(path)
+	name := filepath.Base(path)
+	ext := filepath.Ext(name)
+	base := strings.TrimSuffix(name, ext)
+	return filepath.Join(dir, base+" ("+strconv.Itoa(index)+")"+ext)
+}
+
 func verifyExpectedHash(path string, expected string) (string, bool, error) {
-  data, err := os.ReadFile(path)
-  if err != nil {
-    return "", false, err
-  }
-  currentHash := hashBytes(data)
-  return currentHash, expected == currentHash, nil
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false, err
+	}
+	currentHash := hashBytes(data)
+	return currentHash, expected == currentHash, nil
 }
 
 func hashBytes(data []byte) string {
-  sum := sha256.Sum256(data)
-  return "sha256:" + hex.EncodeToString(sum[:])
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func encodeContent(data []byte) (string, string) {
-  if utf8.Valid(data) {
-    return string(data), "utf-8"
-  }
-  return base64.StdEncoding.EncodeToString(data), "base64"
+	if utf8.Valid(data) {
+		return string(data), "utf-8"
+	}
+	return base64.StdEncoding.EncodeToString(data), "base64"
 }
 
 func decodeJSON(w http.ResponseWriter, r *http.Request, target any) error {
-  r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
-  decoder := json.NewDecoder(r.Body)
-  if err := decoder.Decode(target); err != nil {
-    return err
-  }
-  if err := decoder.Decode(&struct{}{}); err != nil && !errors.Is(err, io.EOF) {
-    return errors.New("unexpected_data")
-  }
-  return nil
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != nil && !errors.Is(err, io.EOF) {
+		return errors.New("unexpected_data")
+	}
+	return nil
 }
 
 func writeJSON(w http.ResponseWriter, status int, payload any) {
-  w.Header().Set("Content-Type", "application/json")
-  w.WriteHeader(status)
-  encoder := json.NewEncoder(w)
-  encoder.SetEscapeHTML(false)
-  _ = encoder.Encode(payload)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	_ = encoder.Encode(payload)
 }
 
 func writeError(w http.ResponseWriter, status int, message string) {
-  writeJSON(w, status, errorResponse{Ok: false, Error: message})
+	writeJSON(w, status, errorResponse{Ok: false, Error: message})
 }
 
 func (s *server) resolvePath(rel string) (string, error) {
-  if strings.TrimSpace(rel) == "" {
-    return "", errors.New("path_required")
-  }
-  if strings.Contains(rel, "\x00") {
-    return "", errors.New("invalid_path")
-  }
-  if filepath.IsAbs(rel) {
-    return "", errors.New("absolute_paths_not_allowed")
-  }
+	if strings.TrimSpace(rel) == "" {
+		return "", errors.New("path_required")
+	}
+	if strings.Contains(rel, "\x00") {
+		return "", errors.New("invalid_path")
+	}
+	if filepath.IsAbs(rel) {
+		return "", errors.New("absolute_paths_not_allowed")
+	}
 
-  cleaned := filepath.Clean(rel)
-  if cleaned == "." || cleaned == "" {
-    return "", errors.New("invalid_path")
-  }
-  if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(os.PathSeparator)) {
-    return "", errors.New("path_outside_workspace")
-  }
-  if cleaned == ".git" || strings.HasPrefix(cleaned, ".git"+string(os.PathSeparator)) {
-    return "", errors.New("git_dir_not_allowed")
-  }
+	cleaned := filepath.Clean(rel)
+	if cleaned == "." || cleaned == "" {
+		return "", errors.New("invalid_path")
+	}
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(os.PathSeparator)) {
+		return "", errors.New("path_outside_workspace")
+	}
+	if cleaned == ".git" || strings.HasPrefix(cleaned, ".git"+string(os.PathSeparator)) {
+		return "", errors.New("git_dir_not_allowed")
+	}
 
-  workspaceAbs, err := filepath.Abs(s.workspace)
-  if err != nil {
-    return "", errors.New("workspace_invalid")
-  }
-  abs := filepath.Join(workspaceAbs, cleaned)
-  abs, err = filepath.Abs(abs)
-  if err != nil {
-    return "", errors.New("invalid_path")
-  }
+	workspaceAbs, err := filepath.Abs(s.workspace)
+	if err != nil {
+		return "", errors.New("workspace_invalid")
+	}
+	abs := filepath.Join(workspaceAbs, cleaned)
+	abs, err = filepath.Abs(abs)
+	if err != nil {
+		return "", errors.New("invalid_path")
+	}
 
 	if !strings.HasPrefix(abs+string(os.PathSeparator), workspaceAbs+string(os.PathSeparator)) && abs != workspaceAbs {
 		return "", errors.New("path_outside_workspace")
@@ -1742,17 +1787,17 @@ func (s *server) ensurePathWithinWorkspace(absPath string) error {
 }
 
 func getenv(key, fallback string) string {
-  value := os.Getenv(key)
-  if value == "" {
-    return fallback
-  }
-  return value
+	value := os.Getenv(key)
+	if value == "" {
+		return fallback
+	}
+	return value
 }
 
 func logRequests(next http.Handler) http.Handler {
-  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-    start := time.Now()
-    next.ServeHTTP(w, r)
-    log.Printf("%s %s %s", r.Method, r.URL.Path, time.Since(start))
-  })
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		next.ServeHTTP(w, r)
+		log.Printf("%s %s %s", r.Method, r.URL.Path, time.Since(start))
+	})
 }

--- a/infra/workspace-image/workspace-agent/main_test.go
+++ b/infra/workspace-image/workspace-agent/main_test.go
@@ -1,159 +1,239 @@
 package main
 
 import (
-  "encoding/base64"
-  "encoding/json"
-  "context"
-  "net/http"
-  "net/http/httptest"
-  "os"
-  "path/filepath"
-  "strings"
-  "testing"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
 )
 
 func TestGitStatusEntriesReturnsNestedUntrackedFiles(t *testing.T) {
-  workspace := t.TempDir()
-  ctx := context.Background()
+	workspace := t.TempDir()
+	ctx := context.Background()
 
-  runGit(t, ctx, workspace, "init", "-b", "main")
-  runGit(t, ctx, workspace, "config", "user.email", "tests@example.com")
-  runGit(t, ctx, workspace, "config", "user.name", "Workspace Agent Tests")
+	runGit(t, ctx, workspace, "init", "-b", "main")
+	runGit(t, ctx, workspace, "config", "user.email", "tests@example.com")
+	runGit(t, ctx, workspace, "config", "user.name", "Workspace Agent Tests")
 
-  baselineFile := filepath.Join(workspace, "README.md")
-  if err := os.WriteFile(baselineFile, []byte("baseline\n"), 0o644); err != nil {
-    t.Fatalf("write baseline file: %v", err)
-  }
+	baselineFile := filepath.Join(workspace, "README.md")
+	if err := os.WriteFile(baselineFile, []byte("baseline\n"), 0o644); err != nil {
+		t.Fatalf("write baseline file: %v", err)
+	}
 
-  runGit(t, ctx, workspace, "add", "README.md")
-  runGit(t, ctx, workspace, "commit", "-m", "baseline")
+	runGit(t, ctx, workspace, "add", "README.md")
+	runGit(t, ctx, workspace, "commit", "-m", "baseline")
 
-  nestedPath := filepath.Join(workspace, "Outputs", "Communications", "2026-02-12 - Summary.md")
-  if err := os.MkdirAll(filepath.Dir(nestedPath), 0o755); err != nil {
-    t.Fatalf("create nested directory: %v", err)
-  }
-  if err := os.WriteFile(nestedPath, []byte("content\n"), 0o644); err != nil {
-    t.Fatalf("write nested file: %v", err)
-  }
+	nestedPath := filepath.Join(workspace, "Outputs", "Communications", "2026-02-12 - Summary.md")
+	if err := os.MkdirAll(filepath.Dir(nestedPath), 0o755); err != nil {
+		t.Fatalf("create nested directory: %v", err)
+	}
+	if err := os.WriteFile(nestedPath, []byte("content\n"), 0o644); err != nil {
+		t.Fatalf("write nested file: %v", err)
+	}
 
-  s := &server{workspace: workspace}
-  entries, err := s.gitStatusEntries(ctx)
-  if err != nil {
-    t.Fatalf("gitStatusEntries failed: %v", err)
-  }
+	s := &server{workspace: workspace}
+	entries, err := s.gitStatusEntries(ctx)
+	if err != nil {
+		t.Fatalf("gitStatusEntries failed: %v", err)
+	}
 
-  expected := filepath.ToSlash("Outputs/Communications/2026-02-12 - Summary.md")
-  for _, entry := range entries {
-    if entry.Path == expected {
-      if entry.Untracked != true {
-        t.Fatalf("expected untracked entry for %q", expected)
-      }
-      if entry.Status != "added" {
-        t.Fatalf("expected status added for %q, got %q", expected, entry.Status)
-      }
-      return
-    }
-  }
+	expected := filepath.ToSlash("Outputs/Communications/2026-02-12 - Summary.md")
+	for _, entry := range entries {
+		if entry.Path == expected {
+			if entry.Untracked != true {
+				t.Fatalf("expected untracked entry for %q", expected)
+			}
+			if entry.Status != "added" {
+				t.Fatalf("expected status added for %q, got %q", expected, entry.Status)
+			}
+			return
+		}
+	}
 
-  t.Fatalf("expected nested untracked file %q in status entries: %#v", expected, entries)
+	t.Fatalf("expected nested untracked file %q in status entries: %#v", expected, entries)
 }
 
 func runGit(t *testing.T, ctx context.Context, dir string, args ...string) {
-  t.Helper()
+	t.Helper()
 
-  command := append([]string{"git"}, args...)
-  _, stderr, code, err := runCmd(ctx, dir, command)
-  if err != nil {
-    t.Fatalf("git command failed (%v): %v", command, err)
-  }
-  if code != 0 {
-    t.Fatalf("git command exited with code %d (%v): %s", code, command, stderr)
-  }
+	command := append([]string{"git"}, args...)
+	_, stderr, code, err := runCmd(ctx, dir, command)
+	if err != nil {
+		t.Fatalf("git command failed (%v): %v", command, err)
+	}
+	if code != 0 {
+		t.Fatalf("git command exited with code %d (%v): %s", code, command, stderr)
+	}
 }
 
 func TestIsInternalWorkspacePath(t *testing.T) {
-  cases := []struct {
-    name string
-    path string
-    want bool
-  }{
-    {name: "dot arche", path: ".arche", want: true},
-    {name: "attachments file", path: ".arche/attachments/file.txt", want: true},
-    {name: "normal file", path: "normal/file.txt", want: false},
-    {name: "empty", path: "", want: false},
-    {name: "duplicate slashes", path: ".arche//attachments/file.txt", want: true},
-  }
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "dot arche", path: ".arche", want: true},
+		{name: "attachments file", path: ".arche/attachments/file.txt", want: true},
+		{name: "normal file", path: "normal/file.txt", want: false},
+		{name: "empty", path: "", want: false},
+		{name: "duplicate slashes", path: ".arche//attachments/file.txt", want: true},
+	}
 
-  for _, tc := range cases {
-    t.Run(tc.name, func(t *testing.T) {
-      got := isInternalWorkspacePath(tc.path)
-      if got != tc.want {
-        t.Fatalf("isInternalWorkspacePath(%q) = %v, want %v", tc.path, got, tc.want)
-      }
-    })
-  }
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isInternalWorkspacePath(tc.path)
+			if got != tc.want {
+				t.Fatalf("isInternalWorkspacePath(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
 }
 
 func TestFileHandlersHappyPath(t *testing.T) {
-  workspace := t.TempDir()
-  s := &server{workspace: workspace}
+	workspace := t.TempDir()
+	s := &server{workspace: workspace}
 
-  t.Run("handleFileWrite base64", func(t *testing.T) {
-    payload := map[string]string{
-      "path":     ".arche/attachments/hello.txt",
-      "content":  base64.StdEncoding.EncodeToString([]byte("hello world")),
-      "encoding": "base64",
-    }
-    req := httptest.NewRequest(http.MethodPost, "/files/write", strings.NewReader(mustJSON(t, payload)))
-    recorder := httptest.NewRecorder()
+	t.Run("handleFileWrite base64", func(t *testing.T) {
+		payload := map[string]string{
+			"path":     ".arche/attachments/hello.txt",
+			"content":  base64.StdEncoding.EncodeToString([]byte("hello world")),
+			"encoding": "base64",
+		}
+		req := httptest.NewRequest(http.MethodPost, "/files/write", strings.NewReader(mustJSON(t, payload)))
+		recorder := httptest.NewRecorder()
 
-    s.handleFileWrite(recorder, req)
+		s.handleFileWrite(recorder, req)
 
-    if recorder.Code != http.StatusOK {
-      t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
-    }
-  })
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+		}
+	})
 
-  t.Run("handleFileList", func(t *testing.T) {
-    req := httptest.NewRequest(http.MethodPost, "/files/list", strings.NewReader(`{"path":".arche/attachments","recursive":false}`))
-    recorder := httptest.NewRecorder()
+	t.Run("handleFileList", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/files/list", strings.NewReader(`{"path":".arche/attachments","recursive":false}`))
+		recorder := httptest.NewRecorder()
 
-    s.handleFileList(recorder, req)
+		s.handleFileList(recorder, req)
 
-    if recorder.Code != http.StatusOK {
-      t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
-    }
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+		}
 
-    var response fileListResponse
-    if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
-      t.Fatalf("decode response: %v", err)
-    }
-    if !response.Ok || len(response.Entries) != 1 {
-      t.Fatalf("unexpected list response: %+v", response)
-    }
-  })
+		var response fileListResponse
+		if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if !response.Ok || len(response.Entries) != 1 {
+			t.Fatalf("unexpected list response: %+v", response)
+		}
+	})
 
-  t.Run("handleFileRename", func(t *testing.T) {
-    req := httptest.NewRequest(http.MethodPost, "/files/rename", strings.NewReader(`{"path":".arche/attachments/hello.txt","newPath":".arche/attachments/renamed.txt"}`))
-    recorder := httptest.NewRecorder()
+	t.Run("handleFileRename", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/files/rename", strings.NewReader(`{"path":".arche/attachments/hello.txt","newPath":".arche/attachments/renamed.txt"}`))
+		recorder := httptest.NewRecorder()
 
-    s.handleFileRename(recorder, req)
+		s.handleFileRename(recorder, req)
 
-    if recorder.Code != http.StatusOK {
-      t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
-    }
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+		}
 
-    if _, err := os.Stat(filepath.Join(workspace, ".arche", "attachments", "renamed.txt")); err != nil {
-      t.Fatalf("renamed file missing: %v", err)
-    }
-  })
+		if _, err := os.Stat(filepath.Join(workspace, ".arche", "attachments", "renamed.txt")); err != nil {
+			t.Fatalf("renamed file missing: %v", err)
+		}
+	})
+}
+
+func TestHandleFileUploadWritesStreamedFile(t *testing.T) {
+	workspace := t.TempDir()
+	s := &server{workspace: workspace}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/files/upload?path=.arche/attachments/upload.bin",
+		strings.NewReader("streamed upload"),
+	)
+	recorder := httptest.NewRecorder()
+
+	s.handleFileUpload(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+
+	var response fileUploadResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if !response.Ok {
+		t.Fatalf("expected ok response: %+v", response)
+	}
+	if response.Path != ".arche/attachments/upload.bin" {
+		t.Fatalf("path = %q", response.Path)
+	}
+	if response.Size != int64(len("streamed upload")) {
+		t.Fatalf("size = %d", response.Size)
+	}
+
+	expectedSum := sha256.Sum256([]byte("streamed upload"))
+	expectedHash := "sha256:" + hex.EncodeToString(expectedSum[:])
+	if response.Hash != expectedHash {
+		t.Fatalf("hash = %q, want %q", response.Hash, expectedHash)
+	}
+	if response.ModifiedAt <= 0 {
+		t.Fatalf("modifiedAt = %d", response.ModifiedAt)
+	}
+
+	data, err := os.ReadFile(filepath.Join(workspace, ".arche", "attachments", "upload.bin"))
+	if err != nil {
+		t.Fatalf("read uploaded file: %v", err)
+	}
+	if string(data) != "streamed upload" {
+		t.Fatalf("uploaded data = %q", string(data))
+	}
+}
+
+func TestHandleFileUploadRejectsOversizedBody(t *testing.T) {
+	workspace := t.TempDir()
+	s := &server{workspace: workspace}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/files/upload?path=.arche/attachments/too-big.bin",
+		strings.NewReader(strings.Repeat("x", maxUploadBodyBytes+1)),
+	)
+	req.Header.Set("Content-Length", strconv.Itoa(maxUploadBodyBytes+1))
+	recorder := httptest.NewRecorder()
+
+	s.handleFileUpload(recorder, req)
+
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+
+	var response errorResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Error != "file_too_large" {
+		t.Fatalf("error = %q", response.Error)
+	}
 }
 
 func mustJSON(t *testing.T, value any) string {
-  t.Helper()
-  encoded, err := json.Marshal(value)
-  if err != nil {
-    t.Fatalf("marshal json: %v", err)
-  }
-  return string(encoded)
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal json: %v", err)
+	}
+	return string(encoded)
 }

--- a/infra/workspace-image/workspace-agent/main_test.go
+++ b/infra/workspace-image/workspace-agent/main_test.go
@@ -3,153 +3,153 @@ package main
 import (
 	"context"
 	"crypto/sha256"
-  "encoding/base64"
+	"encoding/base64"
 	"encoding/hex"
-  "encoding/json"
-  "net/http"
-  "net/http/httptest"
-  "os"
-  "path/filepath"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strconv"
-  "strings"
-  "testing"
+	"strings"
+	"testing"
 )
 
 func TestGitStatusEntriesReturnsNestedUntrackedFiles(t *testing.T) {
-  workspace := t.TempDir()
-  ctx := context.Background()
+	workspace := t.TempDir()
+	ctx := context.Background()
 
-  runGit(t, ctx, workspace, "init", "-b", "main")
-  runGit(t, ctx, workspace, "config", "user.email", "tests@example.com")
-  runGit(t, ctx, workspace, "config", "user.name", "Workspace Agent Tests")
+	runGit(t, ctx, workspace, "init", "-b", "main")
+	runGit(t, ctx, workspace, "config", "user.email", "tests@example.com")
+	runGit(t, ctx, workspace, "config", "user.name", "Workspace Agent Tests")
 
-  baselineFile := filepath.Join(workspace, "README.md")
-  if err := os.WriteFile(baselineFile, []byte("baseline\n"), 0o644); err != nil {
-    t.Fatalf("write baseline file: %v", err)
-  }
+	baselineFile := filepath.Join(workspace, "README.md")
+	if err := os.WriteFile(baselineFile, []byte("baseline\n"), 0o644); err != nil {
+		t.Fatalf("write baseline file: %v", err)
+	}
 
-  runGit(t, ctx, workspace, "add", "README.md")
-  runGit(t, ctx, workspace, "commit", "-m", "baseline")
+	runGit(t, ctx, workspace, "add", "README.md")
+	runGit(t, ctx, workspace, "commit", "-m", "baseline")
 
-  nestedPath := filepath.Join(workspace, "Outputs", "Communications", "2026-02-12 - Summary.md")
-  if err := os.MkdirAll(filepath.Dir(nestedPath), 0o755); err != nil {
-    t.Fatalf("create nested directory: %v", err)
-  }
-  if err := os.WriteFile(nestedPath, []byte("content\n"), 0o644); err != nil {
-    t.Fatalf("write nested file: %v", err)
-  }
+	nestedPath := filepath.Join(workspace, "Outputs", "Communications", "2026-02-12 - Summary.md")
+	if err := os.MkdirAll(filepath.Dir(nestedPath), 0o755); err != nil {
+		t.Fatalf("create nested directory: %v", err)
+	}
+	if err := os.WriteFile(nestedPath, []byte("content\n"), 0o644); err != nil {
+		t.Fatalf("write nested file: %v", err)
+	}
 
-  s := &server{workspace: workspace}
-  entries, err := s.gitStatusEntries(ctx)
-  if err != nil {
-    t.Fatalf("gitStatusEntries failed: %v", err)
-  }
+	s := &server{workspace: workspace}
+	entries, err := s.gitStatusEntries(ctx)
+	if err != nil {
+		t.Fatalf("gitStatusEntries failed: %v", err)
+	}
 
-  expected := filepath.ToSlash("Outputs/Communications/2026-02-12 - Summary.md")
-  for _, entry := range entries {
-    if entry.Path == expected {
-      if entry.Untracked != true {
-        t.Fatalf("expected untracked entry for %q", expected)
-      }
-      if entry.Status != "added" {
-        t.Fatalf("expected status added for %q, got %q", expected, entry.Status)
-      }
-      return
-    }
-  }
+	expected := filepath.ToSlash("Outputs/Communications/2026-02-12 - Summary.md")
+	for _, entry := range entries {
+		if entry.Path == expected {
+			if entry.Untracked != true {
+				t.Fatalf("expected untracked entry for %q", expected)
+			}
+			if entry.Status != "added" {
+				t.Fatalf("expected status added for %q, got %q", expected, entry.Status)
+			}
+			return
+		}
+	}
 
-  t.Fatalf("expected nested untracked file %q in status entries: %#v", expected, entries)
+	t.Fatalf("expected nested untracked file %q in status entries: %#v", expected, entries)
 }
 
 func runGit(t *testing.T, ctx context.Context, dir string, args ...string) {
-  t.Helper()
+	t.Helper()
 
-  command := append([]string{"git"}, args...)
-  _, stderr, code, err := runCmd(ctx, dir, command)
-  if err != nil {
-    t.Fatalf("git command failed (%v): %v", command, err)
-  }
-  if code != 0 {
-    t.Fatalf("git command exited with code %d (%v): %s", code, command, stderr)
-  }
+	command := append([]string{"git"}, args...)
+	_, stderr, code, err := runCmd(ctx, dir, command)
+	if err != nil {
+		t.Fatalf("git command failed (%v): %v", command, err)
+	}
+	if code != 0 {
+		t.Fatalf("git command exited with code %d (%v): %s", code, command, stderr)
+	}
 }
 
 func TestIsInternalWorkspacePath(t *testing.T) {
-  cases := []struct {
-    name string
-    path string
-    want bool
-  }{
-    {name: "dot arche", path: ".arche", want: true},
-    {name: "attachments file", path: ".arche/attachments/file.txt", want: true},
-    {name: "normal file", path: "normal/file.txt", want: false},
-    {name: "empty", path: "", want: false},
-    {name: "duplicate slashes", path: ".arche//attachments/file.txt", want: true},
-  }
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "dot arche", path: ".arche", want: true},
+		{name: "attachments file", path: ".arche/attachments/file.txt", want: true},
+		{name: "normal file", path: "normal/file.txt", want: false},
+		{name: "empty", path: "", want: false},
+		{name: "duplicate slashes", path: ".arche//attachments/file.txt", want: true},
+	}
 
-  for _, tc := range cases {
-    t.Run(tc.name, func(t *testing.T) {
-      got := isInternalWorkspacePath(tc.path)
-      if got != tc.want {
-        t.Fatalf("isInternalWorkspacePath(%q) = %v, want %v", tc.path, got, tc.want)
-      }
-    })
-  }
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isInternalWorkspacePath(tc.path)
+			if got != tc.want {
+				t.Fatalf("isInternalWorkspacePath(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
 }
 
 func TestFileHandlersHappyPath(t *testing.T) {
-  workspace := t.TempDir()
-  s := &server{workspace: workspace}
+	workspace := t.TempDir()
+	s := &server{workspace: workspace}
 
-  t.Run("handleFileWrite base64", func(t *testing.T) {
-    payload := map[string]string{
-      "path":     ".arche/attachments/hello.txt",
-      "content":  base64.StdEncoding.EncodeToString([]byte("hello world")),
-      "encoding": "base64",
-    }
-    req := httptest.NewRequest(http.MethodPost, "/files/write", strings.NewReader(mustJSON(t, payload)))
-    recorder := httptest.NewRecorder()
+	t.Run("handleFileWrite base64", func(t *testing.T) {
+		payload := map[string]string{
+			"path":     ".arche/attachments/hello.txt",
+			"content":  base64.StdEncoding.EncodeToString([]byte("hello world")),
+			"encoding": "base64",
+		}
+		req := httptest.NewRequest(http.MethodPost, "/files/write", strings.NewReader(mustJSON(t, payload)))
+		recorder := httptest.NewRecorder()
 
-    s.handleFileWrite(recorder, req)
+		s.handleFileWrite(recorder, req)
 
-    if recorder.Code != http.StatusOK {
-      t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
-    }
-  })
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+		}
+	})
 
-  t.Run("handleFileList", func(t *testing.T) {
-    req := httptest.NewRequest(http.MethodPost, "/files/list", strings.NewReader(`{"path":".arche/attachments","recursive":false}`))
-    recorder := httptest.NewRecorder()
+	t.Run("handleFileList", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/files/list", strings.NewReader(`{"path":".arche/attachments","recursive":false}`))
+		recorder := httptest.NewRecorder()
 
-    s.handleFileList(recorder, req)
+		s.handleFileList(recorder, req)
 
-    if recorder.Code != http.StatusOK {
-      t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
-    }
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+		}
 
-    var response fileListResponse
-    if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
-      t.Fatalf("decode response: %v", err)
-    }
-    if !response.Ok || len(response.Entries) != 1 {
-      t.Fatalf("unexpected list response: %+v", response)
-    }
-  })
+		var response fileListResponse
+		if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if !response.Ok || len(response.Entries) != 1 {
+			t.Fatalf("unexpected list response: %+v", response)
+		}
+	})
 
-  t.Run("handleFileRename", func(t *testing.T) {
-    req := httptest.NewRequest(http.MethodPost, "/files/rename", strings.NewReader(`{"path":".arche/attachments/hello.txt","newPath":".arche/attachments/renamed.txt"}`))
-    recorder := httptest.NewRecorder()
+	t.Run("handleFileRename", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/files/rename", strings.NewReader(`{"path":".arche/attachments/hello.txt","newPath":".arche/attachments/renamed.txt"}`))
+		recorder := httptest.NewRecorder()
 
-    s.handleFileRename(recorder, req)
+		s.handleFileRename(recorder, req)
 
-    if recorder.Code != http.StatusOK {
-      t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
-    }
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+		}
 
-    if _, err := os.Stat(filepath.Join(workspace, ".arche", "attachments", "renamed.txt")); err != nil {
-      t.Fatalf("renamed file missing: %v", err)
-    }
-  })
+		if _, err := os.Stat(filepath.Join(workspace, ".arche", "attachments", "renamed.txt")); err != nil {
+			t.Fatalf("renamed file missing: %v", err)
+		}
+	})
 }
 
 func TestHandleFileUploadWritesStreamedFile(t *testing.T) {
@@ -229,11 +229,61 @@ func TestHandleFileUploadRejectsOversizedBody(t *testing.T) {
 	}
 }
 
+func TestHandleFileUploadKeepsExistingFileAndCreatesUniqueName(t *testing.T) {
+	workspace := t.TempDir()
+	s := &server{workspace: workspace}
+
+	originalPath := filepath.Join(workspace, ".arche", "attachments", "report.pdf")
+	if err := os.MkdirAll(filepath.Dir(originalPath), 0o755); err != nil {
+		t.Fatalf("create attachments directory: %v", err)
+	}
+	if err := os.WriteFile(originalPath, []byte("original"), 0o644); err != nil {
+		t.Fatalf("write original file: %v", err)
+	}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/files/upload?path=.arche/attachments/report.pdf",
+		strings.NewReader("replacement"),
+	)
+	recorder := httptest.NewRecorder()
+
+	s.handleFileUpload(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+
+	var response fileUploadResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Path != ".arche/attachments/report (1).pdf" {
+		t.Fatalf("path = %q", response.Path)
+	}
+
+	originalData, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatalf("read original file: %v", err)
+	}
+	if string(originalData) != "original" {
+		t.Fatalf("original data = %q", string(originalData))
+	}
+
+	uploadedData, err := os.ReadFile(filepath.Join(workspace, ".arche", "attachments", "report (1).pdf"))
+	if err != nil {
+		t.Fatalf("read uploaded file: %v", err)
+	}
+	if string(uploadedData) != "replacement" {
+		t.Fatalf("uploaded data = %q", string(uploadedData))
+	}
+}
+
 func mustJSON(t *testing.T, value any) string {
-  t.Helper()
-  encoded, err := json.Marshal(value)
-  if err != nil {
-    t.Fatalf("marshal json: %v", err)
-  }
-  return string(encoded)
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal json: %v", err)
+	}
+	return string(encoded)
 }

--- a/infra/workspace-image/workspace-agent/main_test.go
+++ b/infra/workspace-image/workspace-agent/main_test.go
@@ -3,153 +3,153 @@ package main
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/base64"
+  "encoding/base64"
 	"encoding/hex"
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"path/filepath"
+  "encoding/json"
+  "net/http"
+  "net/http/httptest"
+  "os"
+  "path/filepath"
 	"strconv"
-	"strings"
-	"testing"
+  "strings"
+  "testing"
 )
 
 func TestGitStatusEntriesReturnsNestedUntrackedFiles(t *testing.T) {
-	workspace := t.TempDir()
-	ctx := context.Background()
+  workspace := t.TempDir()
+  ctx := context.Background()
 
-	runGit(t, ctx, workspace, "init", "-b", "main")
-	runGit(t, ctx, workspace, "config", "user.email", "tests@example.com")
-	runGit(t, ctx, workspace, "config", "user.name", "Workspace Agent Tests")
+  runGit(t, ctx, workspace, "init", "-b", "main")
+  runGit(t, ctx, workspace, "config", "user.email", "tests@example.com")
+  runGit(t, ctx, workspace, "config", "user.name", "Workspace Agent Tests")
 
-	baselineFile := filepath.Join(workspace, "README.md")
-	if err := os.WriteFile(baselineFile, []byte("baseline\n"), 0o644); err != nil {
-		t.Fatalf("write baseline file: %v", err)
-	}
+  baselineFile := filepath.Join(workspace, "README.md")
+  if err := os.WriteFile(baselineFile, []byte("baseline\n"), 0o644); err != nil {
+    t.Fatalf("write baseline file: %v", err)
+  }
 
-	runGit(t, ctx, workspace, "add", "README.md")
-	runGit(t, ctx, workspace, "commit", "-m", "baseline")
+  runGit(t, ctx, workspace, "add", "README.md")
+  runGit(t, ctx, workspace, "commit", "-m", "baseline")
 
-	nestedPath := filepath.Join(workspace, "Outputs", "Communications", "2026-02-12 - Summary.md")
-	if err := os.MkdirAll(filepath.Dir(nestedPath), 0o755); err != nil {
-		t.Fatalf("create nested directory: %v", err)
-	}
-	if err := os.WriteFile(nestedPath, []byte("content\n"), 0o644); err != nil {
-		t.Fatalf("write nested file: %v", err)
-	}
+  nestedPath := filepath.Join(workspace, "Outputs", "Communications", "2026-02-12 - Summary.md")
+  if err := os.MkdirAll(filepath.Dir(nestedPath), 0o755); err != nil {
+    t.Fatalf("create nested directory: %v", err)
+  }
+  if err := os.WriteFile(nestedPath, []byte("content\n"), 0o644); err != nil {
+    t.Fatalf("write nested file: %v", err)
+  }
 
-	s := &server{workspace: workspace}
-	entries, err := s.gitStatusEntries(ctx)
-	if err != nil {
-		t.Fatalf("gitStatusEntries failed: %v", err)
-	}
+  s := &server{workspace: workspace}
+  entries, err := s.gitStatusEntries(ctx)
+  if err != nil {
+    t.Fatalf("gitStatusEntries failed: %v", err)
+  }
 
-	expected := filepath.ToSlash("Outputs/Communications/2026-02-12 - Summary.md")
-	for _, entry := range entries {
-		if entry.Path == expected {
-			if entry.Untracked != true {
-				t.Fatalf("expected untracked entry for %q", expected)
-			}
-			if entry.Status != "added" {
-				t.Fatalf("expected status added for %q, got %q", expected, entry.Status)
-			}
-			return
-		}
-	}
+  expected := filepath.ToSlash("Outputs/Communications/2026-02-12 - Summary.md")
+  for _, entry := range entries {
+    if entry.Path == expected {
+      if entry.Untracked != true {
+        t.Fatalf("expected untracked entry for %q", expected)
+      }
+      if entry.Status != "added" {
+        t.Fatalf("expected status added for %q, got %q", expected, entry.Status)
+      }
+      return
+    }
+  }
 
-	t.Fatalf("expected nested untracked file %q in status entries: %#v", expected, entries)
+  t.Fatalf("expected nested untracked file %q in status entries: %#v", expected, entries)
 }
 
 func runGit(t *testing.T, ctx context.Context, dir string, args ...string) {
-	t.Helper()
+  t.Helper()
 
-	command := append([]string{"git"}, args...)
-	_, stderr, code, err := runCmd(ctx, dir, command)
-	if err != nil {
-		t.Fatalf("git command failed (%v): %v", command, err)
-	}
-	if code != 0 {
-		t.Fatalf("git command exited with code %d (%v): %s", code, command, stderr)
-	}
+  command := append([]string{"git"}, args...)
+  _, stderr, code, err := runCmd(ctx, dir, command)
+  if err != nil {
+    t.Fatalf("git command failed (%v): %v", command, err)
+  }
+  if code != 0 {
+    t.Fatalf("git command exited with code %d (%v): %s", code, command, stderr)
+  }
 }
 
 func TestIsInternalWorkspacePath(t *testing.T) {
-	cases := []struct {
-		name string
-		path string
-		want bool
-	}{
-		{name: "dot arche", path: ".arche", want: true},
-		{name: "attachments file", path: ".arche/attachments/file.txt", want: true},
-		{name: "normal file", path: "normal/file.txt", want: false},
-		{name: "empty", path: "", want: false},
-		{name: "duplicate slashes", path: ".arche//attachments/file.txt", want: true},
-	}
+  cases := []struct {
+    name string
+    path string
+    want bool
+  }{
+    {name: "dot arche", path: ".arche", want: true},
+    {name: "attachments file", path: ".arche/attachments/file.txt", want: true},
+    {name: "normal file", path: "normal/file.txt", want: false},
+    {name: "empty", path: "", want: false},
+    {name: "duplicate slashes", path: ".arche//attachments/file.txt", want: true},
+  }
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := isInternalWorkspacePath(tc.path)
-			if got != tc.want {
-				t.Fatalf("isInternalWorkspacePath(%q) = %v, want %v", tc.path, got, tc.want)
-			}
-		})
-	}
+  for _, tc := range cases {
+    t.Run(tc.name, func(t *testing.T) {
+      got := isInternalWorkspacePath(tc.path)
+      if got != tc.want {
+        t.Fatalf("isInternalWorkspacePath(%q) = %v, want %v", tc.path, got, tc.want)
+      }
+    })
+  }
 }
 
 func TestFileHandlersHappyPath(t *testing.T) {
-	workspace := t.TempDir()
-	s := &server{workspace: workspace}
+  workspace := t.TempDir()
+  s := &server{workspace: workspace}
 
-	t.Run("handleFileWrite base64", func(t *testing.T) {
-		payload := map[string]string{
-			"path":     ".arche/attachments/hello.txt",
-			"content":  base64.StdEncoding.EncodeToString([]byte("hello world")),
-			"encoding": "base64",
-		}
-		req := httptest.NewRequest(http.MethodPost, "/files/write", strings.NewReader(mustJSON(t, payload)))
-		recorder := httptest.NewRecorder()
+  t.Run("handleFileWrite base64", func(t *testing.T) {
+    payload := map[string]string{
+      "path":     ".arche/attachments/hello.txt",
+      "content":  base64.StdEncoding.EncodeToString([]byte("hello world")),
+      "encoding": "base64",
+    }
+    req := httptest.NewRequest(http.MethodPost, "/files/write", strings.NewReader(mustJSON(t, payload)))
+    recorder := httptest.NewRecorder()
 
-		s.handleFileWrite(recorder, req)
+    s.handleFileWrite(recorder, req)
 
-		if recorder.Code != http.StatusOK {
-			t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
-		}
-	})
+    if recorder.Code != http.StatusOK {
+      t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+    }
+  })
 
-	t.Run("handleFileList", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/files/list", strings.NewReader(`{"path":".arche/attachments","recursive":false}`))
-		recorder := httptest.NewRecorder()
+  t.Run("handleFileList", func(t *testing.T) {
+    req := httptest.NewRequest(http.MethodPost, "/files/list", strings.NewReader(`{"path":".arche/attachments","recursive":false}`))
+    recorder := httptest.NewRecorder()
 
-		s.handleFileList(recorder, req)
+    s.handleFileList(recorder, req)
 
-		if recorder.Code != http.StatusOK {
-			t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
-		}
+    if recorder.Code != http.StatusOK {
+      t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+    }
 
-		var response fileListResponse
-		if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
-			t.Fatalf("decode response: %v", err)
-		}
-		if !response.Ok || len(response.Entries) != 1 {
-			t.Fatalf("unexpected list response: %+v", response)
-		}
-	})
+    var response fileListResponse
+    if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+      t.Fatalf("decode response: %v", err)
+    }
+    if !response.Ok || len(response.Entries) != 1 {
+      t.Fatalf("unexpected list response: %+v", response)
+    }
+  })
 
-	t.Run("handleFileRename", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/files/rename", strings.NewReader(`{"path":".arche/attachments/hello.txt","newPath":".arche/attachments/renamed.txt"}`))
-		recorder := httptest.NewRecorder()
+  t.Run("handleFileRename", func(t *testing.T) {
+    req := httptest.NewRequest(http.MethodPost, "/files/rename", strings.NewReader(`{"path":".arche/attachments/hello.txt","newPath":".arche/attachments/renamed.txt"}`))
+    recorder := httptest.NewRecorder()
 
-		s.handleFileRename(recorder, req)
+    s.handleFileRename(recorder, req)
 
-		if recorder.Code != http.StatusOK {
-			t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
-		}
+    if recorder.Code != http.StatusOK {
+      t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+    }
 
-		if _, err := os.Stat(filepath.Join(workspace, ".arche", "attachments", "renamed.txt")); err != nil {
-			t.Fatalf("renamed file missing: %v", err)
-		}
-	})
+    if _, err := os.Stat(filepath.Join(workspace, ".arche", "attachments", "renamed.txt")); err != nil {
+      t.Fatalf("renamed file missing: %v", err)
+    }
+  })
 }
 
 func TestHandleFileUploadWritesStreamedFile(t *testing.T) {
@@ -230,10 +230,10 @@ func TestHandleFileUploadRejectsOversizedBody(t *testing.T) {
 }
 
 func mustJSON(t *testing.T, value any) string {
-	t.Helper()
-	encoded, err := json.Marshal(value)
-	if err != nil {
-		t.Fatalf("marshal json: %v", err)
-	}
-	return string(encoded)
+  t.Helper()
+  encoded, err := json.Marshal(value)
+  if err != nil {
+    t.Fatalf("marshal json: %v", err)
+  }
+  return string(encoded)
 }


### PR DESCRIPTION
## Summary
- add a dedicated streaming `/files/upload` endpoint in the workspace agent with its own upload size limit, atomic writes, and sha256 metadata
- proxy raw single-file attachment uploads from `apps/web` to the workspace agent instead of sending base64 JSON through `/files/write`
- upload attachments sequentially in the chat UI so large files avoid the 20 MB JSON ceiling while partial failures are reported cleanly

## Validation
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...`
- `pnpm test`
- `pnpm lint`
- `bash scripts/check-podman-images.sh`