### PR TITLE
fix(workspace): avoid unrelated apps in desktop mode

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -10,7 +10,7 @@
     "dev": "pnpm prepare:runtime && tsc && electron dist/main.js",
     "build": "tsc",
     "test:smoke": "pnpm build && node --test tests/desktop-workspace-smoke.test.js",
-    "test": "pnpm build && node --test tests/create-vault.test.js tests/desktop-encryption-key.test.js tests/desktop-next-dist.test.js tests/runtime-supervisor.test.js tests/runtime-binaries.test.js tests/runtime-network.test.js tests/vault-manifest.test.js tests/vault-registry.test.js tests/vault-lock.test.js tests/vault-layout.test.js tests/vault-launch.test.js",
+    "test": "pnpm build && node --test tests/create-vault.test.js tests/desktop-encryption-key.test.js tests/desktop-next-dist.test.js tests/runtime-binaries.test.js tests/runtime-network.test.js tests/runtime-start.test.js tests/runtime-supervisor.test.js tests/vault-manifest.test.js tests/vault-registry.test.js tests/vault-lock.test.js tests/vault-layout.test.js tests/vault-launch.test.js",
     "start": "electron dist/main.js",
     "pack": "pnpm prepare:runtime && electron-builder --dir --config electron-builder.config.js",
     "dist": "pnpm prepare:runtime && electron-builder --config electron-builder.config.js",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -17,6 +17,7 @@ import {
   getRuntimeBinaryEnv,
 } from './runtime-binaries'
 import { findAvailablePort } from './runtime-network'
+import { startRuntimeWithPortRetries } from './runtime-start'
 import { probeHttpServerReady, RuntimeSupervisor } from './runtime-supervisor'
 import { buildLaunchArgs, resolveLaunchContext, type DesktopLaunchContext } from './vault-launch'
 import {
@@ -40,6 +41,8 @@ import {
 import { createVaultManifest, tryReadVault, type DesktopVault } from './vault-manifest'
 
 const DEFAULT_DESKTOP_WEB_PORT = 3000
+const DESKTOP_RUNTIME_READY_PATH = '/api/internal/desktop/runtime'
+const MAX_NEXT_START_ATTEMPTS = 4
 const LOOPBACK_HOST = '127.0.0.1'
 const DESKTOP_TOKEN_HEADER = 'x-arche-desktop-token'
 const DESKTOP_GIT_AUTHOR_NAME = 'Arche Workspace'
@@ -71,6 +74,23 @@ function getPort(): number {
 
 function getNextUrl(): string {
   return `http://${LOOPBACK_HOST}:${getPort()}`
+}
+
+function getDesktopRuntimeReadyUrl(): string {
+  return `${getNextUrl()}${DESKTOP_RUNTIME_READY_PATH}`
+}
+
+function isDesktopRuntimeReadyResponse(response: Response, bodyText: string): boolean {
+  if (!response.ok) {
+    return false
+  }
+
+  try {
+    const payload = JSON.parse(bodyText) as Record<string, unknown>
+    return payload.app === 'arche' && payload.runtime === 'desktop' && payload.status === 'ok'
+  } catch {
+    return false
+  }
 }
 
 function getWebAppDir(): string {
@@ -279,11 +299,29 @@ function verifyPackagedRuntimeBinaries(): string[] {
 }
 
 async function startNextServer(): Promise<void> {
-  if (!nextSupervisor) {
-    nextSupervisor = createNextSupervisor()
-  }
+  await startRuntimeWithPortRetries({
+    preferredPort: DEFAULT_DESKTOP_WEB_PORT,
+    maxAttempts: MAX_NEXT_START_ATTEMPTS,
+    acquirePort: async (preferredPort, excludedPorts) => {
+      await initializeDesktopWebPort(preferredPort, excludedPorts)
+      return getPort()
+    },
+    start: async () => {
+      nextSupervisor = createNextSupervisor()
 
-  await nextSupervisor.start()
+      try {
+        await nextSupervisor.start()
+      } catch (error) {
+        nextSupervisor = null
+        throw error
+      }
+    },
+    onRetry: ({ attempt, previousPort, error }) => {
+      process.stdout.write(
+        `[desktop-runtime] retrying_next_start attempt=${String(attempt)} previous_port=${String(previousPort)} error=${error instanceof Error ? error.message : String(error)}\n`,
+      )
+    },
+  })
 }
 
 function createNextSupervisor(): RuntimeSupervisor {
@@ -303,7 +341,13 @@ function createNextSupervisor(): RuntimeSupervisor {
       PORT: String(getPort()),
       HOSTNAME: LOOPBACK_HOST,
     },
-    probeReadiness: () => probeHttpServerReady(getNextUrl()),
+    probeReadiness: () =>
+      probeHttpServerReady(getDesktopRuntimeReadyUrl(), {
+        headers: {
+          [DESKTOP_TOKEN_HEADER]: desktopApiToken,
+        },
+        validateResponse: isDesktopRuntimeReadyResponse,
+      }),
     restartOnCrash: true,
     maxRestarts: 3,
     log: (event) => {
@@ -312,8 +356,11 @@ function createNextSupervisor(): RuntimeSupervisor {
   })
 }
 
-async function initializeDesktopWebPort(): Promise<void> {
-  nextPort = await findAvailablePort(DEFAULT_DESKTOP_WEB_PORT, LOOPBACK_HOST)
+async function initializeDesktopWebPort(
+  preferredPort: number,
+  excludedPorts: number[] = [],
+): Promise<void> {
+  nextPort = await findAvailablePort(preferredPort, LOOPBACK_HOST, excludedPorts)
   process.env.ARCHE_DESKTOP_WEB_PORT = String(nextPort)
 }
 
@@ -630,7 +677,6 @@ app.whenReady().then(async () => {
   }
 
   resetDesktopDevNextArtifacts()
-  await initializeDesktopWebPort()
 
   const missingRuntimeBinaries = verifyPackagedRuntimeBinaries()
   if (missingRuntimeBinaries.length > 0) {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -43,6 +43,8 @@ import { createVaultManifest, tryReadVault, type DesktopVault } from './vault-ma
 const DEFAULT_DESKTOP_WEB_PORT = 3000
 const DESKTOP_RUNTIME_READY_PATH = '/api/internal/desktop/runtime'
 const MAX_NEXT_START_ATTEMPTS = 4
+const NEXT_READY_TIMEOUT_MS = 30_000
+const NEXT_RETRY_READY_TIMEOUT_MS = 20_000
 const LOOPBACK_HOST = '127.0.0.1'
 const DESKTOP_TOKEN_HEADER = 'x-arche-desktop-token'
 const DESKTOP_GIT_AUTHOR_NAME = 'Arche Workspace'
@@ -72,12 +74,12 @@ function getPort(): number {
   return nextPort
 }
 
-function getNextUrl(): string {
-  return `http://${LOOPBACK_HOST}:${getPort()}`
+function getNextUrl(port = getPort()): string {
+  return `http://${LOOPBACK_HOST}:${port}`
 }
 
-function getDesktopRuntimeReadyUrl(): string {
-  return `${getNextUrl()}${DESKTOP_RUNTIME_READY_PATH}`
+function getDesktopRuntimeReadyUrl(port = getPort()): string {
+  return `${getNextUrl(port)}${DESKTOP_RUNTIME_READY_PATH}`
 }
 
 function isDesktopRuntimeReadyResponse(response: Response, bodyText: string): boolean {
@@ -306,8 +308,13 @@ async function startNextServer(): Promise<void> {
       await initializeDesktopWebPort(preferredPort, excludedPorts)
       return getPort()
     },
-    start: async () => {
-      nextSupervisor = createNextSupervisor()
+    start: async (port, attempt) => {
+      const readyTimeoutMs =
+        attempt === MAX_NEXT_START_ATTEMPTS ? NEXT_READY_TIMEOUT_MS : NEXT_RETRY_READY_TIMEOUT_MS
+      process.stdout.write(
+        `[desktop-runtime] starting_next_start attempt=${String(attempt)}/${String(MAX_NEXT_START_ATTEMPTS)} port=${String(port)} ready_timeout_ms=${String(readyTimeoutMs)}\n`,
+      )
+      nextSupervisor = createNextSupervisor(port, readyTimeoutMs)
 
       try {
         await nextSupervisor.start()
@@ -317,32 +324,35 @@ async function startNextServer(): Promise<void> {
       }
     },
     onRetry: ({ attempt, previousPort, error }) => {
+      const nextReadyTimeoutMs =
+        attempt === MAX_NEXT_START_ATTEMPTS ? NEXT_READY_TIMEOUT_MS : NEXT_RETRY_READY_TIMEOUT_MS
       process.stdout.write(
-        `[desktop-runtime] retrying_next_start attempt=${String(attempt)} previous_port=${String(previousPort)} error=${error instanceof Error ? error.message : String(error)}\n`,
+        `[desktop-runtime] retrying_next_start attempt=${String(attempt)}/${String(MAX_NEXT_START_ATTEMPTS)} previous_port=${String(previousPort)} next_ready_timeout_ms=${String(nextReadyTimeoutMs)} error=${error instanceof Error ? error.message : String(error)}\n`,
       )
     },
   })
 }
 
-function createNextSupervisor(): RuntimeSupervisor {
+function createNextSupervisor(port: number, readyTimeoutMs: number): RuntimeSupervisor {
   return new RuntimeSupervisor({
     componentName: 'next',
     command: app.isPackaged ? getPackagedNodeBinaryPath(getRuntimeBinaryOptions()) : 'pnpm',
     args: app.isPackaged
       ? ['server.js']
-      : ['exec', 'next', 'dev', '-H', LOOPBACK_HOST, '-p', String(getPort())],
+      : ['exec', 'next', 'dev', '-H', LOOPBACK_HOST, '-p', String(port)],
     cwd: getWebAppDir(),
     env: {
       ...getDesktopRuntimeEnv(),
       ARCHE_RUNTIME_MODE: 'desktop',
       ARCHE_DESKTOP_NEXT_DIST_DIR: getDesktopNextDistDirNameForCurrentProcess(),
-      ARCHE_DESKTOP_WEB_PORT: String(getPort()),
-      ARCHE_CONNECTOR_GATEWAY_BASE_URL: `http://${LOOPBACK_HOST}:${getPort()}/api/internal/mcp/connectors`,
-      PORT: String(getPort()),
+      ARCHE_DESKTOP_WEB_PORT: String(port),
+      ARCHE_CONNECTOR_GATEWAY_BASE_URL: `http://${LOOPBACK_HOST}:${String(port)}/api/internal/mcp/connectors`,
+      PORT: String(port),
       HOSTNAME: LOOPBACK_HOST,
     },
+    readyTimeoutMs,
     probeReadiness: () =>
-      probeHttpServerReady(getDesktopRuntimeReadyUrl(), {
+      probeHttpServerReady(getDesktopRuntimeReadyUrl(port), {
         headers: {
           [DESKTOP_TOKEN_HEADER]: desktopApiToken,
         },

--- a/apps/desktop/src/runtime-network.ts
+++ b/apps/desktop/src/runtime-network.ts
@@ -1,5 +1,7 @@
 import { createServer } from 'net'
 
+const MAX_FALLBACK_PORT_ATTEMPTS = 10
+
 export async function findAvailablePort(
   preferredPort: number,
   host: string,
@@ -14,16 +16,21 @@ export async function findAvailablePort(
     throw preferredResult.error
   }
 
-  const fallbackResult = await tryListen(0, host)
-  if (!fallbackResult.ok) {
-    throw fallbackResult.error
+  const maxFallbackAttempts = Math.max(MAX_FALLBACK_PORT_ATTEMPTS, excludedPorts.length + 1)
+  for (let attempt = 0; attempt < maxFallbackAttempts; attempt++) {
+    const fallbackResult = await tryListen(0, host)
+    if (!fallbackResult.ok) {
+      throw fallbackResult.error
+    }
+
+    if (!excludedPorts.includes(fallbackResult.port)) {
+      return fallbackResult.port
+    }
   }
 
-  if (excludedPorts.includes(fallbackResult.port)) {
-    return findAvailablePort(0, host, excludedPorts)
-  }
-
-  return fallbackResult.port
+  throw new Error(
+    `Failed to find an available port after ${String(maxFallbackAttempts)} fallback attempts.`,
+  )
 }
 
 type ListenResult =

--- a/apps/desktop/src/runtime-network.ts
+++ b/apps/desktop/src/runtime-network.ts
@@ -1,18 +1,26 @@
 import { createServer } from 'net'
 
-export async function findAvailablePort(preferredPort: number, host: string): Promise<number> {
+export async function findAvailablePort(
+  preferredPort: number,
+  host: string,
+  excludedPorts: number[] = [],
+): Promise<number> {
   const preferredResult = await tryListen(preferredPort, host)
-  if (preferredResult.ok) {
+  if (preferredResult.ok && !excludedPorts.includes(preferredResult.port)) {
     return preferredResult.port
   }
 
-  if (preferredResult.errorCode !== 'EADDRINUSE') {
+  if (!preferredResult.ok && preferredResult.errorCode !== 'EADDRINUSE') {
     throw preferredResult.error
   }
 
   const fallbackResult = await tryListen(0, host)
   if (!fallbackResult.ok) {
     throw fallbackResult.error
+  }
+
+  if (excludedPorts.includes(fallbackResult.port)) {
+    return findAvailablePort(0, host, excludedPorts)
   }
 
   return fallbackResult.port

--- a/apps/desktop/src/runtime-start.ts
+++ b/apps/desktop/src/runtime-start.ts
@@ -1,0 +1,47 @@
+export type RuntimeRetryEvent = {
+  attempt: number
+  previousPort: number
+  error: unknown
+}
+
+type StartRuntimeWithPortRetriesOptions = {
+  preferredPort: number
+  maxAttempts: number
+  acquirePort: (preferredPort: number, excludedPorts: number[]) => Promise<number>
+  start: (port: number) => Promise<void>
+  onRetry?: (event: RuntimeRetryEvent) => void
+}
+
+export async function startRuntimeWithPortRetries(
+  options: StartRuntimeWithPortRetriesOptions,
+): Promise<number> {
+  const attemptedPorts: number[] = []
+  let lastError: unknown = null
+
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+    const preferredPort = attempt === 1 ? options.preferredPort : 0
+    const port = await options.acquirePort(preferredPort, attemptedPorts)
+    attemptedPorts.push(port)
+
+    try {
+      await options.start(port)
+      return port
+    } catch (error) {
+      lastError = error
+
+      if (attempt === options.maxAttempts) {
+        break
+      }
+
+      options.onRetry?.({
+        attempt: attempt + 1,
+        previousPort: port,
+        error,
+      })
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('Failed to start the local desktop runtime.')
+}

--- a/apps/desktop/src/runtime-start.ts
+++ b/apps/desktop/src/runtime-start.ts
@@ -8,15 +8,19 @@ type StartRuntimeWithPortRetriesOptions = {
   preferredPort: number
   maxAttempts: number
   acquirePort: (preferredPort: number, excludedPorts: number[]) => Promise<number>
-  start: (port: number) => Promise<void>
+  start: (port: number, attempt: number) => Promise<void>
   onRetry?: (event: RuntimeRetryEvent) => void
+}
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
 }
 
 export async function startRuntimeWithPortRetries(
   options: StartRuntimeWithPortRetriesOptions,
 ): Promise<number> {
   const attemptedPorts: number[] = []
-  let lastError: unknown = null
+  const errors: Error[] = []
 
   for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
     const preferredPort = attempt === 1 ? options.preferredPort : 0
@@ -24,10 +28,11 @@ export async function startRuntimeWithPortRetries(
     attemptedPorts.push(port)
 
     try {
-      await options.start(port)
+      await options.start(port, attempt)
       return port
     } catch (error) {
-      lastError = error
+      const normalizedError = normalizeError(error)
+      errors.push(normalizedError)
 
       if (attempt === options.maxAttempts) {
         break
@@ -36,12 +41,21 @@ export async function startRuntimeWithPortRetries(
       options.onRetry?.({
         attempt: attempt + 1,
         previousPort: port,
-        error,
+        error: normalizedError,
       })
     }
   }
 
-  throw lastError instanceof Error
-    ? lastError
-    : new Error('Failed to start the local desktop runtime.')
+  if (errors.length === 1) {
+    throw errors[0]
+  }
+
+  if (errors.length > 1) {
+    throw new AggregateError(
+      errors,
+      `Failed to start the local desktop runtime after ${String(errors.length)} attempts.`,
+    )
+  }
+
+  throw new Error('Failed to start the local desktop runtime.')
 }

--- a/apps/desktop/src/runtime-supervisor.ts
+++ b/apps/desktop/src/runtime-supervisor.ts
@@ -44,6 +44,11 @@ type RuntimeSupervisorOptions = {
   log?: (event: RuntimeLogEvent) => void
 }
 
+type HttpProbeOptions = {
+  headers?: Record<string, string>
+  validateResponse?: (response: Response, bodyText: string) => boolean | Promise<boolean>
+}
+
 const DEFAULT_READY_TIMEOUT_MS = 30_000
 const DEFAULT_READY_POLL_INTERVAL_MS = 250
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 5_000
@@ -332,13 +337,23 @@ export class RuntimeSupervisor {
   }
 }
 
-export async function probeHttpServerReady(url: string): Promise<boolean> {
+export async function probeHttpServerReady(
+  url: string,
+  options: HttpProbeOptions = {},
+): Promise<boolean> {
   try {
     const response = await fetch(url, {
+      headers: options.headers,
       method: 'GET',
       redirect: 'manual',
       signal: AbortSignal.timeout(1_000),
     })
+
+    if (options.validateResponse) {
+      const bodyText = await response.text()
+      return await options.validateResponse(response, bodyText)
+    }
+
     return response.status > 0
   } catch {
     return false

--- a/apps/desktop/tests/runtime-network.test.js
+++ b/apps/desktop/tests/runtime-network.test.js
@@ -10,6 +10,13 @@ test('returns the preferred port when it is available', async () => {
   assert.notEqual(port, 0)
 })
 
+test('does not reuse an excluded preferred port', async () => {
+  const preferredPort = await findAvailablePort(0, '127.0.0.1')
+  const port = await findAvailablePort(preferredPort, '127.0.0.1', [preferredPort])
+
+  assert.notEqual(port, preferredPort)
+})
+
 test('falls back when the preferred port is already in use', async () => {
   const busyServer = net.createServer()
   // Use port 0 to let the OS pick an available ephemeral port, avoiding

--- a/apps/desktop/tests/runtime-start.test.js
+++ b/apps/desktop/tests/runtime-start.test.js
@@ -1,0 +1,71 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { startRuntimeWithPortRetries } = require('../dist/runtime-start.js')
+
+test('retries startup on another port after a failed first attempt', async () => {
+  const acquired = []
+  const started = []
+  const retries = []
+  const allocatedPorts = [3000, 4312]
+
+  const port = await startRuntimeWithPortRetries({
+    preferredPort: 3000,
+    maxAttempts: 4,
+    acquirePort: async (preferredPort, excludedPorts) => {
+      acquired.push({ preferredPort, excludedPorts: [...excludedPorts] })
+      return allocatedPorts.shift()
+    },
+    start: async (nextPort) => {
+      started.push(nextPort)
+      if (nextPort === 3000) {
+        throw new Error('desktop readiness validation failed')
+      }
+    },
+    onRetry: (event) => {
+      retries.push({
+        attempt: event.attempt,
+        previousPort: event.previousPort,
+        message: event.error instanceof Error ? event.error.message : String(event.error),
+      })
+    },
+  })
+
+  assert.equal(port, 4312)
+  assert.deepEqual(acquired, [
+    { preferredPort: 3000, excludedPorts: [] },
+    { preferredPort: 0, excludedPorts: [3000] },
+  ])
+  assert.deepEqual(started, [3000, 4312])
+  assert.deepEqual(retries, [
+    {
+      attempt: 2,
+      previousPort: 3000,
+      message: 'desktop readiness validation failed',
+    },
+  ])
+})
+
+test('throws the last startup error after exhausting retries', async () => {
+  const attempts = []
+
+  await assert.rejects(
+    startRuntimeWithPortRetries({
+      preferredPort: 3000,
+      maxAttempts: 2,
+      acquirePort: async (preferredPort, excludedPorts) => {
+        attempts.push({ preferredPort, excludedPorts: [...excludedPorts] })
+        return preferredPort === 3000 ? 3000 : 4312
+      },
+      start: async (port) => {
+        throw new Error(`failed:${port}`)
+      },
+    }),
+    /failed:4312/,
+  )
+
+  assert.deepEqual(attempts, [
+    { preferredPort: 3000, excludedPorts: [] },
+    { preferredPort: 0, excludedPorts: [3000] },
+  ])
+})

--- a/apps/desktop/tests/runtime-start.test.js
+++ b/apps/desktop/tests/runtime-start.test.js
@@ -16,8 +16,8 @@ test('retries startup on another port after a failed first attempt', async () =>
       acquired.push({ preferredPort, excludedPorts: [...excludedPorts] })
       return allocatedPorts.shift()
     },
-    start: async (nextPort) => {
-      started.push(nextPort)
+    start: async (nextPort, attempt) => {
+      started.push({ port: nextPort, attempt })
       if (nextPort === 3000) {
         throw new Error('desktop readiness validation failed')
       }
@@ -36,7 +36,10 @@ test('retries startup on another port after a failed first attempt', async () =>
     { preferredPort: 3000, excludedPorts: [] },
     { preferredPort: 0, excludedPorts: [3000] },
   ])
-  assert.deepEqual(started, [3000, 4312])
+  assert.deepEqual(started, [
+    { port: 3000, attempt: 1 },
+    { port: 4312, attempt: 2 },
+  ])
   assert.deepEqual(retries, [
     {
       attempt: 2,
@@ -46,7 +49,7 @@ test('retries startup on another port after a failed first attempt', async () =>
   ])
 })
 
-test('throws the last startup error after exhausting retries', async () => {
+test('throws an aggregate startup error after exhausting retries', async () => {
   const attempts = []
 
   await assert.rejects(
@@ -61,7 +64,15 @@ test('throws the last startup error after exhausting retries', async () => {
         throw new Error(`failed:${port}`)
       },
     }),
-    /failed:4312/,
+    (error) => {
+      assert.equal(error instanceof AggregateError, true)
+      assert.equal(error.message, 'Failed to start the local desktop runtime after 2 attempts.')
+      assert.deepEqual(
+        error.errors.map((attemptError) => attemptError.message),
+        ['failed:3000', 'failed:4312'],
+      )
+      return true
+    },
   )
 
   assert.deepEqual(attempts, [

--- a/apps/desktop/tests/runtime-supervisor.test.js
+++ b/apps/desktop/tests/runtime-supervisor.test.js
@@ -1,6 +1,7 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
 const { EventEmitter } = require('node:events')
+const http = require('node:http')
 
 class MockStream extends EventEmitter {}
 
@@ -238,5 +239,92 @@ test('stops restarting after maxRestarts is exceeded', async () => {
     assert.equal(supervisor.getState(), 'error')
   } finally {
     process.kill = originalKill
+  }
+})
+
+test('probeHttpServerReady forwards headers to the readiness endpoint', async () => {
+  const { probeHttpServerReady } = require('../dist/runtime-supervisor.js')
+  const server = http.createServer((req, res) => {
+    if (req.headers['x-arche-desktop-token'] !== 'valid-token') {
+      res.writeHead(401, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ error: 'unauthorized' }))
+      return
+    }
+
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ app: 'arche', runtime: 'desktop', status: 'ok' }))
+  })
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  assert.equal(typeof address, 'object')
+
+  try {
+    const ready = await probeHttpServerReady(`http://127.0.0.1:${address.port}/ready`, {
+      headers: { 'x-arche-desktop-token': 'valid-token' },
+      validateResponse: (response, bodyText) => {
+        if (!response.ok) {
+          return false
+        }
+
+        const body = JSON.parse(bodyText)
+        return body.app === 'arche' && body.runtime === 'desktop' && body.status === 'ok'
+      },
+    })
+
+    assert.equal(ready, true)
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+
+        resolve()
+      })
+    })
+  }
+})
+
+test('probeHttpServerReady rejects unrelated HTTP responses when validation fails', async () => {
+  const { probeHttpServerReady } = require('../dist/runtime-supervisor.js')
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'text/html' })
+    res.end('<html><body>not arche</body></html>')
+  })
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  assert.equal(typeof address, 'object')
+
+  try {
+    const ready = await probeHttpServerReady(`http://127.0.0.1:${address.port}/`, {
+      validateResponse: (response, bodyText) => {
+        if (!response.ok) {
+          return false
+        }
+
+        try {
+          const body = JSON.parse(bodyText)
+          return body.app === 'arche'
+        } catch {
+          return false
+        }
+      },
+    })
+
+    assert.equal(ready, false)
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+
+        resolve()
+      })
+    })
   }
 })

--- a/apps/web/src/app/api/internal/desktop/runtime/route.test.ts
+++ b/apps/web/src/app/api/internal/desktop/runtime/route.test.ts
@@ -79,6 +79,17 @@ describe('GET /api/internal/desktop/runtime', () => {
     expect(body.version).toBe('abc123')
   })
 
+  it('falls back to git sha when the release version is empty', async () => {
+    process.env.ARCHE_RELEASE_VERSION = '   '
+    mockValidateDesktopToken.mockReturnValue(true)
+
+    const { GET } = await import('./route')
+    const res = await GET(makeRequest({ 'x-arche-desktop-token': 'valid-token' }))
+    const body = await res.json()
+
+    expect(body.version).toBe('abc123')
+  })
+
   it('falls back to dev when no version metadata is available', async () => {
     delete process.env.ARCHE_RELEASE_VERSION
     delete process.env.ARCHE_GIT_SHA

--- a/apps/web/src/app/api/internal/desktop/runtime/route.test.ts
+++ b/apps/web/src/app/api/internal/desktop/runtime/route.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+class FakeNextRequest {
+  headers: Headers
+
+  constructor(public readonly nextUrl: URL, headers?: HeadersInit) {
+    this.headers = new Headers(headers)
+  }
+}
+
+vi.mock('next/server', () => ({
+  NextRequest: FakeNextRequest,
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number; headers?: Record<string, string> }) => {
+      return new Response(JSON.stringify(body), {
+        status: init?.status ?? 200,
+        headers: init?.headers,
+      })
+    },
+  },
+}))
+
+const mockValidateDesktopToken = vi.fn<(token: string | null) => boolean>()
+
+vi.mock('@/lib/runtime/desktop/token', () => ({
+  DESKTOP_TOKEN_HEADER: 'x-arche-desktop-token',
+  validateDesktopToken: (token: string | null) => mockValidateDesktopToken(token),
+}))
+
+function makeRequest(headers?: HeadersInit) {
+  return new FakeNextRequest(new URL('http://localhost/api/internal/desktop/runtime'), headers) as never
+}
+
+describe('GET /api/internal/desktop/runtime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.ARCHE_RELEASE_VERSION = '1.2.3'
+    process.env.ARCHE_GIT_SHA = 'abc123'
+  })
+
+  it('returns 401 when the desktop token is missing or invalid', async () => {
+    mockValidateDesktopToken.mockReturnValue(false)
+
+    const { GET } = await import('./route')
+    const res = await GET(makeRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body).toEqual({ error: 'unauthorized' })
+    expect(mockValidateDesktopToken).toHaveBeenCalledWith(null)
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+  })
+
+  it('returns the desktop runtime identity when the token is valid', async () => {
+    mockValidateDesktopToken.mockReturnValue(true)
+
+    const { GET } = await import('./route')
+    const res = await GET(makeRequest({ 'x-arche-desktop-token': 'valid-token' }))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({
+      app: 'arche',
+      runtime: 'desktop',
+      status: 'ok',
+      version: '1.2.3',
+    })
+    expect(mockValidateDesktopToken).toHaveBeenCalledWith('valid-token')
+  })
+
+  it('falls back to git sha when the release version is absent', async () => {
+    delete process.env.ARCHE_RELEASE_VERSION
+    mockValidateDesktopToken.mockReturnValue(true)
+
+    const { GET } = await import('./route')
+    const res = await GET(makeRequest({ 'x-arche-desktop-token': 'valid-token' }))
+    const body = await res.json()
+
+    expect(body.version).toBe('abc123')
+  })
+
+  it('falls back to dev when no version metadata is available', async () => {
+    delete process.env.ARCHE_RELEASE_VERSION
+    delete process.env.ARCHE_GIT_SHA
+    mockValidateDesktopToken.mockReturnValue(true)
+
+    const { GET } = await import('./route')
+    const res = await GET(makeRequest({ 'x-arche-desktop-token': 'valid-token' }))
+    const body = await res.json()
+
+    expect(body.version).toBe('dev')
+  })
+})

--- a/apps/web/src/app/api/internal/desktop/runtime/route.ts
+++ b/apps/web/src/app/api/internal/desktop/runtime/route.ts
@@ -13,12 +13,15 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401, headers: HEADERS })
   }
 
+  const version =
+    process.env.ARCHE_RELEASE_VERSION?.trim() || process.env.ARCHE_GIT_SHA?.trim() || 'dev'
+
   return NextResponse.json(
     {
       app: 'arche',
       runtime: 'desktop',
       status: 'ok',
-      version: process.env.ARCHE_RELEASE_VERSION ?? process.env.ARCHE_GIT_SHA ?? 'dev',
+      version,
     },
     { headers: HEADERS },
   )

--- a/apps/web/src/app/api/internal/desktop/runtime/route.ts
+++ b/apps/web/src/app/api/internal/desktop/runtime/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { DESKTOP_TOKEN_HEADER, validateDesktopToken } from '@/lib/runtime/desktop/token'
+
+const HEADERS = { 'Cache-Control': 'no-store' }
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const token = request.headers.get(DESKTOP_TOKEN_HEADER)
+  if (!validateDesktopToken(token)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401, headers: HEADERS })
+  }
+
+  return NextResponse.json(
+    {
+      app: 'arche',
+      runtime: 'desktop',
+      status: 'ok',
+      version: process.env.ARCHE_RELEASE_VERSION ?? process.env.ARCHE_GIT_SHA ?? 'dev',
+    },
+    { headers: HEADERS },
+  )
+}

--- a/apps/web/src/lib/runtime/desktop/network.ts
+++ b/apps/web/src/lib/runtime/desktop/network.ts
@@ -1,6 +1,7 @@
 import { createServer } from 'net'
 
 const LOOPBACK_HOST = '127.0.0.1'
+const MAX_FALLBACK_PORT_ATTEMPTS = 10
 
 type ListenResult =
   | { ok: true; port: number }
@@ -40,14 +41,19 @@ export async function findAvailablePort(preferredPort: number, excludedPorts: nu
     throw preferredResult.error
   }
 
-  const fallbackResult = await tryListen(0)
-  if (!fallbackResult.ok) {
-    throw fallbackResult.error
+  const maxFallbackAttempts = Math.max(MAX_FALLBACK_PORT_ATTEMPTS, excludedPorts.length + 1)
+  for (let attempt = 0; attempt < maxFallbackAttempts; attempt++) {
+    const fallbackResult = await tryListen(0)
+    if (!fallbackResult.ok) {
+      throw fallbackResult.error
+    }
+
+    if (!excludedPorts.includes(fallbackResult.port)) {
+      return fallbackResult.port
+    }
   }
 
-  if (excludedPorts.includes(fallbackResult.port)) {
-    return findAvailablePort(0, excludedPorts)
-  }
-
-  return fallbackResult.port
+  throw new Error(
+    `Failed to find an available port after ${String(maxFallbackAttempts)} fallback attempts.`,
+  )
 }


### PR DESCRIPTION
## Summary
- add an authenticated desktop readiness endpoint so Electron only trusts the local Arche runtime instead of any HTTP server responding on loopback
- retry desktop frontend startup on alternate ports when readiness validation fails, avoiding collisions with unrelated local apps
- add regression coverage for readiness validation, excluded ports, and the retry flow after an initial port failure

## Validation
- pnpm test (apps/desktop)
- pnpm test (apps/web)
- pnpm lint (apps/web)
- bash scripts/check-podman-images.sh