### PR TITLE
docs: sync desktop and deployment documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,7 +13,7 @@ arche/
 │   ├── compose/       # Local stack (Podman Compose)
 │   ├── deploy/        # VPS deployer (Ansible + Bash)
 │   ├── coolify/       # Coolify deployment configuration
-│   └── workspace-image/  # Workspace Docker image (OpenCode + git)
+│   └── workspace-image/  # Workspace container image (OpenCode + git)
 └── scripts/           # Bare repo initialization scripts (kb-content/kb-config)
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Define your company's identity, tone, products, and processes once. Arche's agen
 
 ## Desktop App
 
-The easiest way to try Arche is the desktop app. It runs locally on your machine — no server or Docker setup required.
+The easiest way to try Arche locally is the desktop app. It runs on your machine with no server or Docker setup required.
 
 Desktop vault behavior:
 
@@ -26,10 +26,12 @@ Head to the [latest release](https://github.com/peaberry-studio/arche/releases/l
 
 | Platform | File |
 |----------|------|
-| macOS (Apple Silicon) | `Arche-*-arm64.dmg` |
-| macOS (Intel) | `Arche-*-x64.dmg` |
-| Linux | `Arche-*-amd64.AppImage` or `.deb` |
-| Windows | `Arche-*-Setup.exe` |
+| macOS (Apple Silicon) | `Arche-arm64.dmg` or `Arche-<version>-arm64-mac.zip` |
+| macOS (Intel) | `Arche-x64.dmg` or `Arche-<version>-mac.zip` |
+
+Official GitHub release assets are currently published for macOS only.
+
+Linux and Windows packaging targets exist in `apps/desktop`, but they are not part of the current release workflow or validation matrix, so they should not be documented as supported release artifacts.
 
 ### Build from Source
 
@@ -42,12 +44,12 @@ If you prefer to build the desktop app yourself:
 cd apps/web && pnpm install
 cd ../desktop && pnpm install
 
-# 2. Build the distributable
+# 2. Build a desktop package for your current host platform
 cd ../..
 bash scripts/build-desktop.sh
 ```
 
-The installer will be in `apps/desktop/release/`.
+The packaged desktop artifacts will be in `apps/desktop/release/`.
 
 For more details, see [`apps/desktop/README.md`](apps/desktop/README.md).
 
@@ -99,7 +101,7 @@ Assumptions:
 
 - DigitalOcean only
 - The shell entrypoint downloads `https://github.com/peaberry-studio/arche/releases/latest/download/archectl_<os>_<arch>` for macOS/Linux on amd64/arm64
-- Versioned images only: `ghcr.io/peaberry-studio/arche/web:<version>` and `ghcr.io/peaberry-studio/arche/workspace:<version>`
+- Image tags are derived from `--version`: `latest` by default, or a pinned tag such as `v1.2.3`
 - Public URL is derived automatically as `https://arche-<droplet-ip>.nip.io`
 - Local deployment state is stored at `~/.arche/deployments/current.json`
 

--- a/infra/coolify/README.md
+++ b/infra/coolify/README.md
@@ -96,14 +96,14 @@ Set these in the web application's environment variables in Coolify:
 | `ARCHE_GATEWAY_TOKEN_SECRET` | Yes | `openssl rand -base64 32` |
 | `ARCHE_CONNECTOR_OAUTH_STATE_SECRET` | Yes | `openssl rand -base64 32` |
 | `ARCHE_GATEWAY_TOKEN_TTL_SECONDS` | No | Default: `86400` (24h) |
-| `ARCHE_GATEWAY_BASE_URL` | No | Default: `http://localhost:3000` |
+| `ARCHE_GATEWAY_BASE_URL` | No | Default: `http://web:3000` |
 | `ARCHE_COOKIE_SECURE` | No | Default: `true` |
 | `ARCHE_SEED_ADMIN_EMAIL` | Yes | Initial admin email |
 | `ARCHE_SEED_ADMIN_PASSWORD` | Yes | Initial admin password |
 | `ARCHE_SEED_ADMIN_SLUG` | No | Default: `admin` |
 | `CONTAINER_PROXY_HOST` | Yes | Hostname of docker-socket-proxy (use the Coolify service name) |
 | `CONTAINER_PROXY_PORT` | Yes | `2375` |
-| `OPENCODE_IMAGE` | No | Default: `arche-workspace:latest` |
+| `OPENCODE_IMAGE` | No | Default: `ghcr.io/peaberry-studio/arche/workspace:latest` |
 | `OPENCODE_NETWORK` | Yes | `arche_internal` |
 
 ### Step 6: Deploy
@@ -167,7 +167,10 @@ git init --bare --initial-branch=main /opt/arche/kb-content
 git init --bare --initial-branch=main /opt/arche/kb-config
 ```
 
-Set `KB_HOST_PATH=/opt/arche/kb` in the web app environment variables.
+Set these web app environment variables:
+
+- `KB_CONTENT_HOST_PATH=/opt/arche/kb-content`
+- `KB_CONFIG_HOST_PATH=/opt/arche/kb-config`
 
 By default, Coolify deployments use `ghcr.io/peaberry-studio/arche/workspace:latest` for user workspaces.
 You only need to build a custom image if you want to override `OPENCODE_IMAGE`.

--- a/infra/deploy/README.md
+++ b/infra/deploy/README.md
@@ -187,7 +187,7 @@ HTTP-01 challenge is used in remote mode. Make sure your domain resolves to the 
 | Service | Image | Purpose |
 |---------|-------|---------|
 | Traefik | `traefik:v3.6.7` | Reverse proxy, TLS termination, routing |
-| docker-socket-proxy | `tecnativa/docker-socket-proxy:0.3` | Secure container API access |
+| docker-socket-proxy | `ghcr.io/tecnativa/docker-socket-proxy:latest` | Secure container API access |
 | PostgreSQL | `postgres:16` | Database |
 | Web | Configurable (`WEB_IMAGE`) | Next.js app (BFF + spawner) |
 


### PR DESCRIPTION
## Summary
- align the root README with the desktop artifacts that are actually published and clarify the current one-click image tag behavior
- fix Coolify and VPS deploy docs so their defaults match the current compose files and environment variables
- tighten architecture wording to refer to the workspace container image instead of a Docker-specific image

## Validation
- `pnpm test`
- `pnpm lint`
- `bash scripts/check-podman-images.sh`