### PR TITLE
feat(workspace): add global connector capabilities

### DIFF
--- a/apps/web/src/app/api/connectors/oauth/callback/route.ts
+++ b/apps/web/src/app/api/connectors/oauth/callback/route.ts
@@ -29,9 +29,27 @@ function normalizeOAuthError(error: string): string {
   return 'oauth_failed'
 }
 
-function buildRedirect(baseUrl: string, slug: string, status: 'success' | 'error', message?: string): URL {
+function isSafeReturnToPath(value: string | undefined): value is string {
+  if (!value) {
+    return false
+  }
+
+  return value.startsWith('/') && !value.startsWith('//')
+}
+
+function buildRedirect(
+  baseUrl: string,
+  slug: string,
+  status: 'success' | 'error',
+  message?: string,
+  returnTo?: string,
+): URL {
   const desktopVault = getCurrentDesktopVault()
-  const targetPath = desktopVault ? getDesktopWorkspaceHref('local', 'connectors') : `/u/${slug}/connectors`
+  const targetPath = desktopVault
+    ? getDesktopWorkspaceHref('local', 'connectors')
+    : isSafeReturnToPath(returnTo)
+      ? returnTo
+      : `/u/${slug}/connectors`
   const url = new URL(targetPath, baseUrl)
   url.searchParams.set('oauth', status)
   if (message) {
@@ -60,11 +78,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 
   if (!session) {
-    return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'error', 'unauthorized'))
+    return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'error', 'unauthorized', parsedState.returnTo))
   }
 
   if (session.user.slug !== parsedState.slug && session.user.role !== 'ADMIN') {
-    return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'error', 'forbidden'))
+    return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'error', 'forbidden', parsedState.returnTo))
   }
 
   if (providerError) {
@@ -77,11 +95,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         error: providerError,
       },
     })
-    return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'error', normalizeOAuthError(providerError)))
+    return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'error', normalizeOAuthError(providerError), parsedState.returnTo))
   }
 
   if (!code) {
-    return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'error', 'missing_code'))
+    return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'error', 'missing_code', parsedState.returnTo))
   }
 
   const connector = await connectorService.findByIdAndUserIdSelect(
@@ -91,13 +109,13 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   )
 
   if (!connector || !validateConnectorType(connector.type) || !isOAuthConnectorType(connector.type)) {
-    return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'error', 'connector_not_found'))
+    return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'error', 'connector_not_found', parsedState.returnTo))
   }
 
   const redirectUri = parsedState.redirectUri || `${baseUrl}/api/connectors/oauth/callback`
   try {
     if (!parsedState.clientId || !parsedState.codeVerifier || !parsedState.tokenEndpoint) {
-      return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'error', 'invalid_state'))
+      return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'error', 'invalid_state', parsedState.returnTo))
     }
 
     const token = await exchangeConnectorOAuthCode({
@@ -151,8 +169,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       },
     })
     console.error('[oauth/callback] exchange failed:', message)
-    return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'error', 'oauth_failed'))
+    return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'error', 'oauth_failed', parsedState.returnTo))
   }
 
-  return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'success'))
+  return NextResponse.redirect(buildRedirect(baseUrl, parsedState.slug, 'success', undefined, parsedState.returnTo))
 }

--- a/apps/web/src/app/api/connectors/oauth/callback/route.ts
+++ b/apps/web/src/app/api/connectors/oauth/callback/route.ts
@@ -5,6 +5,7 @@ import { decryptConfig, encryptConfig } from '@/lib/connectors/crypto'
 import {
   exchangeConnectorOAuthCode,
   isOAuthConnectorType,
+  normalizeConnectorOAuthReturnTo,
   verifyConnectorOAuthState,
 } from '@/lib/connectors/oauth'
 import { buildConfigWithOAuth } from '@/lib/connectors/oauth-config'
@@ -29,14 +30,6 @@ function normalizeOAuthError(error: string): string {
   return 'oauth_failed'
 }
 
-function isSafeReturnToPath(value: string | undefined): value is string {
-  if (!value) {
-    return false
-  }
-
-  return value.startsWith('/') && !value.startsWith('//')
-}
-
 function buildRedirect(
   baseUrl: string,
   slug: string,
@@ -45,10 +38,11 @@ function buildRedirect(
   returnTo?: string,
 ): URL {
   const desktopVault = getCurrentDesktopVault()
+  const returnToPath = normalizeConnectorOAuthReturnTo(returnTo)
   const targetPath = desktopVault
     ? getDesktopWorkspaceHref('local', 'connectors')
-    : isSafeReturnToPath(returnTo)
-      ? returnTo
+    : returnToPath
+      ? returnToPath
       : `/u/${slug}/connectors`
   const url = new URL(targetPath, baseUrl)
   url.searchParams.set('oauth', status)

--- a/apps/web/src/app/api/u/[slug]/agents/[name]/route.ts
+++ b/apps/web/src/app/api/u/[slug]/agents/[name]/route.ts
@@ -4,17 +4,16 @@ import {
   buildAgentPermissionConfigFromCapabilities,
   buildAgentToolsConfigFromCapabilities,
   type AgentCapabilities,
+  type ConnectorCapabilityRecord,
   validateAgentCapabilityConnectorIds,
   validateAgentCapabilitySkillIds,
   validateAgentCapabilityTools,
 } from '@/lib/agent-capabilities'
+import { loadAgentConnectorCapabilityOptions } from '@/lib/agent-connector-capabilities'
 import { auditEvent } from '@/lib/auth'
 import { readCommonWorkspaceConfig, writeCommonWorkspaceConfig } from '@/lib/common-workspace-config-store'
-import type { ConnectorType } from '@/lib/connectors/types'
-import { validateConnectorType } from '@/lib/connectors/validators'
 import { withAuth } from '@/lib/runtime/with-auth'
 import { listSkills } from '@/lib/skills/skill-store'
-import { connectorService, userService } from '@/lib/services'
 import {
   type CommonWorkspaceConfig,
   ensurePrimaryAgent,
@@ -52,12 +51,6 @@ type UpdateAgentRequest = {
   }
 }
 
-type EnabledConnector = {
-  id: string
-  type: ConnectorType
-  enabled: boolean
-}
-
 async function loadCommonConfig() {
   const result = await readCommonWorkspaceConfig()
   if (!result.ok) {
@@ -81,28 +74,17 @@ async function loadCommonConfig() {
   }
 }
 
-async function loadEnabledConnectorsForSlug(slug: string): Promise<EnabledConnector[]> {
-  const user = await userService.findIdBySlug(slug)
-  if (!user) return []
-
-  const connectors = await connectorService.findEnabledByUserId(user.id)
-
-  const enabled: EnabledConnector[] = []
-  for (const connector of connectors) {
-    if (!validateConnectorType(connector.type)) continue
-    enabled.push({
-      id: connector.id,
-      type: connector.type as ConnectorType,
-      enabled: connector.enabled,
-    })
-  }
-
-  return enabled
+async function loadAvailableConnectorCapabilities(): Promise<ConnectorCapabilityRecord[]> {
+  const connectors = await loadAgentConnectorCapabilityOptions()
+  return connectors.map((connector) => ({
+    id: connector.id,
+    type: connector.type,
+  }))
 }
 
 function parseCapabilities(
   value: unknown,
-  enabledConnectors: EnabledConnector[],
+  availableConnectors: ConnectorCapabilityRecord[],
   availableSkillIds: Set<string>,
 ): { ok: true; capabilities: AgentCapabilities } | { ok: false; error: string } {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -125,9 +107,9 @@ function parseCapabilities(
     return { ok: false, error: connectorResult.error }
   }
 
-  const enabledConnectorIds = new Set(enabledConnectors.map((connector) => connector.id))
+  const availableConnectorIds = new Set(availableConnectors.map((connector) => connector.id))
   const unknownConnectorId = connectorResult.connectorIds.find(
-    (connectorId) => !enabledConnectorIds.has(connectorId)
+    (connectorId) => !availableConnectorIds.has(connectorId)
   )
   if (unknownConnectorId) {
     return { ok: false, error: 'unknown_mcp_connector' }
@@ -272,7 +254,7 @@ export const PATCH = withAuth<AgentDetailResponse | { error: string; message?: s
     }
 
     if ('capabilities' in body) {
-      const enabledConnectors = await loadEnabledConnectorsForSlug(slug)
+      const availableConnectors = await loadAvailableConnectorCapabilities()
       const skillsResult = await listSkills()
       if (!skillsResult.ok) {
         const status = skillsResult.error === 'kb_unavailable' ? 503 : 500
@@ -281,7 +263,7 @@ export const PATCH = withAuth<AgentDetailResponse | { error: string; message?: s
 
       const capabilitiesResult = parseCapabilities(
         body.capabilities,
-        enabledConnectors,
+        availableConnectors,
         new Set(skillsResult.data.map((skill) => skill.name))
       )
       if (!capabilitiesResult.ok) {
@@ -290,7 +272,7 @@ export const PATCH = withAuth<AgentDetailResponse | { error: string; message?: s
 
       updated.tools = buildAgentToolsConfigFromCapabilities(
         capabilitiesResult.capabilities,
-        enabledConnectors
+        availableConnectors
       )
 
       const permission = buildAgentPermissionConfigFromCapabilities(

--- a/apps/web/src/app/api/u/[slug]/agents/[name]/route.ts
+++ b/apps/web/src/app/api/u/[slug]/agents/[name]/route.ts
@@ -9,7 +9,7 @@ import {
   validateAgentCapabilitySkillIds,
   validateAgentCapabilityTools,
 } from '@/lib/agent-capabilities'
-import { loadAgentConnectorCapabilityOptions } from '@/lib/agent-connector-capabilities'
+import { loadAvailableConnectorCapabilities } from '@/lib/agent-connector-capabilities'
 import { auditEvent } from '@/lib/auth'
 import { readCommonWorkspaceConfig, writeCommonWorkspaceConfig } from '@/lib/common-workspace-config-store'
 import { withAuth } from '@/lib/runtime/with-auth'
@@ -72,14 +72,6 @@ async function loadCommonConfig() {
     config: parsed.config,
     hash: result.hash,
   }
-}
-
-async function loadAvailableConnectorCapabilities(): Promise<ConnectorCapabilityRecord[]> {
-  const connectors = await loadAgentConnectorCapabilityOptions()
-  return connectors.map((connector) => ({
-    id: connector.id,
-    type: connector.type,
-  }))
 }
 
 function parseCapabilities(

--- a/apps/web/src/app/api/u/[slug]/agents/connectors/route.ts
+++ b/apps/web/src/app/api/u/[slug]/agents/connectors/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+
+import {
+  loadAgentConnectorCapabilityOptions,
+  type AgentConnectorCapabilityOption,
+} from '@/lib/agent-connector-capabilities'
+import { withAuth } from '@/lib/runtime/with-auth'
+
+type AgentConnectorCapabilitiesResponse = {
+  connectors: AgentConnectorCapabilityOption[]
+}
+
+export const GET = withAuth<AgentConnectorCapabilitiesResponse | { error: string }>(
+  { csrf: false },
+  async (_request, { user }) => {
+    if (user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+    }
+
+    const connectors = await loadAgentConnectorCapabilityOptions()
+    return NextResponse.json({ connectors })
+  },
+)

--- a/apps/web/src/app/api/u/[slug]/agents/connectors/route.ts
+++ b/apps/web/src/app/api/u/[slug]/agents/connectors/route.ts
@@ -17,6 +17,7 @@ export const GET = withAuth<AgentConnectorCapabilitiesResponse | { error: string
       return NextResponse.json({ error: 'forbidden' }, { status: 403 })
     }
 
+    // This catalog is global across workspaces; the slug is only used for authenticated routing.
     const connectors = await loadAgentConnectorCapabilityOptions()
     return NextResponse.json({ connectors })
   },

--- a/apps/web/src/app/api/u/[slug]/agents/route.ts
+++ b/apps/web/src/app/api/u/[slug]/agents/route.ts
@@ -4,17 +4,16 @@ import {
   buildAgentPermissionConfigFromCapabilities,
   buildAgentToolsConfigFromCapabilities,
   type AgentCapabilities,
+  type ConnectorCapabilityRecord,
   validateAgentCapabilityConnectorIds,
   validateAgentCapabilitySkillIds,
   validateAgentCapabilityTools,
 } from '@/lib/agent-capabilities'
+import { loadAgentConnectorCapabilityOptions } from '@/lib/agent-connector-capabilities'
 import { auditEvent } from '@/lib/auth'
 import { readCommonWorkspaceConfig, writeCommonWorkspaceConfig } from '@/lib/common-workspace-config-store'
-import type { ConnectorType } from '@/lib/connectors/types'
-import { validateConnectorType } from '@/lib/connectors/validators'
 import { withAuth } from '@/lib/runtime/with-auth'
 import { listSkills } from '@/lib/skills/skill-store'
-import { connectorService, userService } from '@/lib/services'
 import {
   type CommonAgentConfig,
   type CommonWorkspaceConfig,
@@ -58,13 +57,7 @@ type CreateAgentRequest = {
   }
 }
 
-type EnabledConnector = {
-  id: string
-  type: ConnectorType
-  enabled: boolean
-}
-
-const RESERVED_AGENT_IDS = new Set(['models'])
+const RESERVED_AGENT_IDS = new Set(['connectors', 'models'])
 
 async function loadCommonConfig() {
   const result = await readCommonWorkspaceConfig()
@@ -89,28 +82,17 @@ async function loadCommonConfig() {
   }
 }
 
-async function loadEnabledConnectorsForSlug(slug: string): Promise<EnabledConnector[]> {
-  const user = await userService.findIdBySlug(slug)
-  if (!user) return []
-
-  const connectors = await connectorService.findEnabledByUserId(user.id)
-
-  const enabled: EnabledConnector[] = []
-  for (const connector of connectors) {
-    if (!validateConnectorType(connector.type)) continue
-    enabled.push({
-      id: connector.id,
-      type: connector.type as ConnectorType,
-      enabled: connector.enabled,
-    })
-  }
-
-  return enabled
+async function loadAvailableConnectorCapabilities(): Promise<ConnectorCapabilityRecord[]> {
+  const connectors = await loadAgentConnectorCapabilityOptions()
+  return connectors.map((connector) => ({
+    id: connector.id,
+    type: connector.type,
+  }))
 }
 
 function parseCapabilities(
   value: unknown,
-  enabledConnectors: EnabledConnector[],
+  availableConnectors: ConnectorCapabilityRecord[],
   availableSkillIds: Set<string>,
 ): { ok: true; capabilities: AgentCapabilities } | { ok: false; error: string } {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -133,9 +115,9 @@ function parseCapabilities(
     return { ok: false, error: connectorResult.error }
   }
 
-  const enabledConnectorIds = new Set(enabledConnectors.map((connector) => connector.id))
+  const availableConnectorIds = new Set(availableConnectors.map((connector) => connector.id))
   const unknownConnectorId = connectorResult.connectorIds.find(
-    (connectorId) => !enabledConnectorIds.has(connectorId)
+    (connectorId) => !availableConnectorIds.has(connectorId)
   )
   if (unknownConnectorId) {
     return { ok: false, error: 'unknown_mcp_connector' }
@@ -268,7 +250,7 @@ export const POST = withAuth<{ agent: AgentListItem; hash?: string } | { error: 
         ? body.temperature
         : undefined
 
-    const enabledConnectors = await loadEnabledConnectorsForSlug(slug)
+    const availableConnectors = await loadAvailableConnectorCapabilities()
     const skillsResult = await listSkills()
     if (!skillsResult.ok) {
       const status = skillsResult.error === 'kb_unavailable' ? 503 : 500
@@ -277,7 +259,7 @@ export const POST = withAuth<{ agent: AgentListItem; hash?: string } | { error: 
 
     const capabilitiesResult = parseCapabilities(
       body.capabilities,
-      enabledConnectors,
+      availableConnectors,
       new Set(skillsResult.data.map((skill) => skill.name))
     )
     if (!capabilitiesResult.ok) {
@@ -292,7 +274,7 @@ export const POST = withAuth<{ agent: AgentListItem; hash?: string } | { error: 
       temperature,
       prompt,
       permission: buildAgentPermissionConfigFromCapabilities(capabilitiesResult.capabilities, undefined),
-      tools: buildAgentToolsConfigFromCapabilities(capabilitiesResult.capabilities, enabledConnectors),
+      tools: buildAgentToolsConfigFromCapabilities(capabilitiesResult.capabilities, availableConnectors),
     }
 
     const nextConfig: CommonWorkspaceConfig = {

--- a/apps/web/src/app/api/u/[slug]/agents/route.ts
+++ b/apps/web/src/app/api/u/[slug]/agents/route.ts
@@ -9,7 +9,7 @@ import {
   validateAgentCapabilitySkillIds,
   validateAgentCapabilityTools,
 } from '@/lib/agent-capabilities'
-import { loadAgentConnectorCapabilityOptions } from '@/lib/agent-connector-capabilities'
+import { loadAvailableConnectorCapabilities } from '@/lib/agent-connector-capabilities'
 import { auditEvent } from '@/lib/auth'
 import { readCommonWorkspaceConfig, writeCommonWorkspaceConfig } from '@/lib/common-workspace-config-store'
 import { withAuth } from '@/lib/runtime/with-auth'
@@ -80,14 +80,6 @@ async function loadCommonConfig() {
     config: parsed.config,
     hash: result.hash,
   }
-}
-
-async function loadAvailableConnectorCapabilities(): Promise<ConnectorCapabilityRecord[]> {
-  const connectors = await loadAgentConnectorCapabilityOptions()
-  return connectors.map((connector) => ({
-    id: connector.id,
-    type: connector.type,
-  }))
 }
 
 function parseCapabilities(

--- a/apps/web/src/app/api/u/[slug]/connectors/[id]/oauth/start/route.ts
+++ b/apps/web/src/app/api/u/[slug]/connectors/[id]/oauth/start/route.ts
@@ -13,6 +13,23 @@ type StartOAuthResponse = {
   authorizeUrl: string
 }
 
+function normalizeReturnTo(value: string | null): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  try {
+    const url = new URL(value, 'http://localhost')
+    if (url.origin !== 'http://localhost') {
+      return undefined
+    }
+
+    return `${url.pathname}${url.search}${url.hash}`
+  } catch {
+    return undefined
+  }
+}
+
 export const POST = withAuth<
   StartOAuthResponse | { error: string; message?: string },
   { slug: string; id: string }
@@ -41,6 +58,7 @@ export const POST = withAuth<
 
   const baseUrl = getPublicBaseUrl(request.headers, request.nextUrl.origin)
   const redirectUri = `${baseUrl}/api/connectors/oauth/callback`
+  const returnTo = normalizeReturnTo(request.nextUrl.searchParams.get('returnTo'))
 
   let connectorConfig: Record<string, unknown> | undefined
   if (connector.type === 'custom') {
@@ -59,6 +77,7 @@ export const POST = withAuth<
     const prepared = await prepareConnectorOAuthAuthorization({
       connectorId: connector.id,
       slug,
+      returnTo,
       userId: targetUser.id,
       connectorType: connector.type,
       redirectUri,

--- a/apps/web/src/app/api/u/[slug]/connectors/[id]/oauth/start/route.ts
+++ b/apps/web/src/app/api/u/[slug]/connectors/[id]/oauth/start/route.ts
@@ -2,7 +2,11 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { auditEvent } from '@/lib/auth'
 import { decryptConfig } from '@/lib/connectors/crypto'
-import { isOAuthConnectorType, prepareConnectorOAuthAuthorization } from '@/lib/connectors/oauth'
+import {
+  isOAuthConnectorType,
+  normalizeConnectorOAuthReturnTo,
+  prepareConnectorOAuthAuthorization,
+} from '@/lib/connectors/oauth'
 import { validateConnectorType } from '@/lib/connectors/validators'
 import { getPublicBaseUrl } from '@/lib/http'
 import { requireCapability } from '@/lib/runtime/require-capability'
@@ -11,23 +15,6 @@ import { connectorService, userService } from '@/lib/services'
 
 type StartOAuthResponse = {
   authorizeUrl: string
-}
-
-function normalizeReturnTo(value: string | null): string | undefined {
-  if (!value) {
-    return undefined
-  }
-
-  try {
-    const url = new URL(value, 'http://localhost')
-    if (url.origin !== 'http://localhost') {
-      return undefined
-    }
-
-    return `${url.pathname}${url.search}${url.hash}`
-  } catch {
-    return undefined
-  }
 }
 
 export const POST = withAuth<
@@ -58,7 +45,7 @@ export const POST = withAuth<
 
   const baseUrl = getPublicBaseUrl(request.headers, request.nextUrl.origin)
   const redirectUri = `${baseUrl}/api/connectors/oauth/callback`
-  const returnTo = normalizeReturnTo(request.nextUrl.searchParams.get('returnTo'))
+  const returnTo = normalizeConnectorOAuthReturnTo(request.nextUrl.searchParams.get('returnTo'))
 
   let connectorConfig: Record<string, unknown> | undefined
   if (connector.type === 'custom') {

--- a/apps/web/src/components/agents/agent-form.tsx
+++ b/apps/web/src/components/agents/agent-form.tsx
@@ -8,13 +8,14 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { notifyWorkspaceConfigChanged } from '@/lib/runtime/config-status-events'
-import { cn } from '@/lib/utils'
 import {
   OPENCODE_AGENT_TOOL_OPTIONS,
   type AgentCapabilities,
   type OpenCodeAgentToolId,
 } from '@/lib/agent-capabilities'
+import type { AgentConnectorCapabilityOption } from '@/lib/agent-connector-capabilities'
+import { notifyWorkspaceConfigChanged } from '@/lib/runtime/config-status-events'
+import { cn } from '@/lib/utils'
 
 type AgentFormProps = {
   agentId?: string
@@ -30,13 +31,6 @@ type AgentFormProps = {
 type ModelOption = {
   id: string
   label: string
-}
-
-type ConnectorListItem = {
-  id: string
-  type: string
-  name: string
-  enabled: boolean
 }
 
 type SkillListItem = {
@@ -64,7 +58,7 @@ export function AgentForm({
   const [enabledTools, setEnabledTools] = useState<OpenCodeAgentToolId[]>([])
   const [enabledMcpConnectorIds, setEnabledMcpConnectorIds] = useState<string[]>([])
   const [enabledSkillIds, setEnabledSkillIds] = useState<string[]>([])
-  const [connectors, setConnectors] = useState<ConnectorListItem[]>([])
+  const [connectors, setConnectors] = useState<AgentConnectorCapabilityOption[]>([])
   const [skills, setSkills] = useState<SkillListItem[]>([])
   const [modelOptions, setModelOptions] = useState<ModelOption[]>([])
   const [hash, setHash] = useState<string | undefined>()
@@ -82,7 +76,7 @@ export function AgentForm({
     async function loadFormOptions() {
       const [modelsResponse, connectorsResponse, skillsResponse] = await Promise.all([
         fetch(`/api/u/${slug}/agents/models`, { cache: 'no-store' }).catch(() => null),
-        fetch(`/api/u/${slug}/connectors`, { cache: 'no-store' }).catch(() => null),
+        fetch(`/api/u/${slug}/agents/connectors`, { cache: 'no-store' }).catch(() => null),
         fetch(`/api/u/${slug}/skills`, { cache: 'no-store' }).catch(() => null),
       ])
 
@@ -97,13 +91,13 @@ export function AgentForm({
 
       if (connectorsResponse?.ok) {
         const data = (await connectorsResponse.json().catch(() => null)) as
-          | { connectors?: ConnectorListItem[] }
+          | { connectors?: AgentConnectorCapabilityOption[] }
           | null
-        const enabledConnectorList = (data?.connectors ?? []).filter((connector) => connector.enabled)
-        setConnectors(enabledConnectorList)
+        const availableConnectors = data?.connectors ?? []
+        setConnectors(availableConnectors)
         setEnabledMcpConnectorIds((current) =>
           current.filter((connectorId) =>
-            enabledConnectorList.some((connector) => connector.id === connectorId)
+            availableConnectors.some((connector) => connector.id === connectorId)
           )
         )
       }
@@ -510,18 +504,21 @@ export function AgentForm({
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="right" className="max-w-[240px] text-xs leading-relaxed">
-                  MCP connectors let the agent interact with external services like Linear, Notion, or custom APIs. Manage connectors from the Connectors page.
+                  Built-in MCP connectors apply globally by type. Custom connectors are granted per configured connector across all workspaces, including service users.
                 </TooltipContent>
               </Tooltip>
             </div>
             {connectors.length === 0 ? (
               <div className="flex items-center gap-2 rounded-lg border border-dashed border-border/60 px-3 py-2.5 text-sm text-muted-foreground/70">
-                No enabled connectors available.
+                No connectors available.
               </div>
             ) : (
               <div className="grid gap-2 md:grid-cols-2">
                 {connectors.map((connector) => {
                   const checked = enabledMcpConnectorIds.includes(connector.id)
+                  const metadata = connector.scope === 'type'
+                    ? 'All workspaces with this connector type'
+                    : `${connector.ownerSlug ?? 'Unknown workspace'}${connector.ownerKind === 'SERVICE' ? ' service workspace' : ''}${connector.enabled ? '' : ' · disabled'}`
                   return (
                     <label
                       key={connector.id}
@@ -531,15 +528,19 @@ export function AgentForm({
                           ? 'border-primary/40 bg-primary/5 text-foreground'
                           : 'border-border/60 bg-card/40 text-muted-foreground hover:bg-card/70'
                       )}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        onChange={() => toggleMcpConnector(connector.id)}
-                        className={checkboxClassName}
-                      />
-                      <span className="font-medium">{connector.name}</span>
-                      <span className="text-xs text-muted-foreground">{connector.type}</span>
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => toggleMcpConnector(connector.id)}
+                          className={checkboxClassName}
+                        />
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate font-medium">{connector.name}</span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {connector.type} · {metadata}
+                          </span>
+                        </span>
                     </label>
                   )
                 })}

--- a/apps/web/src/components/agents/agent-form.tsx
+++ b/apps/web/src/components/agents/agent-form.tsx
@@ -528,19 +528,19 @@ export function AgentForm({
                           ? 'border-primary/40 bg-primary/5 text-foreground'
                           : 'border-border/60 bg-card/40 text-muted-foreground hover:bg-card/70'
                       )}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={checked}
-                          onChange={() => toggleMcpConnector(connector.id)}
-                          className={checkboxClassName}
-                        />
-                        <span className="min-w-0 flex-1">
-                          <span className="block truncate font-medium">{connector.name}</span>
-                          <span className="block truncate text-xs text-muted-foreground">
-                            {connector.type} · {metadata}
-                          </span>
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggleMcpConnector(connector.id)}
+                        className={checkboxClassName}
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate font-medium">{connector.name}</span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {connector.type} · {metadata}
                         </span>
+                      </span>
                     </label>
                   )
                 })}

--- a/apps/web/src/components/connectors/connectors-manager.tsx
+++ b/apps/web/src/components/connectors/connectors-manager.tsx
@@ -19,6 +19,7 @@ type ConnectorsManagerProps = {
   embedded?: boolean
   title?: string
   description?: string
+  oauthReturnTo?: string
 }
 
 function toConnectorListItemArray(value: unknown): ConnectorListItem[] {
@@ -47,6 +48,7 @@ export function ConnectorsManager({
   embedded = false,
   title = 'Connectors',
   description = 'Configure integrations for your workspace.',
+  oauthReturnTo,
 }: ConnectorsManagerProps) {
   const [connectors, setConnectors] = useState<ConnectorListItem[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -227,7 +229,12 @@ export function ConnectorsManager({
       setActionError(null)
 
       try {
-        const response = await fetch(`/api/u/${slug}/connectors/${id}/oauth/start`, {
+        const requestUrl = new URL(`/api/u/${slug}/connectors/${id}/oauth/start`, window.location.origin)
+        if (oauthReturnTo) {
+          requestUrl.searchParams.set('returnTo', oauthReturnTo)
+        }
+
+        const response = await fetch(`${requestUrl.pathname}${requestUrl.search}`, {
           method: 'POST',
           headers: { accept: 'application/json' },
         })
@@ -247,7 +254,7 @@ export function ConnectorsManager({
         markConnectorBusy(id, false)
       }
     },
-    [markConnectorBusy, slug],
+    [markConnectorBusy, oauthReturnTo, slug],
   )
 
   const content = (

--- a/apps/web/src/components/settings/slack-integration-settings-content.test.tsx
+++ b/apps/web/src/components/settings/slack-integration-settings-content.test.tsx
@@ -1,7 +1,13 @@
 /** @vitest-environment jsdom */
 
-import { fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/components/connectors/connectors-manager', () => ({
+  ConnectorsManager: ({ slug, oauthReturnTo }: { slug: string; oauthReturnTo?: string }) => (
+    <div>Connectors {slug} {oauthReturnTo}</div>
+  ),
+}))
 
 vi.mock('@/components/providers/provider-credentials-panel', () => ({
   ProviderCredentialsPanel: ({ slug }: { slug: string }) => <div>Provider credentials {slug}</div>,
@@ -37,6 +43,7 @@ vi.mock('@/components/settings/slack-integration-danger-zone', () => ({
 
 describe('SlackIntegrationSettingsContent', () => {
   beforeEach(() => {
+    cleanup()
     vi.clearAllMocks()
   })
 
@@ -53,6 +60,7 @@ describe('SlackIntegrationSettingsContent', () => {
 
     expect(screen.getByRole('button', { name: 'Panel refresh 0' })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Danger refresh 0' })).toBeTruthy()
+    expect(screen.getByText('Connectors slack-bot /u/alice/settings/integrations/slack')).toBeTruthy()
 
     fireEvent.click(screen.getByRole('button', { name: 'Panel refresh 0' }))
 
@@ -63,5 +71,20 @@ describe('SlackIntegrationSettingsContent', () => {
 
     expect(screen.getByRole('button', { name: 'Panel refresh 2' })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Danger refresh 2' })).toBeTruthy()
+  })
+
+  it('hides service workspace panels when the reserved service user is unavailable', async () => {
+    const { SlackIntegrationSettingsContent } = await import('./slack-integration-settings-content')
+
+    render(
+      <SlackIntegrationSettingsContent
+        serviceUserSlug="slack-bot"
+        showProviderCredentials={false}
+        slug="alice"
+      />,
+    )
+
+    expect(screen.queryByText(/Provider credentials slack-bot/)).toBeNull()
+    expect(screen.queryByText(/Connectors slack-bot/)).toBeNull()
   })
 })

--- a/apps/web/src/components/settings/slack-integration-settings-content.tsx
+++ b/apps/web/src/components/settings/slack-integration-settings-content.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 
+import { ConnectorsManager } from '@/components/connectors/connectors-manager'
 import { ProviderCredentialsPanel } from '@/components/providers/provider-credentials-panel'
 import { SettingsSection } from '@/components/settings/settings-section'
 import { SlackIntegrationDangerZone } from '@/components/settings/slack-integration-danger-zone'
@@ -35,12 +36,27 @@ export function SlackIntegrationSettingsContent({
       />
 
       {showProviderCredentials ? (
-        <SettingsSection
-          title="Provider credentials for Slack bot"
-          description="Manage API access for the reserved slack-bot service workspace used to generate Slack replies."
-        >
-          <ProviderCredentialsPanel slug={serviceUserSlug} showHeader={false} />
-        </SettingsSection>
+        <>
+          <SettingsSection
+            title="Provider credentials for Slack bot"
+            description="Manage API access for the reserved slack-bot service workspace used to generate Slack replies."
+          >
+            <ProviderCredentialsPanel slug={serviceUserSlug} showHeader={false} />
+          </SettingsSection>
+
+          <SettingsSection
+            title="Connectors for Slack bot"
+            description="Create, enable, and test the connectors available to the reserved slack-bot service workspace."
+          >
+            <ConnectorsManager
+              slug={serviceUserSlug}
+              embedded
+              title="Slack bot connectors"
+              description="These connectors are available to the slack-bot service workspace when an agent capability allows them."
+              oauthReturnTo={`/u/${slug}/settings/integrations/slack`}
+            />
+          </SettingsSection>
+        </>
       ) : null}
 
       <SlackIntegrationDangerZone

--- a/apps/web/src/lib/__tests__/agent-capabilities.test.ts
+++ b/apps/web/src/lib/__tests__/agent-capabilities.test.ts
@@ -40,12 +40,12 @@ describe('agent-capabilities', () => {
       {
         skillIds: ['pdf-processing'],
         tools: ['document_inspect', 'presentation_inspect', 'read', 'grep'],
-        mcpConnectorIds: ['cntr1', 'cntr3'],
+        mcpConnectorIds: ['globallinear', 'globalzendesk'],
       },
       [
-        { id: 'cntr1', type: 'linear', enabled: true },
-        { id: 'cntr2', type: 'notion', enabled: true },
-        { id: 'cntr3', type: 'zendesk', enabled: true },
+        { id: 'globallinear', type: 'linear' },
+        { id: 'globalnotion', type: 'notion' },
+        { id: 'globalzendesk', type: 'zendesk' },
       ]
     )
 
@@ -56,9 +56,9 @@ describe('agent-capabilities', () => {
     expect(config.skill).toBe(true)
     expect(config.write).toBe(false)
     expect(config['arche_*']).toBe(false)
-    expect(config['arche_linear_cntr1_*']).toBe(true)
-    expect(config['arche_zendesk_cntr3_*']).toBe(true)
-    expect(config['arche_notion_cntr2_*']).toBeUndefined()
+    expect(config['arche_linear_globallinear_*']).toBe(true)
+    expect(config['arche_zendesk_globalzendesk_*']).toBe(true)
+    expect(config['arche_notion_globalnotion_*']).toBeUndefined()
   })
 
   it('extracts capabilities from tools config', () => {
@@ -84,7 +84,7 @@ describe('agent-capabilities', () => {
     expect(capabilities).toEqual({
       skillIds: ['pdf-processing'],
       tools: ['document_inspect', 'grep', 'read'],
-      mcpConnectorIds: ['conn123', 'conn456'],
+      mcpConnectorIds: ['conn123', 'globalzendesk'],
     })
   })
 

--- a/apps/web/src/lib/__tests__/agent-connector-capabilities.test.ts
+++ b/apps/web/src/lib/__tests__/agent-connector-capabilities.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildAgentConnectorCapabilityOptions } from '@/lib/agent-connector-capabilities'
+
+describe('agent connector capabilities', () => {
+  it('includes built-in connector types and custom connectors across human and service users', () => {
+    const options = buildAgentConnectorCapabilityOptions([
+      {
+        id: 'linear-user-1',
+        type: 'linear',
+        name: 'Linear',
+        enabled: true,
+        user: { kind: 'HUMAN', slug: 'alice' },
+      },
+      {
+        id: 'custom-user-1',
+        type: 'custom',
+        name: 'Alice MCP',
+        enabled: true,
+        user: { kind: 'HUMAN', slug: 'alice' },
+      },
+      {
+        id: 'custom-service-1',
+        type: 'custom',
+        name: 'Slack MCP',
+        enabled: false,
+        user: { kind: 'SERVICE', slug: 'slack-bot' },
+      },
+    ])
+
+    expect(options).toEqual([
+      {
+        id: 'globallinear',
+        type: 'linear',
+        name: 'Linear',
+        enabled: true,
+        scope: 'type',
+        ownerKind: null,
+        ownerSlug: null,
+      },
+      {
+        id: 'globalnotion',
+        type: 'notion',
+        name: 'Notion',
+        enabled: false,
+        scope: 'type',
+        ownerKind: null,
+        ownerSlug: null,
+      },
+      {
+        id: 'globalzendesk',
+        type: 'zendesk',
+        name: 'Zendesk',
+        enabled: false,
+        scope: 'type',
+        ownerKind: null,
+        ownerSlug: null,
+      },
+      {
+        id: 'custom-user-1',
+        type: 'custom',
+        name: 'Alice MCP',
+        enabled: true,
+        scope: 'connector',
+        ownerKind: 'HUMAN',
+        ownerSlug: 'alice',
+      },
+      {
+        id: 'custom-service-1',
+        type: 'custom',
+        name: 'Slack MCP',
+        enabled: false,
+        scope: 'connector',
+        ownerKind: 'SERVICE',
+        ownerSlug: 'slack-bot',
+      },
+    ])
+  })
+
+  it('coalesces multiple single-instance connectors into one global capability per type', () => {
+    const options = buildAgentConnectorCapabilityOptions([
+      {
+        id: 'linear-user-1',
+        type: 'linear',
+        name: 'Linear',
+        enabled: false,
+        user: { kind: 'HUMAN', slug: 'alice' },
+      },
+      {
+        id: 'linear-user-2',
+        type: 'linear',
+        name: 'Linear',
+        enabled: true,
+        user: { kind: 'SERVICE', slug: 'slack-bot' },
+      },
+    ])
+
+    expect(options.filter((option) => option.type === 'linear')).toEqual([
+      {
+        id: 'globallinear',
+        type: 'linear',
+        name: 'Linear',
+        enabled: true,
+        scope: 'type',
+        ownerKind: null,
+        ownerSlug: null,
+      },
+    ])
+  })
+})

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -1,4 +1,8 @@
-import { CONNECTOR_TYPES, type ConnectorType } from '@/lib/connectors/types'
+import {
+  CONNECTOR_TYPES,
+  isSingleInstanceConnectorType,
+  type ConnectorType,
+} from '@/lib/connectors/types'
 import { SKILL_NAME_PATTERN } from '@/lib/skills/types'
 
 export const OPENCODE_AGENT_TOOLS = [
@@ -61,8 +65,13 @@ export type AgentCapabilities = {
 export type ConnectorCapabilityRecord = {
   id: string
   type: ConnectorType
-  enabled: boolean
 }
+
+const SINGLE_INSTANCE_AGENT_CONNECTOR_CAPABILITY_IDS = {
+  linear: 'globallinear',
+  notion: 'globalnotion',
+  zendesk: 'globalzendesk',
+} as const satisfies Record<Exclude<ConnectorType, 'custom'>, string>
 
 const TOOL_SET = new Set<string>(OPENCODE_AGENT_TOOLS)
 const CONNECTOR_TYPE_PATTERN = CONNECTOR_TYPES.join('|')
@@ -70,6 +79,16 @@ export const MCP_TOOL_PATTERN = new RegExp(`^arche_(${CONNECTOR_TYPE_PATTERN})_(
 
 function buildMcpServerKey(type: ConnectorType, id: string): string {
   return `arche_${type}_${id}`
+}
+
+export function getConnectorCapabilityId(type: ConnectorType, id: string): string {
+  if (type === 'custom') {
+    return id
+  }
+
+  return isSingleInstanceConnectorType(type)
+    ? SINGLE_INSTANCE_AGENT_CONNECTOR_CAPABILITY_IDS[type]
+    : id
 }
 
 function uniqueSorted(values: string[]): string[] {
@@ -175,7 +194,7 @@ export function buildAgentToolsConfigFromCapabilities(
   const connectorById = new Map(connectors.map((connector) => [connector.id, connector]))
   for (const connectorId of capabilities.mcpConnectorIds) {
     const connector = connectorById.get(connectorId)
-    if (!connector || !connector.enabled) continue
+    if (!connector) continue
     const serverKey = buildMcpServerKey(connector.type, connector.id)
     toolConfig[`${serverKey}_*`] = true
   }
@@ -201,7 +220,8 @@ export function extractAgentCapabilitiesFromTools(
     .flatMap(([toolId]) => {
       const match = toolId.match(MCP_TOOL_PATTERN)
       if (!match) return []
-      return [match[2]]
+      const [, type, connectorId] = match
+      return [getConnectorCapabilityId(type as ConnectorType, connectorId)]
     })
 
   let skillIds: string[] = []

--- a/apps/web/src/lib/agent-connector-capabilities.ts
+++ b/apps/web/src/lib/agent-connector-capabilities.ts
@@ -1,6 +1,6 @@
 import type { UserKind } from '@prisma/client'
 
-import { getConnectorCapabilityId } from '@/lib/agent-capabilities'
+import { getConnectorCapabilityId, type ConnectorCapabilityRecord } from '@/lib/agent-capabilities'
 import {
   isSingleInstanceConnectorType,
   SINGLE_INSTANCE_CONNECTOR_TYPES,
@@ -19,16 +19,11 @@ export type AgentConnectorCapabilityOption = {
   ownerSlug: string | null
 }
 
-function getSingleInstanceConnectorLabel(type: Exclude<ConnectorType, 'custom'>): string {
-  switch (type) {
-    case 'linear':
-      return 'Linear'
-    case 'notion':
-      return 'Notion'
-    case 'zendesk':
-      return 'Zendesk'
-  }
-}
+const SINGLE_INSTANCE_CONNECTOR_LABELS = {
+  linear: 'Linear',
+  notion: 'Notion',
+  zendesk: 'Zendesk',
+} as const satisfies Record<Exclude<ConnectorType, 'custom'>, string>
 
 export function buildAgentConnectorCapabilityOptions(entries: Array<{
   id: string
@@ -43,7 +38,7 @@ export function buildAgentConnectorCapabilityOptions(entries: Array<{
     options.set(getConnectorCapabilityId(type, type), {
       id: getConnectorCapabilityId(type, type),
       type,
-      name: getSingleInstanceConnectorLabel(type),
+      name: SINGLE_INSTANCE_CONNECTOR_LABELS[type],
       enabled: false,
       scope: 'type',
       ownerKind: null,
@@ -97,4 +92,12 @@ export function buildAgentConnectorCapabilityOptions(entries: Array<{
 export async function loadAgentConnectorCapabilityOptions(): Promise<AgentConnectorCapabilityOption[]> {
   const entries = await connectorService.findCapabilityInventoryEntries()
   return buildAgentConnectorCapabilityOptions(entries)
+}
+
+export async function loadAvailableConnectorCapabilities(): Promise<ConnectorCapabilityRecord[]> {
+  const connectors = await loadAgentConnectorCapabilityOptions()
+  return connectors.map((connector) => ({
+    id: connector.id,
+    type: connector.type,
+  }))
 }

--- a/apps/web/src/lib/agent-connector-capabilities.ts
+++ b/apps/web/src/lib/agent-connector-capabilities.ts
@@ -1,0 +1,100 @@
+import type { UserKind } from '@prisma/client'
+
+import { getConnectorCapabilityId } from '@/lib/agent-capabilities'
+import {
+  isSingleInstanceConnectorType,
+  SINGLE_INSTANCE_CONNECTOR_TYPES,
+  type ConnectorType,
+} from '@/lib/connectors/types'
+import { validateConnectorType } from '@/lib/connectors/validators'
+import { connectorService } from '@/lib/services'
+
+export type AgentConnectorCapabilityOption = {
+  id: string
+  type: ConnectorType
+  name: string
+  enabled: boolean
+  scope: 'connector' | 'type'
+  ownerKind: UserKind | null
+  ownerSlug: string | null
+}
+
+function getSingleInstanceConnectorLabel(type: Exclude<ConnectorType, 'custom'>): string {
+  switch (type) {
+    case 'linear':
+      return 'Linear'
+    case 'notion':
+      return 'Notion'
+    case 'zendesk':
+      return 'Zendesk'
+  }
+}
+
+export function buildAgentConnectorCapabilityOptions(entries: Array<{
+  id: string
+  type: string
+  name: string
+  enabled: boolean
+  user: { kind: UserKind; slug: string }
+}>): AgentConnectorCapabilityOption[] {
+  const options = new Map<string, AgentConnectorCapabilityOption>()
+
+  for (const type of SINGLE_INSTANCE_CONNECTOR_TYPES) {
+    options.set(getConnectorCapabilityId(type, type), {
+      id: getConnectorCapabilityId(type, type),
+      type,
+      name: getSingleInstanceConnectorLabel(type),
+      enabled: false,
+      scope: 'type',
+      ownerKind: null,
+      ownerSlug: null,
+    })
+  }
+
+  for (const entry of entries) {
+    if (!validateConnectorType(entry.type)) continue
+
+    if (isSingleInstanceConnectorType(entry.type)) {
+      const id = getConnectorCapabilityId(entry.type, entry.id)
+      const existing = options.get(id)
+      if (!existing) continue
+
+      options.set(id, {
+        ...existing,
+        enabled: existing.enabled || entry.enabled,
+      })
+      continue
+    }
+
+    options.set(entry.id, {
+      id: entry.id,
+      type: entry.type,
+      name: entry.name,
+      enabled: entry.enabled,
+      scope: 'connector',
+      ownerKind: entry.user.kind,
+      ownerSlug: entry.user.slug,
+    })
+  }
+
+  return Array.from(options.values()).sort((left, right) => {
+    if (left.scope !== right.scope) {
+      return left.scope === 'type' ? -1 : 1
+    }
+
+    if (left.type !== right.type) {
+      return left.type.localeCompare(right.type)
+    }
+
+    if (left.name !== right.name) {
+      return left.name.localeCompare(right.name)
+    }
+
+    return (left.ownerSlug ?? '').localeCompare(right.ownerSlug ?? '')
+  })
+}
+
+export async function loadAgentConnectorCapabilityOptions(): Promise<AgentConnectorCapabilityOption[]> {
+  const entries = await connectorService.findCapabilityInventoryEntries()
+  return buildAgentConnectorCapabilityOptions(entries)
+}

--- a/apps/web/src/lib/connectors/oauth.ts
+++ b/apps/web/src/lib/connectors/oauth.ts
@@ -6,6 +6,7 @@ import { validateConnectorTestEndpoint } from '@/lib/security/ssrf'
 type OAuthStatePayload = {
   connectorId: string
   slug: string
+  returnTo?: string
   userId: string
   connectorType: OAuthConnectorType
   exp: number
@@ -445,6 +446,7 @@ export function isOAuthConnectorType(type: ConnectorType): type is OAuthConnecto
 export function issueConnectorOAuthState(input: {
   connectorId: string
   slug: string
+  returnTo?: string
   userId: string
   connectorType: OAuthConnectorType
   redirectUri?: string
@@ -460,6 +462,7 @@ export function issueConnectorOAuthState(input: {
   return encodeStatePayload({
     connectorId: input.connectorId,
     slug: input.slug,
+    returnTo: input.returnTo,
     userId: input.userId,
     connectorType: input.connectorType,
     exp: Math.floor(Date.now() / 1000) + getOAuthStateTtlSeconds(),
@@ -483,6 +486,7 @@ export function verifyConnectorOAuthState(token: string): OAuthStatePayload {
 export async function prepareConnectorOAuthAuthorization(input: {
   connectorId: string
   slug: string
+  returnTo?: string
   userId: string
   connectorType: OAuthConnectorType
   redirectUri: string
@@ -507,6 +511,7 @@ export async function prepareConnectorOAuthAuthorization(input: {
   const state = issueConnectorOAuthState({
     connectorId: input.connectorId,
     slug: input.slug,
+    returnTo: input.returnTo,
     userId: input.userId,
     connectorType: input.connectorType,
     redirectUri: input.redirectUri,

--- a/apps/web/src/lib/connectors/oauth.ts
+++ b/apps/web/src/lib/connectors/oauth.ts
@@ -443,6 +443,23 @@ export function isOAuthConnectorType(type: ConnectorType): type is OAuthConnecto
   return OAUTH_CONNECTOR_TYPES.includes(type as OAuthConnectorType)
 }
 
+export function normalizeConnectorOAuthReturnTo(value: string | null | undefined): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  try {
+    const url = new URL(value, 'http://localhost')
+    if (url.origin !== 'http://localhost') {
+      return undefined
+    }
+
+    return `${url.pathname}${url.search}${url.hash}`
+  } catch {
+    return undefined
+  }
+}
+
 export function issueConnectorOAuthState(input: {
   connectorId: string
   slug: string

--- a/apps/web/src/lib/services/__tests__/services.test.ts
+++ b/apps/web/src/lib/services/__tests__/services.test.ts
@@ -251,6 +251,33 @@ describe('service layer', () => {
       expect(mockPrisma.connector.findFirst).toHaveBeenCalledWith({ where: { id: 'c1', userId: 'u1' } })
     })
 
+    it('findCapabilityInventoryEntries returns connector owners', async () => {
+      mockPrisma.connector.findMany.mockResolvedValue([])
+
+      const { connectorService } = await import('../index')
+      await connectorService.findCapabilityInventoryEntries()
+
+      expect(mockPrisma.connector.findMany).toHaveBeenCalledWith({
+        select: {
+          id: true,
+          type: true,
+          name: true,
+          enabled: true,
+          user: {
+            select: {
+              kind: true,
+              slug: true,
+            },
+          },
+        },
+        orderBy: [
+          { type: 'asc' },
+          { name: 'asc' },
+          { id: 'asc' },
+        ],
+      })
+    })
+
     it('updateManyByIdAndUserId scopes update to both id and userId', async () => {
       mockPrisma.connector.updateMany.mockResolvedValue({ count: 1 })
 

--- a/apps/web/src/lib/services/connector.ts
+++ b/apps/web/src/lib/services/connector.ts
@@ -1,3 +1,5 @@
+import type { UserKind } from '@prisma/client'
+
 import { prisma } from '@/lib/prisma'
 
 // ---------------------------------------------------------------------------
@@ -32,6 +34,17 @@ export type ConnectorHashEntry = {
   type: string
   enabled: boolean
   updatedAt: Date
+}
+
+export type ConnectorCapabilityInventoryEntry = {
+  id: string
+  type: string
+  name: string
+  enabled: boolean
+  user: {
+    kind: UserKind
+    slug: string
+  }
 }
 
 export type ConnectorFullRecord = {
@@ -76,6 +89,28 @@ export function findHashEntriesByUserId(userId: string): Promise<ConnectorHashEn
     where: { userId },
     select: { id: true, type: true, enabled: true, updatedAt: true },
     orderBy: { id: 'asc' },
+  })
+}
+
+export function findCapabilityInventoryEntries(): Promise<ConnectorCapabilityInventoryEntry[]> {
+  return prisma.connector.findMany({
+    select: {
+      id: true,
+      type: true,
+      name: true,
+      enabled: true,
+      user: {
+        select: {
+          kind: true,
+          slug: true,
+        },
+      },
+    },
+    orderBy: [
+      { type: 'asc' },
+      { name: 'asc' },
+      { id: 'asc' },
+    ],
   })
 }
 

--- a/apps/web/src/lib/spawner/__tests__/agent-config-transforms.test.ts
+++ b/apps/web/src/lib/spawner/__tests__/agent-config-transforms.test.ts
@@ -219,7 +219,7 @@ describe('remapAgentConnectorTools', () => {
     expect(tools.task).toBe(true)
   })
 
-  it('adds all user connectors when user has multiple custom connectors', () => {
+  it('keeps custom connector access scoped to the exact connector id', () => {
     const config = {
       agent: {
         worker: {
@@ -234,9 +234,22 @@ describe('remapAgentConnectorTools', () => {
     const result = remapAgentConnectorTools(config, userKeys)
     const tools = (result.agent as Record<string, Record<string, unknown>>).worker.tools as Record<string, boolean>
 
-    expect(tools['arche_custom_user1_*']).toBe(true)
-    expect(tools['arche_custom_user2_*']).toBe(true)
     expect(tools['arche_custom_admin1_*']).toBeUndefined()
+  })
+
+  it('preserves custom connector access when the exact connector exists', () => {
+    const config = {
+      agent: {
+        worker: {
+          tools: {
+            'arche_custom_sameconnector_*': true,
+          },
+        },
+      },
+    }
+
+    const result = remapAgentConnectorTools(config, new Set(['arche_custom_sameconnector']))
+    expect(result).toBe(config)
   })
 
   it('preserves arche_*: false', () => {

--- a/apps/web/src/lib/spawner/agent-config-transforms.ts
+++ b/apps/web/src/lib/spawner/agent-config-transforms.ts
@@ -1,5 +1,5 @@
 import { MCP_TOOL_PATTERN } from '@/lib/agent-capabilities'
-import { CONNECTOR_TYPES } from '@/lib/connectors/types'
+import { CONNECTOR_TYPES, isSingleInstanceConnectorType, type ConnectorType } from '@/lib/connectors/types'
 
 const CONNECTOR_TYPE_PATTERN = CONNECTOR_TYPES.join('|')
 const MCP_SERVER_KEY_PATTERN = new RegExp(`^arche_(${CONNECTOR_TYPE_PATTERN})_([a-z0-9]+)$`)
@@ -142,6 +142,17 @@ export function remapAgentConnectorTools(
       }
 
       const [, type, adminId] = match
+
+      if (!isSingleInstanceConnectorType(type as ConnectorType)) {
+        if (userMcpKeys.has(`arche_${type}_${adminId}`)) {
+          nextTools[toolKey] = enabled
+          continue
+        }
+
+        toolsChanged = true
+        continue
+      }
+
       const userIds = userConnectorsByType.get(type)
 
       if (!userIds || userIds.length === 0) {

--- a/apps/web/tests/agent-connectors-route.test.ts
+++ b/apps/web/tests/agent-connectors-route.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetSession = vi.fn()
+const mockGetRuntimeCapabilities = vi.fn()
+const mockIsDesktop = vi.fn(() => false)
+const mockValidateDesktopToken = vi.fn(() => false)
+const mockLoadAgentConnectorCapabilityOptions = vi.fn()
+
+function session(slug: string, role: 'USER' | 'ADMIN' = 'USER') {
+  return {
+    user: { id: 'user-1', email: 'alice@example.com', slug, role },
+    sessionId: 'session-1',
+  }
+}
+
+async function loadRoute() {
+  vi.doMock('@/lib/runtime/session', () => ({
+    getSession: () => mockGetSession(),
+  }))
+
+  vi.doMock('@/lib/runtime/mode', () => ({
+    isDesktop: () => mockIsDesktop(),
+  }))
+
+  vi.doMock('@/lib/runtime/capabilities', () => ({
+    getRuntimeCapabilities: () => mockGetRuntimeCapabilities(),
+  }))
+
+  vi.doMock('@/lib/runtime/desktop/token', () => ({
+    DESKTOP_TOKEN_HEADER: 'x-arche-desktop-token',
+    validateDesktopToken: () => mockValidateDesktopToken(),
+  }))
+
+  vi.doMock('@/lib/agent-connector-capabilities', () => ({
+    loadAgentConnectorCapabilityOptions: () => mockLoadAgentConnectorCapabilityOptions(),
+  }))
+
+  return import('@/app/api/u/[slug]/agents/connectors/route')
+}
+
+describe('GET /api/u/[slug]/agents/connectors', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    mockGetRuntimeCapabilities.mockReturnValue({
+      multiUser: true,
+      auth: true,
+      containers: true,
+      workspaceAgent: true,
+      reaper: true,
+      connectors: true,
+      csrf: true,
+      teamManagement: true,
+      kickstart: true,
+      autopilot: true,
+      slackIntegration: true,
+      twoFactor: false,
+    })
+  })
+
+  it('returns the global connector capability catalog for admins', async () => {
+    mockGetSession.mockResolvedValue(session('admin', 'ADMIN'))
+    mockLoadAgentConnectorCapabilityOptions.mockResolvedValue([
+      {
+        id: 'globallinear',
+        type: 'linear',
+        name: 'Linear',
+        enabled: true,
+        scope: 'type',
+        ownerKind: null,
+        ownerSlug: null,
+      },
+      {
+        id: 'custom-1',
+        type: 'custom',
+        name: 'Slack MCP',
+        enabled: false,
+        scope: 'connector',
+        ownerKind: 'SERVICE',
+        ownerSlug: 'slack-bot',
+      },
+    ])
+
+    const { GET } = await loadRoute()
+    const response = await GET(new Request('http://localhost/api/u/admin/agents/connectors') as never, {
+      params: Promise.resolve({ slug: 'admin' }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      connectors: [
+        {
+          id: 'globallinear',
+          type: 'linear',
+          name: 'Linear',
+          enabled: true,
+          scope: 'type',
+          ownerKind: null,
+          ownerSlug: null,
+        },
+        {
+          id: 'custom-1',
+          type: 'custom',
+          name: 'Slack MCP',
+          enabled: false,
+          scope: 'connector',
+          ownerKind: 'SERVICE',
+          ownerSlug: 'slack-bot',
+        },
+      ],
+    })
+  })
+
+  it('rejects non-admin users', async () => {
+    mockGetSession.mockResolvedValue(session('alice', 'USER'))
+
+    const { GET } = await loadRoute()
+    const response = await GET(new Request('http://localhost/api/u/alice/agents/connectors') as never, {
+      params: Promise.resolve({ slug: 'alice' }),
+    })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ error: 'forbidden' })
+    expect(mockLoadAgentConnectorCapabilityOptions).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/tests/connectors-oauth-callback-route.test.ts
+++ b/apps/web/tests/connectors-oauth-callback-route.test.ts
@@ -42,11 +42,16 @@ async function loadRoute() {
     },
   }))
 
-  vi.doMock('@/lib/connectors/oauth', () => ({
-    exchangeConnectorOAuthCode: (...args: unknown[]) => mockExchangeConnectorOAuthCode(...args),
-    isOAuthConnectorType: () => true,
-    verifyConnectorOAuthState: (...args: unknown[]) => mockVerifyConnectorOAuthState(...args),
-  }))
+  vi.doMock('@/lib/connectors/oauth', async () => {
+    const actual = await vi.importActual<typeof import('@/lib/connectors/oauth')>('@/lib/connectors/oauth')
+
+    return {
+      ...actual,
+      exchangeConnectorOAuthCode: (...args: unknown[]) => mockExchangeConnectorOAuthCode(...args),
+      isOAuthConnectorType: () => true,
+      verifyConnectorOAuthState: (...args: unknown[]) => mockVerifyConnectorOAuthState(...args),
+    }
+  })
 
   vi.doMock('@/lib/connectors/crypto', () => ({
     decryptConfig: (...args: unknown[]) => mockDecryptConfig(...args),
@@ -118,7 +123,7 @@ describe('GET /api/connectors/oauth/callback', () => {
     mockVerifyConnectorOAuthState.mockReturnValue({
       connectorId: 'custom-1',
       slug: 'slack-bot',
-      returnTo: 'https://evil.example.com/steal',
+      returnTo: '/\\evil.example.com',
       userId: 'service-1',
       connectorType: 'custom',
       clientId: 'client-id',
@@ -137,6 +142,34 @@ describe('GET /api/connectors/oauth/callback', () => {
 
     expect(response.headers.get('location')).toBe(
       'https://arche.example.com/u/slack-bot/connectors?oauth=success'
+    )
+  })
+
+  it('keeps a safe embedded return path on connector lookup errors', async () => {
+    mockGetSession.mockResolvedValue(session('alice', 'ADMIN'))
+    mockFindByIdAndUserIdSelect.mockResolvedValue(null)
+    mockVerifyConnectorOAuthState.mockReturnValue({
+      connectorId: 'custom-1',
+      slug: 'slack-bot',
+      returnTo: '/u/alice/settings/integrations/slack',
+      userId: 'service-1',
+      connectorType: 'custom',
+      clientId: 'client-id',
+      codeVerifier: 'verifier',
+      tokenEndpoint: 'https://oauth.example.com/token',
+      authorizationEndpoint: 'https://oauth.example.com/authorize',
+      registrationEndpoint: 'https://oauth.example.com/register',
+      redirectUri: 'https://arche.example.com/api/connectors/oauth/callback',
+    })
+
+    const { GET } = await loadRoute()
+    const response = await GET({
+      headers: new Headers(),
+      nextUrl: new URL('https://arche.example.com/api/connectors/oauth/callback?code=oauth-code&state=token'),
+    } as never)
+
+    expect(response.headers.get('location')).toBe(
+      'https://arche.example.com/u/alice/settings/integrations/slack?oauth=error&message=connector_not_found'
     )
   })
 })

--- a/apps/web/tests/connectors-oauth-callback-route.test.ts
+++ b/apps/web/tests/connectors-oauth-callback-route.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetSession = vi.fn()
+const mockVerifyConnectorOAuthState = vi.fn()
+const mockExchangeConnectorOAuthCode = vi.fn()
+const mockFindByIdAndUserIdSelect = vi.fn()
+const mockUpdateByIdUnsafe = vi.fn()
+const mockAuditEvent = vi.fn()
+const mockDecryptConfig = vi.fn()
+const mockEncryptConfig = vi.fn()
+const mockBuildConfigWithOAuth = vi.fn()
+
+function session(slug: string, role: 'USER' | 'ADMIN' = 'USER') {
+  return {
+    user: { id: 'user-1', email: 'alice@example.com', slug, role },
+    sessionId: 'session-1',
+  }
+}
+
+async function loadRoute() {
+  vi.doMock('@/lib/runtime/session', () => ({
+    getSession: () => mockGetSession(),
+  }))
+
+  vi.doMock('@/lib/runtime/desktop/current-vault', () => ({
+    getCurrentDesktopVault: () => null,
+    getDesktopWorkspaceHref: () => '/desktop/connectors',
+  }))
+
+  vi.doMock('@/lib/http', () => ({
+    getPublicBaseUrl: () => 'https://arche.example.com',
+  }))
+
+  vi.doMock('@/lib/auth', () => ({
+    auditEvent: (...args: unknown[]) => mockAuditEvent(...args),
+  }))
+
+  vi.doMock('@/lib/services', () => ({
+    connectorService: {
+      findByIdAndUserIdSelect: (...args: unknown[]) => mockFindByIdAndUserIdSelect(...args),
+      updateByIdUnsafe: (...args: unknown[]) => mockUpdateByIdUnsafe(...args),
+    },
+  }))
+
+  vi.doMock('@/lib/connectors/oauth', () => ({
+    exchangeConnectorOAuthCode: (...args: unknown[]) => mockExchangeConnectorOAuthCode(...args),
+    isOAuthConnectorType: () => true,
+    verifyConnectorOAuthState: (...args: unknown[]) => mockVerifyConnectorOAuthState(...args),
+  }))
+
+  vi.doMock('@/lib/connectors/crypto', () => ({
+    decryptConfig: (...args: unknown[]) => mockDecryptConfig(...args),
+    encryptConfig: (...args: unknown[]) => mockEncryptConfig(...args),
+  }))
+
+  vi.doMock('@/lib/connectors/oauth-config', () => ({
+    buildConfigWithOAuth: (...args: unknown[]) => mockBuildConfigWithOAuth(...args),
+  }))
+
+  vi.doMock('@/lib/connectors/validators', () => ({
+    validateConnectorType: () => true,
+  }))
+
+  return import('@/app/api/connectors/oauth/callback/route')
+}
+
+describe('GET /api/connectors/oauth/callback', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    mockFindByIdAndUserIdSelect.mockResolvedValue({
+      id: 'custom-1',
+      type: 'custom',
+      config: 'encrypted-config',
+    })
+    mockDecryptConfig.mockReturnValue({ endpoint: 'https://mcp.example.com/mcp' })
+    mockExchangeConnectorOAuthCode.mockResolvedValue({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: '2026-04-21T10:00:00.000Z',
+    })
+    mockBuildConfigWithOAuth.mockReturnValue({ authType: 'oauth' })
+    mockEncryptConfig.mockReturnValue('next-config')
+    mockUpdateByIdUnsafe.mockResolvedValue(undefined)
+    mockAuditEvent.mockResolvedValue(undefined)
+  })
+
+  it('redirects back to a safe embedded return path after success', async () => {
+    mockGetSession.mockResolvedValue(session('alice', 'ADMIN'))
+    mockVerifyConnectorOAuthState.mockReturnValue({
+      connectorId: 'custom-1',
+      slug: 'slack-bot',
+      returnTo: '/u/alice/settings/integrations/slack',
+      userId: 'service-1',
+      connectorType: 'custom',
+      clientId: 'client-id',
+      codeVerifier: 'verifier',
+      tokenEndpoint: 'https://oauth.example.com/token',
+      authorizationEndpoint: 'https://oauth.example.com/authorize',
+      registrationEndpoint: 'https://oauth.example.com/register',
+      redirectUri: 'https://arche.example.com/api/connectors/oauth/callback',
+    })
+
+    const { GET } = await loadRoute()
+    const response = await GET({
+      headers: new Headers(),
+      nextUrl: new URL('https://arche.example.com/api/connectors/oauth/callback?code=oauth-code&state=token'),
+    } as never)
+
+    expect(response.headers.get('location')).toBe(
+      'https://arche.example.com/u/alice/settings/integrations/slack?oauth=success'
+    )
+  })
+
+  it('falls back to the workspace connectors page for unsafe return paths', async () => {
+    mockGetSession.mockResolvedValue(session('alice', 'ADMIN'))
+    mockVerifyConnectorOAuthState.mockReturnValue({
+      connectorId: 'custom-1',
+      slug: 'slack-bot',
+      returnTo: 'https://evil.example.com/steal',
+      userId: 'service-1',
+      connectorType: 'custom',
+      clientId: 'client-id',
+      codeVerifier: 'verifier',
+      tokenEndpoint: 'https://oauth.example.com/token',
+      authorizationEndpoint: 'https://oauth.example.com/authorize',
+      registrationEndpoint: 'https://oauth.example.com/register',
+      redirectUri: 'https://arche.example.com/api/connectors/oauth/callback',
+    })
+
+    const { GET } = await loadRoute()
+    const response = await GET({
+      headers: new Headers(),
+      nextUrl: new URL('https://arche.example.com/api/connectors/oauth/callback?code=oauth-code&state=token'),
+    } as never)
+
+    expect(response.headers.get('location')).toBe(
+      'https://arche.example.com/u/slack-bot/connectors?oauth=success'
+    )
+  })
+})

--- a/apps/web/tests/connectors-oauth.test.ts
+++ b/apps/web/tests/connectors-oauth.test.ts
@@ -56,6 +56,7 @@ describe('connectors oauth state', () => {
     const state = issueConnectorOAuthState({
       connectorId: 'conn-custom',
       slug: 'alice',
+      returnTo: '/u/alice/settings/integrations/slack',
       userId: 'user1',
       connectorType: 'custom',
       redirectUri: 'https://arche.example.com/api/connectors/oauth/callback',
@@ -73,6 +74,7 @@ describe('connectors oauth state', () => {
     expect(payload).toMatchObject({
       connectorId: 'conn-custom',
       slug: 'alice',
+      returnTo: '/u/alice/settings/integrations/slack',
       userId: 'user1',
       connectorType: 'custom',
       redirectUri: 'https://arche.example.com/api/connectors/oauth/callback',
@@ -155,6 +157,31 @@ describe('connectors oauth state', () => {
     expect(state.authorizationEndpoint).toBe('https://mcp.custom.example.com/authorize')
     expect(state.tokenEndpoint).toBe('https://mcp.custom.example.com/token')
     expect(state.registrationEndpoint).toBe('https://mcp.custom.example.com/register')
+  })
+
+  it('propagates an optional returnTo path through prepared OAuth state', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('registration error', { status: 500 }))
+    )
+
+    const prepared = await prepareConnectorOAuthAuthorization({
+      connectorId: 'conn-custom',
+      slug: 'alice',
+      returnTo: '/u/alice/settings/integrations/slack',
+      userId: 'user1',
+      connectorType: 'custom',
+      redirectUri: 'https://arche.example.com/api/connectors/oauth/callback',
+      connectorConfig: {
+        endpoint: 'https://mcp.custom.example.com/mcp',
+        oauthClientId: 'static-client-id',
+        oauthAuthorizationEndpoint: 'https://oauth.custom.example.com/authorize',
+        oauthTokenEndpoint: 'https://oauth.custom.example.com/token',
+      },
+    })
+
+    const state = verifyConnectorOAuthState(prepared.state)
+    expect(state.returnTo).toBe('/u/alice/settings/integrations/slack')
   })
 
   it('falls back to static custom OAuth client when dynamic registration fails', async () => {


### PR DESCRIPTION
## Summary
- expose a global connector capability catalog for agents, using shared type-based entries for Linear, Notion, and Zendesk plus per-connector entries for custom connectors across human and service workspaces
- keep custom connector permissions scoped to exact connectors at runtime, and preserve embedded OAuth returns back to Slack integration settings
- embed `slack-bot` connector management inside Slack integration settings and cover the new catalog and OAuth flows with tests

## Testing
- pnpm test
- pnpm lint
- bash scripts/check-podman-images.sh
