### PR TITLE
feat(spawner): run the idle reaper as a daemon

### DIFF
--- a/apps/web/Containerfile
+++ b/apps/web/Containerfile
@@ -32,6 +32,8 @@ COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/prisma ./prisma
 COPY --from=build /app/prisma.config.ts ./prisma.config.ts
+COPY --from=build /app/src ./src
+COPY --from=build /app/tsconfig.json ./tsconfig.json
 COPY --from=build /app/kickstart/agents/definitions ./kickstart/agents/definitions
 COPY --from=build /app/kickstart/templates/definitions ./kickstart/templates/definitions
 COPY web/start.sh ./start.sh

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "prebuild": "pnpm prisma:generate && pnpm prisma:generate:desktop",
     "build": "next build",
     "start": "next start",
+    "start:reaper": "tsx src/reaper-daemon.ts",
     "lint": "eslint",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/apps/web/src/instrumentation-node.test.ts
+++ b/apps/web/src/instrumentation-node.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const initWebPrismaMock = vi.fn()
 const isDesktopMock = vi.fn()
 const startAutopilotSchedulerMock = vi.fn()
+const startReaperMock = vi.fn()
 const startSlackSocketManagerMock = vi.fn()
 
 vi.mock('@/lib/autopilot/scheduler', () => ({
@@ -22,6 +23,11 @@ vi.mock('@/lib/runtime/mode', () => ({
 vi.mock('@/lib/slack/socket-mode', () => ({
   startSlackSocketManager: (...args: unknown[]) => startSlackSocketManagerMock(...args),
   stopSlackSocketManager: vi.fn(),
+}))
+
+vi.mock('@/lib/spawner/reaper', () => ({
+  startReaper: (...args: unknown[]) => startReaperMock(...args),
+  stopReaper: vi.fn(),
 }))
 
 describe('registerNodeInstrumentation', () => {
@@ -48,6 +54,7 @@ describe('registerNodeInstrumentation', () => {
     await registerNodeInstrumentation()
 
     expect(initWebPrismaMock).toHaveBeenCalledTimes(1)
+    expect(startReaperMock).not.toHaveBeenCalled()
     expect(startSlackSocketManagerMock).toHaveBeenCalledTimes(1)
     expect(startAutopilotSchedulerMock).toHaveBeenCalledTimes(1)
     expect(processOnceSpy).toHaveBeenCalledTimes(3)
@@ -66,6 +73,7 @@ describe('registerNodeInstrumentation', () => {
     await registerNodeInstrumentation()
 
     expect(initWebPrismaMock).toHaveBeenCalledTimes(1)
+    expect(startReaperMock).not.toHaveBeenCalled()
     expect(startSlackSocketManagerMock).toHaveBeenCalledTimes(1)
     expect(startAutopilotSchedulerMock).not.toHaveBeenCalled()
     expect(processOnceSpy).toHaveBeenCalledTimes(3)
@@ -81,6 +89,7 @@ describe('registerNodeInstrumentation', () => {
     await registerNodeInstrumentation()
 
     expect(initWebPrismaMock).not.toHaveBeenCalled()
+    expect(startReaperMock).not.toHaveBeenCalled()
     expect(startSlackSocketManagerMock).not.toHaveBeenCalled()
     expect(startAutopilotSchedulerMock).not.toHaveBeenCalled()
     expect(processOnceSpy).not.toHaveBeenCalled()
@@ -95,6 +104,7 @@ describe('registerNodeInstrumentation', () => {
     await registerNodeInstrumentation()
     await registerNodeInstrumentation()
 
+    expect(startReaperMock).not.toHaveBeenCalled()
     expect(startSlackSocketManagerMock).toHaveBeenCalledTimes(2)
     expect(processOnceSpy).toHaveBeenCalledTimes(3)
 

--- a/apps/web/src/instrumentation-node.test.ts
+++ b/apps/web/src/instrumentation-node.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const initWebPrismaMock = vi.fn()
 const isDesktopMock = vi.fn()
 const startAutopilotSchedulerMock = vi.fn()
-const startReaperMock = vi.fn()
 const startSlackSocketManagerMock = vi.fn()
 
 vi.mock('@/lib/autopilot/scheduler', () => ({
@@ -25,11 +24,6 @@ vi.mock('@/lib/slack/socket-mode', () => ({
   stopSlackSocketManager: vi.fn(),
 }))
 
-vi.mock('@/lib/spawner/reaper', () => ({
-  startReaper: (...args: unknown[]) => startReaperMock(...args),
-  stopReaper: vi.fn(),
-}))
-
 describe('registerNodeInstrumentation', () => {
   const originalNodeEnv = process.env.NODE_ENV
 
@@ -47,14 +41,13 @@ describe('registerNodeInstrumentation', () => {
     delete globalThis.archeWebCleanupRegistered
   })
 
-  it('starts Prisma, reaper, Slack, and autopilot in production web mode', async () => {
+  it('starts Prisma, Slack, and autopilot in production web mode', async () => {
     const processOnceSpy = vi.spyOn(process, 'once').mockImplementation(() => process)
 
     const { registerNodeInstrumentation } = await import('./instrumentation-node')
     await registerNodeInstrumentation()
 
     expect(initWebPrismaMock).toHaveBeenCalledTimes(1)
-    expect(startReaperMock).toHaveBeenCalledTimes(1)
     expect(startSlackSocketManagerMock).toHaveBeenCalledTimes(1)
     expect(startAutopilotSchedulerMock).toHaveBeenCalledTimes(1)
     expect(processOnceSpy).toHaveBeenCalledTimes(3)
@@ -65,7 +58,7 @@ describe('registerNodeInstrumentation', () => {
     processOnceSpy.mockRestore()
   })
 
-  it('skips autopilot outside production but still starts reaper and Slack', async () => {
+  it('skips autopilot outside production but still starts Slack', async () => {
     process.env.NODE_ENV = 'development'
     const processOnceSpy = vi.spyOn(process, 'once').mockImplementation(() => process)
 
@@ -73,7 +66,6 @@ describe('registerNodeInstrumentation', () => {
     await registerNodeInstrumentation()
 
     expect(initWebPrismaMock).toHaveBeenCalledTimes(1)
-    expect(startReaperMock).toHaveBeenCalledTimes(1)
     expect(startSlackSocketManagerMock).toHaveBeenCalledTimes(1)
     expect(startAutopilotSchedulerMock).not.toHaveBeenCalled()
     expect(processOnceSpy).toHaveBeenCalledTimes(3)
@@ -89,7 +81,6 @@ describe('registerNodeInstrumentation', () => {
     await registerNodeInstrumentation()
 
     expect(initWebPrismaMock).not.toHaveBeenCalled()
-    expect(startReaperMock).not.toHaveBeenCalled()
     expect(startSlackSocketManagerMock).not.toHaveBeenCalled()
     expect(startAutopilotSchedulerMock).not.toHaveBeenCalled()
     expect(processOnceSpy).not.toHaveBeenCalled()
@@ -104,7 +95,6 @@ describe('registerNodeInstrumentation', () => {
     await registerNodeInstrumentation()
     await registerNodeInstrumentation()
 
-    expect(startReaperMock).toHaveBeenCalledTimes(2)
     expect(startSlackSocketManagerMock).toHaveBeenCalledTimes(2)
     expect(processOnceSpy).toHaveBeenCalledTimes(3)
 

--- a/apps/web/src/instrumentation-node.test.ts
+++ b/apps/web/src/instrumentation-node.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const initWebPrismaMock = vi.fn()
+const isDesktopMock = vi.fn()
+const startAutopilotSchedulerMock = vi.fn()
+const startReaperMock = vi.fn()
+const startSlackSocketManagerMock = vi.fn()
+
+vi.mock('@/lib/autopilot/scheduler', () => ({
+  startAutopilotScheduler: (...args: unknown[]) => startAutopilotSchedulerMock(...args),
+  stopAutopilotScheduler: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  initWebPrisma: (...args: unknown[]) => initWebPrismaMock(...args),
+  prisma: { $disconnect: vi.fn() },
+}))
+
+vi.mock('@/lib/runtime/mode', () => ({
+  isDesktop: () => isDesktopMock(),
+}))
+
+vi.mock('@/lib/slack/socket-mode', () => ({
+  startSlackSocketManager: (...args: unknown[]) => startSlackSocketManagerMock(...args),
+  stopSlackSocketManager: vi.fn(),
+}))
+
+vi.mock('@/lib/spawner/reaper', () => ({
+  startReaper: (...args: unknown[]) => startReaperMock(...args),
+  stopReaper: vi.fn(),
+}))
+
+describe('registerNodeInstrumentation', () => {
+  const originalNodeEnv = process.env.NODE_ENV
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    delete globalThis.archeWebCleanupRegistered
+    isDesktopMock.mockReturnValue(false)
+    initWebPrismaMock.mockResolvedValue(undefined)
+    process.env.NODE_ENV = 'production'
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv
+    delete globalThis.archeWebCleanupRegistered
+  })
+
+  it('starts Prisma, reaper, Slack, and autopilot in production web mode', async () => {
+    const processOnceSpy = vi.spyOn(process, 'once').mockImplementation(() => process)
+
+    const { registerNodeInstrumentation } = await import('./instrumentation-node')
+    await registerNodeInstrumentation()
+
+    expect(initWebPrismaMock).toHaveBeenCalledTimes(1)
+    expect(startReaperMock).toHaveBeenCalledTimes(1)
+    expect(startSlackSocketManagerMock).toHaveBeenCalledTimes(1)
+    expect(startAutopilotSchedulerMock).toHaveBeenCalledTimes(1)
+    expect(processOnceSpy).toHaveBeenCalledTimes(3)
+    expect(processOnceSpy).toHaveBeenCalledWith('SIGTERM', expect.any(Function))
+    expect(processOnceSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function))
+    expect(processOnceSpy).toHaveBeenCalledWith('beforeExit', expect.any(Function))
+
+    processOnceSpy.mockRestore()
+  })
+
+  it('skips autopilot outside production but still starts reaper and Slack', async () => {
+    process.env.NODE_ENV = 'development'
+    const processOnceSpy = vi.spyOn(process, 'once').mockImplementation(() => process)
+
+    const { registerNodeInstrumentation } = await import('./instrumentation-node')
+    await registerNodeInstrumentation()
+
+    expect(initWebPrismaMock).toHaveBeenCalledTimes(1)
+    expect(startReaperMock).toHaveBeenCalledTimes(1)
+    expect(startSlackSocketManagerMock).toHaveBeenCalledTimes(1)
+    expect(startAutopilotSchedulerMock).not.toHaveBeenCalled()
+    expect(processOnceSpy).toHaveBeenCalledTimes(3)
+
+    processOnceSpy.mockRestore()
+  })
+
+  it('returns early in desktop mode', async () => {
+    isDesktopMock.mockReturnValue(true)
+    const processOnceSpy = vi.spyOn(process, 'once').mockImplementation(() => process)
+
+    const { registerNodeInstrumentation } = await import('./instrumentation-node')
+    await registerNodeInstrumentation()
+
+    expect(initWebPrismaMock).not.toHaveBeenCalled()
+    expect(startReaperMock).not.toHaveBeenCalled()
+    expect(startSlackSocketManagerMock).not.toHaveBeenCalled()
+    expect(startAutopilotSchedulerMock).not.toHaveBeenCalled()
+    expect(processOnceSpy).not.toHaveBeenCalled()
+
+    processOnceSpy.mockRestore()
+  })
+
+  it('registers shutdown hooks only once across repeated startup calls', async () => {
+    const processOnceSpy = vi.spyOn(process, 'once').mockImplementation(() => process)
+
+    const { registerNodeInstrumentation } = await import('./instrumentation-node')
+    await registerNodeInstrumentation()
+    await registerNodeInstrumentation()
+
+    expect(startReaperMock).toHaveBeenCalledTimes(2)
+    expect(startSlackSocketManagerMock).toHaveBeenCalledTimes(2)
+    expect(processOnceSpy).toHaveBeenCalledTimes(3)
+
+    processOnceSpy.mockRestore()
+  })
+})

--- a/apps/web/src/instrumentation-node.ts
+++ b/apps/web/src/instrumentation-node.ts
@@ -69,9 +69,6 @@ export async function registerNodeInstrumentation() {
   const { initWebPrisma } = await import('@/lib/prisma')
   await initWebPrisma()
 
-  const { startReaper } = await import('@/lib/spawner/reaper')
-  startReaper()
-
   if (process.env.NODE_ENV === 'production') {
     const { startAutopilotScheduler } = await import('@/lib/autopilot/scheduler')
     startAutopilotScheduler()

--- a/apps/web/src/instrumentation-node.ts
+++ b/apps/web/src/instrumentation-node.ts
@@ -69,6 +69,9 @@ export async function registerNodeInstrumentation() {
   const { initWebPrisma } = await import('@/lib/prisma')
   await initWebPrisma()
 
+  const { startReaper } = await import('@/lib/spawner/reaper')
+  startReaper()
+
   if (process.env.NODE_ENV === 'production') {
     const { startAutopilotScheduler } = await import('@/lib/autopilot/scheduler')
     startAutopilotScheduler()

--- a/apps/web/src/lib/spawner/reaper.ts
+++ b/apps/web/src/lib/spawner/reaper.ts
@@ -1,7 +1,19 @@
 import { auditService, instanceService } from '@/lib/services'
 import { getIdleTimeoutMinutes } from './config'
 
+export const REAPER_INTERVAL_MS = 5 * 60 * 1000
+
 let reaperInterval: NodeJS.Timeout | null = null
+let lastRunError: string | null = null
+let lastRunFinishedAt: Date | null = null
+let lastRunStartedAt: Date | null = null
+
+export type ReaperStatus = {
+  lastRunError: string | null
+  lastRunFinishedAt: Date | null
+  lastRunStartedAt: Date | null
+  running: boolean
+}
 
 export async function reapIdleInstances(): Promise<number> {
   const timeoutMinutes = getIdleTimeoutMinutes()
@@ -44,24 +56,41 @@ export async function reapIdleInstances(): Promise<number> {
   return reapedCount
 }
 
+export function getReaperStatus(): ReaperStatus {
+  return {
+    lastRunError,
+    lastRunFinishedAt,
+    lastRunStartedAt,
+    running: reaperInterval !== null,
+  }
+}
+
+async function runReaperCycle(): Promise<void> {
+  lastRunStartedAt = new Date()
+
+  try {
+    const count = await reapIdleInstances()
+    lastRunError = null
+
+    if (count > 0) {
+      console.error(`[reaper] Stopped ${count} idle instance(s)`)
+    }
+  } catch (err) {
+    lastRunError = err instanceof Error ? err.message : 'reaper_error'
+    console.error('[reaper] Error:', err)
+  } finally {
+    lastRunFinishedAt = new Date()
+  }
+}
+
 export function startReaper(): void {
   if (reaperInterval) return
-  const REAPER_INTERVAL_MS = 5 * 60 * 1000
 
-  reaperInterval = setInterval(async () => {
-    try {
-      const count = await reapIdleInstances()
-      if (count > 0) {
-        console.error(`[reaper] Stopped ${count} idle instance(s)`)
-      }
-    } catch (err) {
-      console.error('[reaper] Error:', err)
-    }
+  reaperInterval = setInterval(() => {
+    void runReaperCycle()
   }, REAPER_INTERVAL_MS)
 
-  reapIdleInstances().catch((err) => {
-    console.error('[reaper] Initial reap failed:', err)
-  })
+  void runReaperCycle()
 }
 
 export function stopReaper(): void {

--- a/apps/web/src/reaper-daemon.test.ts
+++ b/apps/web/src/reaper-daemon.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const disconnectMock = vi.fn()
+const getReaperStatusMock = vi.fn()
+const initWebPrismaMock = vi.fn()
+const startReaperMock = vi.fn()
+const stopReaperMock = vi.fn()
+
+vi.mock('@/lib/prisma', () => ({
+  initWebPrisma: (...args: unknown[]) => initWebPrismaMock(...args),
+  prisma: {
+    $disconnect: (...args: unknown[]) => disconnectMock(...args),
+  },
+}))
+
+vi.mock('@/lib/spawner/reaper', () => ({
+  getReaperStatus: (...args: unknown[]) => getReaperStatusMock(...args),
+  REAPER_INTERVAL_MS: 300_000,
+  startReaper: (...args: unknown[]) => startReaperMock(...args),
+  stopReaper: (...args: unknown[]) => stopReaperMock(...args),
+}))
+
+describe('reaper daemon', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    delete globalThis.archeReaperCleanupRegistered
+    getReaperStatusMock.mockReturnValue({
+      lastRunError: null,
+      lastRunFinishedAt: new Date(),
+      lastRunStartedAt: new Date(),
+      running: true,
+    })
+    initWebPrismaMock.mockResolvedValue(undefined)
+    disconnectMock.mockResolvedValue(undefined)
+    stopReaperMock.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    delete globalThis.archeReaperCleanupRegistered
+  })
+
+  it('starts Prisma, the reaper, and shutdown hooks', async () => {
+    const processOnceSpy = vi.spyOn(process, 'once').mockImplementation(() => process)
+
+    const { startReaperDaemon } = await import('./reaper-daemon')
+    await startReaperDaemon()
+
+    expect(initWebPrismaMock).toHaveBeenCalledTimes(1)
+    expect(startReaperMock).toHaveBeenCalledTimes(1)
+    expect(processOnceSpy).toHaveBeenCalledTimes(3)
+
+    processOnceSpy.mockRestore()
+  })
+
+  it('exits when the watchdog detects the reaper has stalled', async () => {
+    const processOnceSpy = vi.spyOn(process, 'once').mockImplementation(() => process)
+    const processExitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+
+    const { REAPER_WATCHDOG_TIMEOUT_MS, startReaperDaemon } = await import('./reaper-daemon')
+    await startReaperDaemon()
+
+    getReaperStatusMock.mockReturnValue({
+      lastRunError: 'boom',
+      lastRunFinishedAt: new Date(Date.now() - REAPER_WATCHDOG_TIMEOUT_MS - 1_000),
+      lastRunStartedAt: new Date(Date.now() - REAPER_WATCHDOG_TIMEOUT_MS - 1_000),
+      running: true,
+    })
+
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    expect(processExitSpy).toHaveBeenCalledWith(1)
+
+    processExitSpy.mockRestore()
+    processOnceSpy.mockRestore()
+  })
+
+  it('stops the reaper and disconnects Prisma on SIGTERM', async () => {
+    const handlers = new Map<string, () => void>()
+    const processKillSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as never)
+    const processOnceSpy = vi.spyOn(process, 'once').mockImplementation(((event, handler) => {
+      handlers.set(String(event), handler as () => void)
+      return process
+    }) as never)
+
+    const { startReaperDaemon } = await import('./reaper-daemon')
+    await startReaperDaemon()
+
+    handlers.get('SIGTERM')?.()
+    await vi.runAllTimersAsync()
+
+    expect(stopReaperMock).toHaveBeenCalledTimes(1)
+    expect(disconnectMock).toHaveBeenCalledTimes(1)
+    expect(processKillSpy).toHaveBeenCalledWith(process.pid, 'SIGTERM')
+
+    processKillSpy.mockRestore()
+    processOnceSpy.mockRestore()
+  })
+})

--- a/apps/web/src/reaper-daemon.ts
+++ b/apps/web/src/reaper-daemon.ts
@@ -1,0 +1,95 @@
+declare global {
+  var archeReaperCleanupRegistered: boolean | undefined
+}
+
+import { prisma } from '@/lib/prisma'
+import { getReaperStatus, REAPER_INTERVAL_MS, startReaper, stopReaper } from '@/lib/spawner/reaper'
+
+const REAPER_WATCHDOG_INTERVAL_MS = 60_000
+export const REAPER_WATCHDOG_TIMEOUT_MS = REAPER_INTERVAL_MS * 2 + 60_000
+
+function getHealthyReaperHeartbeat(): Date | null {
+  const status = getReaperStatus()
+  return status.lastRunFinishedAt ?? status.lastRunStartedAt
+}
+
+function isReaperHealthy(now: number): boolean {
+  const status = getReaperStatus()
+  if (!status.running) {
+    return false
+  }
+
+  const heartbeat = getHealthyReaperHeartbeat()
+  if (!heartbeat) {
+    return true
+  }
+
+  return now - heartbeat.getTime() <= REAPER_WATCHDOG_TIMEOUT_MS
+}
+
+function startReaperWatchdog(): NodeJS.Timeout {
+  return setInterval(() => {
+    if (isReaperHealthy(Date.now())) {
+      return
+    }
+
+    console.error('[reaper-daemon] Watchdog detected an unhealthy reaper state', getReaperStatus())
+    process.exit(1)
+  }, REAPER_WATCHDOG_INTERVAL_MS)
+}
+
+async function gracefulShutdown(watchdog: NodeJS.Timeout): Promise<void> {
+  clearInterval(watchdog)
+
+  try {
+    stopReaper()
+    console.log('[reaper-daemon] Reaper stopped')
+  } catch (error) {
+    console.error('[reaper-daemon] Failed to stop reaper', error)
+  }
+
+  try {
+    await prisma.$disconnect()
+    console.log('[reaper-daemon] Prisma disconnected')
+  } catch (error) {
+    console.error('[reaper-daemon] Failed to disconnect Prisma', error)
+  }
+}
+
+function registerShutdownHooks(watchdog: NodeJS.Timeout): void {
+  if (globalThis.archeReaperCleanupRegistered) {
+    return
+  }
+
+  globalThis.archeReaperCleanupRegistered = true
+
+  process.once('SIGTERM', () => {
+    void gracefulShutdown(watchdog).finally(() => process.kill(process.pid, 'SIGTERM'))
+  })
+
+  process.once('SIGINT', () => {
+    void gracefulShutdown(watchdog).finally(() => process.kill(process.pid, 'SIGINT'))
+  })
+
+  process.once('beforeExit', () => {
+    void gracefulShutdown(watchdog)
+  })
+}
+
+export async function startReaperDaemon(): Promise<void> {
+  const { initWebPrisma } = await import('@/lib/prisma')
+  await initWebPrisma()
+
+  startReaper()
+  const watchdog = startReaperWatchdog()
+  registerShutdownHooks(watchdog)
+
+  console.log('[reaper-daemon] Reaper daemon started')
+}
+
+if (!process.env.VITEST) {
+  void startReaperDaemon().catch((error) => {
+    console.error('[reaper-daemon] Failed to start reaper daemon', error)
+    process.exit(1)
+  })
+}

--- a/infra/deploy/ansible/roles/app/tasks/main.yml
+++ b/infra/deploy/ansible/roles/app/tasks/main.yml
@@ -402,6 +402,38 @@
   changed_when: true
   ignore_errors: true
 
+- name: Recreate reaper daemon (podman compose)
+  ansible.builtin.shell:
+    cmd: >
+      podman compose -f {{ app_dir }}/compose.yml --env-file {{ app_dir }}/.env
+      -p arche up -d --force-recreate reaper
+  changed_when: true
+  when:
+    - deploy_mode == 'remote'
+    - podman_compose_check.rc == 0
+
+- name: Recreate reaper daemon (podman-compose fallback)
+  ansible.builtin.shell:
+    cmd: >
+      podman-compose -f {{ app_dir }}/compose.yml --env-file {{ app_dir }}/.env
+      -p arche up -d --force-recreate reaper
+  changed_when: true
+  when:
+    - deploy_mode == 'remote'
+    - podman_compose_check.rc != 0
+
+- name: Verify reaper daemon is running
+  ansible.builtin.shell:
+    cmd: >
+      podman ps --filter label=com.docker.compose.project=arche --filter label=com.docker.compose.service=reaper
+      --format '{{ '{{' }}.Names{{ '}}' }}'
+  register: reaper_status
+  changed_when: false
+  failed_when:
+    - deploy_mode == 'remote'
+    - reaper_status.stdout | trim | length == 0
+  when: deploy_mode == 'remote'
+
 # ---------------------------------------------------------------------------
 # Step 6: Post-deploy verification
 # ---------------------------------------------------------------------------

--- a/infra/deploy/ansible/roles/app/templates/compose.yml.j2
+++ b/infra/deploy/ansible/roles/app/templates/compose.yml.j2
@@ -114,6 +114,26 @@ services:
       timeout: 5s
       retries: 5
 
+{% if deploy_mode == 'remote' %}
+  reaper:
+    image: {{ web_image }}
+    restart: unless-stopped
+    command:
+      - pnpm
+      - run
+      - start:reaper
+    env_file:
+      - {{ env_file_name | default('.env') }}
+    networks:
+      - default
+      - arche-internal
+    depends_on:
+      postgres:
+        condition: service_healthy
+      docker-socket-proxy:
+        condition: service_healthy
+{% endif %}
+
 {% if deploy_mode == 'local-dev' %}
   # In local-dev mode, web runs in compose with source mounts and
   # `next dev --webpack` for hot reload.


### PR DESCRIPTION
## Summary
- add a dedicated reaper daemon entrypoint and watchdog backed by the existing web image
- recreate the daemon through deploy compose/tasks after a successful web rollout
- remove the stacked embedded reaper startup from the web bootstrap once the daemon owns that role