### PR TITLE
fix(workspace): refresh provider auth for long-running runs

### DIFF
--- a/apps/web/prisma/migrations/20260421112049_add_instance_provider_sync_state/migration.sql
+++ b/apps/web/prisma/migrations/20260421112049_add_instance_provider_sync_state/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "instances" ADD COLUMN     "provider_sync_hash" TEXT,
+ADD COLUMN     "provider_synced_at" TIMESTAMP(3);

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -125,6 +125,8 @@ model Instance {
   containerId     String?        @map("container_id")
   serverPassword  String         @map("server_password")
   appliedConfigSha String?       @map("applied_config_sha")
+  providerSyncHash String?       @map("provider_sync_hash")
+  providerSyncedAt DateTime?     @map("provider_synced_at")
 
   user            User           @relation(fields: [slug], references: [slug])
 

--- a/apps/web/prisma/schema.sqlite.prisma
+++ b/apps/web/prisma/schema.sqlite.prisma
@@ -91,6 +91,8 @@ model Instance {
   containerId     String?  @map("container_id")
   serverPassword  String   @map("server_password")
   appliedConfigSha String? @map("applied_config_sha")
+  providerSyncHash String? @map("provider_sync_hash")
+  providerSyncedAt DateTime? @map("provider_synced_at")
 
   user            User     @relation(fields: [slug], references: [slug])
 

--- a/apps/web/src/app/api/internal/providers/[provider]/[...path]/route.test.ts
+++ b/apps/web/src/app/api/internal/providers/[provider]/[...path]/route.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+class FakeNextRequest extends Request {
+  nextUrl: URL
+
+  constructor(url: string, init?: RequestInit) {
+    super(url, init)
+    this.nextUrl = new URL(url)
+  }
+}
+
+vi.mock('next/server', async () => {
+  const actual = await vi.importActual<typeof import('next/server')>('next/server')
+
+  return {
+    ...actual,
+    NextRequest: FakeNextRequest,
+  }
+})
+
+const mockCheckRateLimit = vi.fn()
+const mockDecryptProviderSecret = vi.fn()
+const mockGetActiveCredentialForUser = vi.fn()
+const mockGetCanonicalProviderId = vi.fn()
+const mockGetRuntimeCapabilities = vi.fn()
+const mockVerifyGatewayToken = vi.fn()
+
+vi.mock('@/lib/providers/catalog', () => ({
+  getCanonicalProviderId: (...args: unknown[]) => mockGetCanonicalProviderId(...args),
+}))
+
+vi.mock('@/lib/providers/crypto', () => ({
+  decryptProviderSecret: (...args: unknown[]) => mockDecryptProviderSecret(...args),
+}))
+
+vi.mock('@/lib/providers/store', () => ({
+  getActiveCredentialForUser: (...args: unknown[]) => mockGetActiveCredentialForUser(...args),
+}))
+
+vi.mock('@/lib/providers/tokens', () => ({
+  verifyGatewayToken: (...args: unknown[]) => mockVerifyGatewayToken(...args),
+}))
+
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+}))
+
+vi.mock('@/lib/runtime/capabilities', () => ({
+  getRuntimeCapabilities: () => mockGetRuntimeCapabilities(),
+}))
+
+function buildRequest(headers?: HeadersInit): Request {
+  return new FakeNextRequest('https://arche.example.com/api/internal/providers/openai/responses', {
+    body: JSON.stringify({ model: 'gpt-5.4' }),
+    headers: {
+      'content-type': 'application/json',
+      ...headers,
+    },
+    method: 'POST',
+  })
+}
+
+describe('POST /api/internal/providers/[provider]/[...path]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetCanonicalProviderId.mockReturnValue('openai')
+    mockGetRuntimeCapabilities.mockReturnValue({ auth: true })
+    mockCheckRateLimit.mockReturnValue({ allowed: true, resetAt: Date.now() + 60_000 })
+    mockVerifyGatewayToken.mockReturnValue({
+      userId: 'user-1',
+      workspaceSlug: 'slack-bot',
+      providerId: 'openai',
+      version: 1,
+    })
+    mockGetActiveCredentialForUser.mockResolvedValue({
+      id: 'cred-1',
+      secret: 'enc',
+      type: 'api',
+      version: 2,
+    })
+    mockDecryptProviderSecret.mockReturnValue({ apiKey: 'sk-test' })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 })))
+  })
+
+  it('rejects gateway tokens whose credential version no longer matches', async () => {
+    const { POST } = await import('./route')
+    const response = await POST(buildRequest({ authorization: 'Bearer gateway-token' }) as never, {
+      params: Promise.resolve({ path: ['responses'], provider: 'openai' }),
+    })
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'invalid_token' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('forwards the request when the credential version matches the gateway token', async () => {
+    mockGetActiveCredentialForUser.mockResolvedValue({
+      id: 'cred-1',
+      secret: 'enc',
+      type: 'api',
+      version: 1,
+    })
+
+    const { POST } = await import('./route')
+    const response = await POST(buildRequest({ authorization: 'Bearer gateway-token' }) as never, {
+      params: Promise.resolve({ path: ['responses'], provider: 'openai' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/app/api/internal/providers/[provider]/[...path]/route.ts
+++ b/apps/web/src/app/api/internal/providers/[provider]/[...path]/route.ts
@@ -302,6 +302,10 @@ async function handleProxy(
         return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
       }
     } else {
+      if (payload && payload.version !== credential.version) {
+        return NextResponse.json({ error: 'invalid_token' }, { status: 401 })
+      }
+
       if (credential.type !== 'api') {
         return NextResponse.json({ error: 'unsupported_credential' }, { status: 501 })
       }

--- a/apps/web/src/lib/autopilot/__tests__/runner.test.ts
+++ b/apps/web/src/lib/autopilot/__tests__/runner.test.ts
@@ -14,6 +14,7 @@ const findTaskByIdAndUserIdMock = vi.fn()
 const touchActivityMock = vi.fn()
 const findByIdSelectMock = vi.fn()
 const createAuditEventMock = vi.fn()
+const ensureProviderAccessFreshForExecutionMock = vi.fn()
 
 vi.mock('@/lib/spawner/core', () => ({
   getInstanceStatus: (...args: unknown[]) => getInstanceStatusMock(...args),
@@ -22,6 +23,10 @@ vi.mock('@/lib/spawner/core', () => ({
 
 vi.mock('@/lib/opencode/client', () => ({
   createInstanceClient: (...args: unknown[]) => createInstanceClientMock(...args),
+}))
+
+vi.mock('@/lib/opencode/providers', () => ({
+  ensureProviderAccessFreshForExecution: (...args: unknown[]) => ensureProviderAccessFreshForExecutionMock(...args),
 }))
 
 vi.mock('@/lib/services', () => ({
@@ -61,6 +66,7 @@ describe('autopilot runner', () => {
     releaseTaskLeaseMock.mockResolvedValue(undefined)
     touchActivityMock.mockResolvedValue(undefined)
     createAuditEventMock.mockResolvedValue(undefined)
+    ensureProviderAccessFreshForExecutionMock.mockResolvedValue(undefined)
   })
 
   it('marks a claimed task as succeeded when the session completes cleanly', async () => {

--- a/apps/web/src/lib/opencode/__tests__/providers.test.ts
+++ b/apps/web/src/lib/opencode/__tests__/providers.test.ts
@@ -194,6 +194,26 @@ describe('syncProviderAccessForInstance', () => {
     }
   })
 
+  it('returns success when provider sync state persistence fails after auth succeeds', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    mockGetCredential.mockResolvedValue(null)
+    mockInstanceService.setProviderSyncState.mockRejectedValue(new Error('db unavailable'))
+
+    const result = await syncProviderAccessForInstance({
+      instance: fakeInstance,
+      slug: 'alice',
+      userId: 'user-1',
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[opencode/providers] Failed to persist provider sync state',
+      expect.any(Error),
+    )
+
+    consoleErrorSpy.mockRestore()
+  })
+
   it('skips provider sync refresh when the running instance already matches the expected hash', async () => {
     mockGetCredential.mockImplementation(async ({ providerId }) => {
       if (providerId === 'openai') return { id: '1', version: 3 } as never

--- a/apps/web/src/lib/opencode/__tests__/providers.test.ts
+++ b/apps/web/src/lib/opencode/__tests__/providers.test.ts
@@ -5,16 +5,37 @@ vi.mock('@/lib/providers/store', () => ({
   getActiveCredentialForUser: vi.fn(),
 }))
 
+vi.mock('@/lib/opencode/client', () => ({
+  getInstanceBasicAuth: vi.fn(),
+}))
+
+vi.mock('@/lib/providers/config', () => ({
+  getGatewayTokenTtlSeconds: vi.fn(() => 3600),
+}))
+
+vi.mock('@/lib/services', () => ({
+  instanceService: {
+    findProviderSyncBySlug: vi.fn(),
+    setProviderSyncState: vi.fn(),
+  },
+}))
+
 // Mock provider tokens
 vi.mock('@/lib/providers/tokens', () => ({
   issueGatewayToken: vi.fn(() => 'gateway-token-xyz'),
 }))
 
+import { getInstanceBasicAuth } from '@/lib/opencode/client'
+import { getGatewayTokenTtlSeconds } from '@/lib/providers/config'
 import { getActiveCredentialForUser } from '@/lib/providers/store'
+import { instanceService } from '@/lib/services'
 import { issueGatewayToken } from '@/lib/providers/tokens'
-import { syncProviderAccessForInstance } from '../providers'
+import { ensureProviderAccessFreshForExecution, getProviderSyncHashForUser, syncProviderAccessForInstance } from '../providers'
 
+const mockGetInstanceBasicAuth = vi.mocked(getInstanceBasicAuth)
+const mockGetGatewayTokenTtlSeconds = vi.mocked(getGatewayTokenTtlSeconds)
 const mockGetCredential = vi.mocked(getActiveCredentialForUser)
+const mockInstanceService = vi.mocked(instanceService)
 const mockIssueToken = vi.mocked(issueGatewayToken)
 
 const fakeInstance = {
@@ -25,6 +46,14 @@ const fakeInstance = {
 beforeEach(() => {
   vi.clearAllMocks()
   vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('ok', { status: 200 })))
+  mockGetGatewayTokenTtlSeconds.mockReturnValue(3600)
+  mockGetInstanceBasicAuth.mockResolvedValue(fakeInstance)
+  mockInstanceService.findProviderSyncBySlug.mockResolvedValue({
+    providerSyncHash: null,
+    providerSyncedAt: null,
+    status: 'running',
+  })
+  mockInstanceService.setProviderSyncState.mockResolvedValue(undefined)
 })
 
 describe('syncProviderAccessForInstance', () => {
@@ -68,6 +97,11 @@ describe('syncProviderAccessForInstance', () => {
     expect(mockIssueToken).toHaveBeenCalledTimes(3)
     expect(mockIssueToken).toHaveBeenCalledWith(
       expect.objectContaining({ providerId: 'opencode', version: 0 }),
+    )
+    expect(mockInstanceService.setProviderSyncState).toHaveBeenCalledWith(
+      'alice',
+      await getProviderSyncHashForUser('user-1'),
+      expect.any(Date),
     )
   })
 
@@ -158,5 +192,39 @@ describe('syncProviderAccessForInstance', () => {
         expect(headers.Authorization).toBe(fakeInstance.authHeader)
       }
     }
+  })
+
+  it('skips provider sync refresh when the running instance already matches the expected hash', async () => {
+    mockGetCredential.mockImplementation(async ({ providerId }) => {
+      if (providerId === 'openai') return { id: '1', version: 3 } as never
+      return null
+    })
+
+    mockInstanceService.findProviderSyncBySlug.mockResolvedValue({
+      providerSyncHash: await getProviderSyncHashForUser('user-1'),
+      providerSyncedAt: new Date(),
+      status: 'running',
+    })
+
+    await ensureProviderAccessFreshForExecution({ slug: 'alice', userId: 'user-1' })
+
+    expect(mockGetInstanceBasicAuth).not.toHaveBeenCalled()
+  })
+
+  it('refreshes provider access when the sync record is stale by age', async () => {
+    mockGetCredential.mockImplementation(async ({ providerId }) => {
+      if (providerId === 'openai') return { id: '1', version: 3 } as never
+      return null
+    })
+    mockGetGatewayTokenTtlSeconds.mockReturnValue(120)
+    mockInstanceService.findProviderSyncBySlug.mockResolvedValue({
+      providerSyncHash: await getProviderSyncHashForUser('user-1'),
+      providerSyncedAt: new Date(Date.now() - 120_000),
+      status: 'running',
+    })
+
+    await ensureProviderAccessFreshForExecution({ slug: 'alice', userId: 'user-1' })
+
+    expect(mockGetInstanceBasicAuth).toHaveBeenCalledWith('alice')
   })
 })

--- a/apps/web/src/lib/opencode/__tests__/session-execution.test.ts
+++ b/apps/web/src/lib/opencode/__tests__/session-execution.test.ts
@@ -6,6 +6,10 @@ vi.mock('@/lib/opencode/client', () => ({
   createInstanceClient: vi.fn(),
 }))
 
+vi.mock('@/lib/opencode/providers', () => ({
+  ensureProviderAccessFreshForExecution: vi.fn(),
+}))
+
 vi.mock('@/lib/services', () => ({
   instanceService: {
     touchActivity: (...args: unknown[]) => touchActivityMock(...args),
@@ -143,5 +147,46 @@ describe('session execution helpers', () => {
       sessionId: 'session-1',
       slug: 'slack-bot',
     })).resolves.toBe('provider_auth_missing')
+  })
+
+  it('refreshes provider access when execution reuses a running workspace', async () => {
+    const { ensureProviderAccessFreshForExecution } = await import('@/lib/opencode/providers')
+    const { getInstanceStatus } = await import('@/lib/spawner/core')
+
+    vi.mocked(getInstanceStatus).mockResolvedValue({ status: 'running' } as never)
+
+    const { ensureWorkspaceRunningForExecution } = await import('../session-execution')
+    await ensureWorkspaceRunningForExecution('slack-bot', 'user-1')
+
+    expect(ensureProviderAccessFreshForExecution).toHaveBeenCalledWith({
+      slug: 'slack-bot',
+      userId: 'user-1',
+    })
+  })
+
+  it('refreshes provider access after a workspace finishes starting', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const { ensureProviderAccessFreshForExecution } = await import('@/lib/opencode/providers')
+      const { getInstanceStatus } = await import('@/lib/spawner/core')
+
+      vi.mocked(getInstanceStatus)
+        .mockResolvedValueOnce({ status: 'starting' } as never)
+        .mockResolvedValueOnce({ status: 'running' } as never)
+
+      const { ensureWorkspaceRunningForExecution } = await import('../session-execution')
+      const promise = ensureWorkspaceRunningForExecution('slack-bot', 'user-1')
+
+      await vi.advanceTimersByTimeAsync(2_000)
+      await promise
+
+      expect(ensureProviderAccessFreshForExecution).toHaveBeenCalledWith({
+        slug: 'slack-bot',
+        userId: 'user-1',
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/apps/web/src/lib/opencode/providers.ts
+++ b/apps/web/src/lib/opencode/providers.ts
@@ -19,12 +19,16 @@ type SyncProviderAccessInput = {
   disposeInstance?: boolean
 }
 
+// Refresh slightly before the gateway token expires so long-running runs do not
+// reuse credentials that are about to age out.
 const PROVIDER_SYNC_REFRESH_SKEW_MS = 60_000
 const providerSyncLocks = new Map<string, Promise<void>>()
 
 type EnabledProviderVersions = Map<ProviderId, { version: number }>
 
 function buildProviderSyncHash(enabledByProvider: EnabledProviderVersions): string {
+  // Only configured providers affect runtime auth. Missing credentials and
+  // providers that require no managed sync intentionally hash to the same state.
   const payload = Array.from(enabledByProvider.entries())
     .map(([providerId, value]) => ({ providerId, version: value.version }))
     .sort((left, right) => left.providerId.localeCompare(right.providerId))
@@ -223,7 +227,11 @@ export async function syncProviderAccessForInstance(
       })
     }
 
-    await instanceService.setProviderSyncState(input.slug, providerSyncHash, new Date())
+    try {
+      await instanceService.setProviderSyncState(input.slug, providerSyncHash, new Date())
+    } catch (error) {
+      console.error('[opencode/providers] Failed to persist provider sync state', error)
+    }
 
     return { ok: true }
   } catch (error) {

--- a/apps/web/src/lib/opencode/providers.ts
+++ b/apps/web/src/lib/opencode/providers.ts
@@ -1,7 +1,12 @@
+import crypto from 'node:crypto'
+
+import { getInstanceBasicAuth } from '@/lib/opencode/client'
+import { getGatewayTokenTtlSeconds } from '@/lib/providers/config'
 import { toRuntimeProviderId } from '@/lib/providers/catalog'
 import { getActiveCredentialForUser } from '@/lib/providers/store'
 import { issueGatewayToken } from '@/lib/providers/tokens'
 import { PROVIDERS, type ProviderId } from '@/lib/providers/types'
+import { instanceService } from '@/lib/services'
 
 export type SyncProviderAccessResult =
   | { ok: true }
@@ -12,6 +17,116 @@ type SyncProviderAccessInput = {
   slug: string
   userId: string
   disposeInstance?: boolean
+}
+
+const PROVIDER_SYNC_REFRESH_SKEW_MS = 60_000
+const providerSyncLocks = new Map<string, Promise<void>>()
+
+type EnabledProviderVersions = Map<ProviderId, { version: number }>
+
+function buildProviderSyncHash(enabledByProvider: EnabledProviderVersions): string {
+  const payload = Array.from(enabledByProvider.entries())
+    .map(([providerId, value]) => ({ providerId, version: value.version }))
+    .sort((left, right) => left.providerId.localeCompare(right.providerId))
+
+  return crypto.createHash('sha256').update(JSON.stringify(payload)).digest('hex')
+}
+
+async function loadEnabledProviderVersions(userId: string): Promise<EnabledProviderVersions> {
+  const enabledByProvider = new Map<ProviderId, { version: number }>()
+
+  for (const providerId of PROVIDERS) {
+    const credential = await getActiveCredentialForUser({
+      userId,
+      providerId,
+    })
+    if (!credential) {
+      continue
+    }
+
+    enabledByProvider.set(providerId, { version: Number(credential.version) })
+  }
+
+  return enabledByProvider
+}
+
+function shouldRefreshProviderAccess(args: {
+  expectedHash: string
+  providerSyncHash: string | null
+  providerSyncedAt: Date | null
+}): boolean {
+  if (args.providerSyncHash !== args.expectedHash) {
+    return true
+  }
+
+  if (!args.providerSyncedAt) {
+    return true
+  }
+
+  const ttlMs = getGatewayTokenTtlSeconds() * 1000
+  const refreshAgeMs = Math.max(0, ttlMs - PROVIDER_SYNC_REFRESH_SKEW_MS)
+  return Date.now() - args.providerSyncedAt.getTime() >= refreshAgeMs
+}
+
+async function withProviderSyncLock<T>(slug: string, work: () => Promise<T>): Promise<T> {
+  const previous = providerSyncLocks.get(slug) ?? Promise.resolve()
+  let releaseCurrent!: () => void
+  const current = new Promise<void>((resolve) => {
+    releaseCurrent = resolve
+  })
+
+  providerSyncLocks.set(slug, current)
+  await previous.catch(() => undefined)
+
+  try {
+    return await work()
+  } finally {
+    releaseCurrent()
+
+    if (providerSyncLocks.get(slug) === current) {
+      providerSyncLocks.delete(slug)
+    }
+  }
+}
+
+export async function getProviderSyncHashForUser(userId: string): Promise<string> {
+  return buildProviderSyncHash(await loadEnabledProviderVersions(userId))
+}
+
+export async function ensureProviderAccessFreshForExecution(args: {
+  slug: string
+  userId: string
+}): Promise<void> {
+  await withProviderSyncLock(args.slug, async () => {
+    const expectedHash = await getProviderSyncHashForUser(args.userId)
+    const current = await instanceService.findProviderSyncBySlug(args.slug)
+
+    if (
+      current?.status === 'running' &&
+      !shouldRefreshProviderAccess({
+        expectedHash,
+        providerSyncHash: current.providerSyncHash,
+        providerSyncedAt: current.providerSyncedAt,
+      })
+    ) {
+      return
+    }
+
+    const instance = await getInstanceBasicAuth(args.slug)
+    if (!instance) {
+      throw new Error('instance_unavailable')
+    }
+
+    const syncResult = await syncProviderAccessForInstance({
+      instance,
+      slug: args.slug,
+      userId: args.userId,
+    })
+
+    if (!syncResult.ok) {
+      throw new Error(syncResult.error)
+    }
+  })
 }
 
 async function fetchRequired(
@@ -33,25 +148,16 @@ export async function syncProviderAccessForInstance(
   const instance = input.instance
 
   try {
-    const enabledByProvider = new Map<ProviderId, { version: number }>()
-
-    for (const providerId of PROVIDERS) {
-      const pid = providerId as ProviderId
-      const credential = await getActiveCredentialForUser({
-        userId: input.userId,
-        providerId: pid,
-      })
-      if (!credential) continue
-      enabledByProvider.set(pid, { version: Number(credential.version) })
-    }
+    const enabledByProvider = await loadEnabledProviderVersions(input.userId)
+    const providerSyncHash = buildProviderSyncHash(enabledByProvider)
 
     for (const providerId of PROVIDERS) {
       const enabled = enabledByProvider.get(providerId)
       const url = `${instance.baseUrl}/auth/${toRuntimeProviderId(providerId)}`
 
-        if (!enabled) {
-          if (providerId === 'opencode') {
-            const token = issueGatewayToken({
+      if (!enabled) {
+        if (providerId === 'opencode') {
+          const token = issueGatewayToken({
             userId: input.userId,
             workspaceSlug: input.slug,
             providerId: 'opencode',
@@ -74,12 +180,12 @@ export async function syncProviderAccessForInstance(
         await fetchRequired(
           url,
           {
-          method: 'DELETE',
-          headers: {
-            Authorization: instance.authHeader,
-            Accept: 'application/json',
-          },
-          cache: 'no-store',
+            method: 'DELETE',
+            headers: {
+              Authorization: instance.authHeader,
+              Accept: 'application/json',
+            },
+            cache: 'no-store',
           },
           [404],
         )
@@ -116,6 +222,8 @@ export async function syncProviderAccessForInstance(
         cache: 'no-store',
       })
     }
+
+    await instanceService.setProviderSyncState(input.slug, providerSyncHash, new Date())
 
     return { ok: true }
   } catch (error) {

--- a/apps/web/src/lib/opencode/session-execution.ts
+++ b/apps/web/src/lib/opencode/session-execution.ts
@@ -1,4 +1,5 @@
 import { createInstanceClient } from '@/lib/opencode/client'
+import { ensureProviderAccessFreshForExecution } from '@/lib/opencode/providers'
 import { transformParts } from '@/lib/opencode/transform'
 import type { MessagePart } from '@/lib/opencode/types'
 import { instanceService } from '@/lib/services'
@@ -123,6 +124,7 @@ async function inspectSessionOutcome(
 export async function ensureWorkspaceRunningForExecution(slug: string, userId: string): Promise<void> {
   const current = await getInstanceStatus(slug)
   if (current?.status === 'running') {
+    await ensureProviderAccessFreshForExecution({ slug, userId })
     return
   }
 
@@ -132,6 +134,7 @@ export async function ensureWorkspaceRunningForExecution(slug: string, userId: s
       await sleep(INSTANCE_START_POLL_INTERVAL_MS)
       const next = await getInstanceStatus(slug)
       if (next?.status === 'running') {
+        await ensureProviderAccessFreshForExecution({ slug, userId })
         return
       }
     }
@@ -143,6 +146,8 @@ export async function ensureWorkspaceRunningForExecution(slug: string, userId: s
   if (!startResult.ok && startResult.error !== 'already_running') {
     throw new Error(startResult.detail ?? startResult.error)
   }
+
+  await ensureProviderAccessFreshForExecution({ slug, userId })
 }
 
 export async function captureSessionMessageCursor(

--- a/apps/web/src/lib/prisma-desktop.ts
+++ b/apps/web/src/lib/prisma-desktop.ts
@@ -41,6 +41,8 @@ const SCHEMA_DDL = [
     "container_id" TEXT,
     "server_password" TEXT NOT NULL,
     "applied_config_sha" TEXT,
+    "provider_sync_hash" TEXT,
+    "provider_synced_at" DATETIME,
     CONSTRAINT "instances_slug_fkey" FOREIGN KEY ("slug") REFERENCES "users" ("slug") ON DELETE RESTRICT ON UPDATE CASCADE
   )`,
   `CREATE TABLE IF NOT EXISTS "sessions" (
@@ -188,7 +190,7 @@ const SCHEMA_DDL = [
   `CREATE INDEX IF NOT EXISTS "two_factor_recovery_user_id_idx" ON "two_factor_recovery"("user_id")`,
 ]
 
-const SCHEMA_VERSION = '4'
+const SCHEMA_VERSION = '5'
 
 async function ensureAutopilotRunResultSeenAtColumn(client: DesktopPrismaClient): Promise<void> {
   const columns = await client.$queryRawUnsafe('PRAGMA table_info("autopilot_runs")') as Array<{ name?: string }>
@@ -205,6 +207,20 @@ async function ensureUserKindColumn(client: DesktopPrismaClient): Promise<void> 
 
   if (!hasKind) {
     await client.$executeRawUnsafe('ALTER TABLE "users" ADD COLUMN "kind" TEXT NOT NULL DEFAULT \'HUMAN\'')
+  }
+}
+
+async function ensureInstanceProviderSyncColumns(client: DesktopPrismaClient): Promise<void> {
+  const columns = await client.$queryRawUnsafe('PRAGMA table_info("instances")') as Array<{ name?: string }>
+  const hasProviderSyncHash = columns.some((column) => column.name === 'provider_sync_hash')
+  const hasProviderSyncedAt = columns.some((column) => column.name === 'provider_synced_at')
+
+  if (!hasProviderSyncHash) {
+    await client.$executeRawUnsafe('ALTER TABLE "instances" ADD COLUMN "provider_sync_hash" TEXT')
+  }
+
+  if (!hasProviderSyncedAt) {
+    await client.$executeRawUnsafe('ALTER TABLE "instances" ADD COLUMN "provider_synced_at" DATETIME')
   }
 }
 
@@ -252,6 +268,7 @@ export async function initDesktopDatabase(): Promise<void> {
 
   if (storedVersion === SCHEMA_VERSION) {
     await ensureAutopilotRunResultSeenAtColumn(client)
+    await ensureInstanceProviderSyncColumns(client)
     await ensureUserKindColumn(client)
     return
   }
@@ -261,6 +278,7 @@ export async function initDesktopDatabase(): Promise<void> {
   }
 
   await ensureAutopilotRunResultSeenAtColumn(client)
+  await ensureInstanceProviderSyncColumns(client)
   await ensureUserKindColumn(client)
 
   await client.$executeRaw`INSERT OR REPLACE INTO _arche_schema_meta (key, value) VALUES ('schema_version', ${SCHEMA_VERSION})`

--- a/apps/web/src/lib/services/__tests__/services.test.ts
+++ b/apps/web/src/lib/services/__tests__/services.test.ts
@@ -476,7 +476,28 @@ describe('service layer', () => {
 
       expect(mockPrisma.instance.update).toHaveBeenCalledWith({
         where: { slug: 'alice' },
-        data: { status: 'error', containerId: null },
+        data: {
+          status: 'error',
+          containerId: null,
+          providerSyncHash: null,
+          providerSyncedAt: null,
+        },
+      })
+    })
+
+    it('setProviderSyncState persists the latest provider sync hash and timestamp', async () => {
+      const syncedAt = new Date('2026-04-21T10:00:00.000Z')
+      mockPrisma.instance.update.mockResolvedValue({ slug: 'alice', providerSyncHash: 'hash-123' })
+
+      const { instanceService } = await import('../index')
+      await instanceService.setProviderSyncState('alice', 'hash-123', syncedAt)
+
+      expect(mockPrisma.instance.update).toHaveBeenCalledWith({
+        where: { slug: 'alice' },
+        data: {
+          providerSyncHash: 'hash-123',
+          providerSyncedAt: syncedAt,
+        },
       })
     })
 

--- a/apps/web/src/lib/services/instance.ts
+++ b/apps/web/src/lib/services/instance.ts
@@ -18,6 +18,8 @@ export type InstanceRecord = {
   containerId: string | null
   serverPassword: string
   appliedConfigSha: string | null
+  providerSyncHash: string | null
+  providerSyncedAt: Date | null
 }
 
 export type InstanceCredentials = {
@@ -32,6 +34,14 @@ export type InstanceStatusDetails = {
   lastActivityAt: Date | null
   containerId: string | null
   serverPassword: string
+  providerSyncHash: string | null
+  providerSyncedAt: Date | null
+}
+
+export type InstanceProviderSyncDetails = {
+  providerSyncHash: string | null
+  providerSyncedAt: Date | null
+  status: InstanceStatus
 }
 
 export type InstanceActiveEntry = {
@@ -66,6 +76,19 @@ export function findStatusBySlug(slug: string): Promise<InstanceStatusDetails | 
       lastActivityAt: true,
       containerId: true,
       serverPassword: true,
+      providerSyncHash: true,
+      providerSyncedAt: true,
+    },
+  })
+}
+
+export function findProviderSyncBySlug(slug: string): Promise<InstanceProviderSyncDetails | null> {
+  return prisma.instance.findUnique({
+    where: { slug },
+    select: {
+      providerSyncHash: true,
+      providerSyncedAt: true,
+      status: true,
     },
   })
 }
@@ -135,6 +158,8 @@ export function upsertStarting(slug: string, serverPassword: string) {
       status: 'starting',
       serverPassword,
       startedAt: new Date(),
+      providerSyncHash: null,
+      providerSyncedAt: null,
     },
     update: {
       status: 'starting',
@@ -142,6 +167,8 @@ export function upsertStarting(slug: string, serverPassword: string) {
       startedAt: new Date(),
       stoppedAt: null,
       containerId: null,
+      providerSyncHash: null,
+      providerSyncedAt: null,
     },
   })
 }
@@ -156,7 +183,12 @@ export function setContainerId(slug: string, containerId: string) {
 export function setError(slug: string) {
   return prisma.instance.update({
     where: { slug },
-    data: { status: 'error', containerId: null },
+    data: {
+      status: 'error',
+      containerId: null,
+      providerSyncHash: null,
+      providerSyncedAt: null,
+    },
   })
 }
 
@@ -178,6 +210,8 @@ export function setStopped(slug: string) {
       status: 'stopped',
       stoppedAt: new Date(),
       containerId: null,
+      providerSyncHash: null,
+      providerSyncedAt: null,
     },
   })
 }
@@ -188,6 +222,8 @@ export function setStoppedNoContainer(slug: string) {
     data: {
       status: 'stopped',
       stoppedAt: new Date(),
+      providerSyncHash: null,
+      providerSyncedAt: null,
     },
   })
 }
@@ -199,6 +235,18 @@ export function setStoppedById(id: string) {
       status: 'stopped',
       stoppedAt: new Date(),
       containerId: null,
+      providerSyncHash: null,
+      providerSyncedAt: null,
+    },
+  })
+}
+
+export function setProviderSyncState(slug: string, providerSyncHash: string, providerSyncedAt: Date) {
+  return prisma.instance.update({
+    where: { slug },
+    data: {
+      providerSyncHash,
+      providerSyncedAt,
     },
   })
 }

--- a/apps/web/tests/opencode-providers.test.ts
+++ b/apps/web/tests/opencode-providers.test.ts
@@ -4,6 +4,12 @@ vi.mock('@/lib/providers/store', () => ({
   getActiveCredentialForUser: vi.fn(),
 }))
 
+vi.mock('@/lib/services', () => ({
+  instanceService: {
+    setProviderSyncState: vi.fn(),
+  },
+}))
+
 vi.mock('@/lib/providers/tokens', () => ({
   issueGatewayToken: vi.fn(),
 }))


### PR DESCRIPTION
## Summary
- refresh provider gateway auth before Slack and Autopilot reuse long-running workspaces
- persist per-instance provider sync state and validate gateway tokens against the active credential version
- add the additive instance sync-state migration plus route, service, and execution coverage