### PR TITLE
refactor(settings): extract ConnectorsPanel for Slack integration page

### DIFF
--- a/apps/web/src/components/connectors/connectors-manager.tsx
+++ b/apps/web/src/components/connectors/connectors-manager.tsx
@@ -1,18 +1,9 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useRef } from 'react'
 
-import { AddConnectorModal } from '@/components/connectors/add-connector-modal'
-import { getConnectorErrorMessage } from '@/components/connectors/error-messages'
-import { ConnectorList } from '@/components/connectors/connector-list'
-import { ZendeskConnectorSettingsDialog } from '@/components/connectors/zendesk-connector-settings-dialog'
-import type {
-  ConnectorListItem,
-  ConnectorTestResult,
-  ConnectorTestState,
-} from '@/components/connectors/types'
+import { ConnectorsPanel, type ConnectorsPanelHandle } from '@/components/connectors/connectors-panel'
 import { Button } from '@/components/ui/button'
-import { notifyWorkspaceConfigChanged } from '@/lib/runtime/config-status-events'
 
 type ConnectorsManagerProps = {
   slug: string
@@ -22,27 +13,6 @@ type ConnectorsManagerProps = {
   oauthReturnTo?: string
 }
 
-function toConnectorListItemArray(value: unknown): ConnectorListItem[] {
-  if (!value || typeof value !== 'object' || !('connectors' in value)) return []
-  const data = value as { connectors?: ConnectorListItem[] }
-  return Array.isArray(data.connectors) ? data.connectors : []
-}
-
-function formatTestResult(result: ConnectorTestResult): ConnectorTestState {
-  if (result.ok) {
-    return { status: 'success', message: result.message ?? 'Connection verified.' }
-  }
-
-  if (!result.tested) {
-    return {
-      status: 'error',
-      message: result.message ?? 'Connection was not tested against the external service.',
-    }
-  }
-
-  return { status: 'error', message: result.message ?? 'Connection test failed.' }
-}
-
 export function ConnectorsManager({
   slug,
   embedded = false,
@@ -50,212 +20,7 @@ export function ConnectorsManager({
   description = 'Configure integrations for your workspace.',
   oauthReturnTo,
 }: ConnectorsManagerProps) {
-  const [connectors, setConnectors] = useState<ConnectorListItem[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [loadError, setLoadError] = useState<string | null>(null)
-  const [actionError, setActionError] = useState<string | null>(null)
-  const [busyConnectorIds, setBusyConnectorIds] = useState<Record<string, boolean>>({})
-  const [testStates, setTestStates] = useState<Record<string, ConnectorTestState>>({})
-  const [isModalOpen, setIsModalOpen] = useState(false)
-  const [settingsConnector, setSettingsConnector] = useState<ConnectorListItem | null>(null)
-
-  const markConnectorBusy = useCallback((id: string, busy: boolean) => {
-    setBusyConnectorIds((current) => {
-      if (!busy) {
-        const next = { ...current }
-        delete next[id]
-        return next
-      }
-      return { ...current, [id]: true }
-    })
-  }, [])
-
-  const loadConnectors = useCallback(async () => {
-    setIsLoading(true)
-    setLoadError(null)
-
-    try {
-      const response = await fetch(`/api/u/${slug}/connectors`, { cache: 'no-store' })
-      const data = (await response.json().catch(() => null)) as unknown
-
-      if (!response.ok) {
-        setLoadError(getConnectorErrorMessage(data, 'load_failed'))
-        return
-      }
-
-      setConnectors(toConnectorListItemArray(data))
-      setActionError(null)
-    } catch {
-      setLoadError(getConnectorErrorMessage(null, 'network_error'))
-    } finally {
-      setIsLoading(false)
-    }
-  }, [slug])
-
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    const oauthStatus = params.get('oauth')
-    const message = params.get('message')
-
-    if (oauthStatus === 'error') {
-      setActionError(getConnectorErrorMessage({ error: message ?? 'oauth_error' }, 'oauth_error'))
-    }
-
-    if (oauthStatus === 'success') {
-      setActionError(null)
-      void loadConnectors()
-    }
-
-    if (oauthStatus || message) {
-      const cleanUrl = new URL(window.location.href)
-      cleanUrl.searchParams.delete('oauth')
-      cleanUrl.searchParams.delete('message')
-      window.history.replaceState({}, '', `${cleanUrl.pathname}${cleanUrl.search}`)
-    }
-  }, [loadConnectors])
-
-  useEffect(() => {
-    void loadConnectors()
-  }, [loadConnectors])
-
-  const handleDelete = useCallback(
-    async (id: string) => {
-      markConnectorBusy(id, true)
-      setActionError(null)
-
-      try {
-        const response = await fetch(`/api/u/${slug}/connectors/${id}`, {
-          method: 'DELETE',
-        })
-        const data = (await response.json().catch(() => null)) as unknown
-
-        if (!response.ok) {
-          setActionError(getConnectorErrorMessage(data, 'delete_failed'))
-          return
-        }
-
-        setConnectors((current) => current.filter((connector) => connector.id !== id))
-        setTestStates((current) => {
-          const next = { ...current }
-          delete next[id]
-          return next
-        })
-        notifyWorkspaceConfigChanged()
-      } catch {
-        setActionError(getConnectorErrorMessage(null, 'network_error'))
-      } finally {
-        markConnectorBusy(id, false)
-      }
-    },
-    [markConnectorBusy, slug],
-  )
-
-  const handleToggleEnabled = useCallback(
-    async (id: string, currentEnabled: boolean) => {
-      markConnectorBusy(id, true)
-      setActionError(null)
-
-      try {
-        const response = await fetch(`/api/u/${slug}/connectors/${id}`, {
-          method: 'PATCH',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ enabled: !currentEnabled }),
-        })
-        const data = (await response.json().catch(() => null)) as
-          | { enabled?: boolean; error?: string; message?: string }
-          | null
-
-        if (!response.ok) {
-          setActionError(getConnectorErrorMessage(data, 'update_failed'))
-          return
-        }
-
-        setConnectors((current) =>
-          current.map((connector) =>
-            connector.id === id
-              ? { ...connector, enabled: data?.enabled ?? !currentEnabled }
-              : connector,
-          ),
-        )
-        notifyWorkspaceConfigChanged()
-      } catch {
-        setActionError(getConnectorErrorMessage(null, 'network_error'))
-      } finally {
-        markConnectorBusy(id, false)
-      }
-    },
-    [markConnectorBusy, slug],
-  )
-
-  const handleTestConnection = useCallback(
-    async (id: string) => {
-      markConnectorBusy(id, true)
-
-      try {
-        const response = await fetch(`/api/u/${slug}/connectors/${id}/test`, {
-          method: 'POST',
-        })
-        const data = (await response.json().catch(() => null)) as
-          | (ConnectorTestResult & { error?: string; message?: string })
-          | null
-
-        if (!response.ok || !data) {
-          setTestStates((current) => ({
-            ...current,
-            [id]: {
-              status: 'error',
-              message: getConnectorErrorMessage(data, 'test_failed'),
-            },
-          }))
-          return
-        }
-
-        setTestStates((current) => ({ ...current, [id]: formatTestResult(data) }))
-      } catch {
-        setTestStates((current) => ({
-          ...current,
-          [id]: { status: 'error', message: getConnectorErrorMessage(null, 'network_error') },
-        }))
-      } finally {
-        markConnectorBusy(id, false)
-      }
-    },
-    [markConnectorBusy, slug],
-  )
-
-  const handleConnectOAuth = useCallback(
-    async (id: string) => {
-      markConnectorBusy(id, true)
-      setActionError(null)
-
-      try {
-        const requestUrl = new URL(`/api/u/${slug}/connectors/${id}/oauth/start`, window.location.origin)
-        if (oauthReturnTo) {
-          requestUrl.searchParams.set('returnTo', oauthReturnTo)
-        }
-
-        const response = await fetch(`${requestUrl.pathname}${requestUrl.search}`, {
-          method: 'POST',
-          headers: { accept: 'application/json' },
-        })
-        const data = (await response.json().catch(() => null)) as
-          | { authorizeUrl?: string; error?: string }
-          | null
-
-        if (!response.ok || !data?.authorizeUrl) {
-          setActionError(getConnectorErrorMessage(data, 'oauth_start_failed'))
-          return
-        }
-
-        window.location.href = data.authorizeUrl
-      } catch {
-        setActionError(getConnectorErrorMessage(null, 'network_error'))
-      } finally {
-        markConnectorBusy(id, false)
-      }
-    },
-    [markConnectorBusy, oauthReturnTo, slug],
-  )
+  const panelRef = useRef<ConnectorsPanelHandle>(null)
 
   const content = (
     <>
@@ -264,52 +29,12 @@ export function ConnectorsManager({
           <h1 className="type-display text-3xl font-semibold tracking-tight">{title}</h1>
           <p className="text-muted-foreground">{description}</p>
         </div>
-        <Button variant="outline" onClick={() => setIsModalOpen(true)}>Add connector</Button>
+        <Button variant="outline" onClick={() => panelRef.current?.openAddModal()}>
+          Add connector
+        </Button>
       </div>
 
-      {actionError ? (
-        <div className="rounded-lg border border-border/60 bg-card/50 p-4 text-sm text-destructive">
-          The action could not be completed: {actionError}
-        </div>
-      ) : null}
-
-      <ConnectorList
-        connectors={connectors}
-        loadError={loadError}
-        isLoading={isLoading}
-        busyConnectorIds={busyConnectorIds}
-        testStates={testStates}
-        onRetry={loadConnectors}
-        onCreateFirst={() => setIsModalOpen(true)}
-        onDelete={handleDelete}
-        onOpenSettings={setSettingsConnector}
-        onToggleEnabled={handleToggleEnabled}
-        onTestConnection={handleTestConnection}
-        onConnectOAuth={handleConnectOAuth}
-      />
-
-      <AddConnectorModal
-        slug={slug}
-        existingConnectors={connectors}
-        open={isModalOpen}
-        onOpenChange={setIsModalOpen}
-        onSaved={() => {
-          notifyWorkspaceConfigChanged()
-          void loadConnectors()
-        }}
-      />
-
-      <ZendeskConnectorSettingsDialog
-        open={Boolean(settingsConnector)}
-        slug={slug}
-        connectorId={settingsConnector?.id ?? null}
-        connectorName={settingsConnector?.name ?? null}
-        onOpenChange={(open) => {
-          if (!open) {
-            setSettingsConnector(null)
-          }
-        }}
-      />
+      <ConnectorsPanel ref={panelRef} slug={slug} oauthReturnTo={oauthReturnTo} />
     </>
   )
 

--- a/apps/web/src/components/connectors/connectors-panel.tsx
+++ b/apps/web/src/components/connectors/connectors-panel.tsx
@@ -1,0 +1,310 @@
+'use client'
+
+import { useCallback, useEffect, useImperativeHandle, useState, type Ref } from 'react'
+
+import { AddConnectorModal } from '@/components/connectors/add-connector-modal'
+import { ConnectorList } from '@/components/connectors/connector-list'
+import { getConnectorErrorMessage } from '@/components/connectors/error-messages'
+import { ZendeskConnectorSettingsDialog } from '@/components/connectors/zendesk-connector-settings-dialog'
+import type {
+  ConnectorListItem,
+  ConnectorTestResult,
+  ConnectorTestState,
+} from '@/components/connectors/types'
+import { notifyWorkspaceConfigChanged } from '@/lib/runtime/config-status-events'
+
+export type ConnectorsPanelHandle = {
+  openAddModal: () => void
+}
+
+type ConnectorsPanelProps = {
+  slug: string
+  oauthReturnTo?: string
+  ref?: Ref<ConnectorsPanelHandle>
+}
+
+function toConnectorListItemArray(value: unknown): ConnectorListItem[] {
+  if (!value || typeof value !== 'object' || !('connectors' in value)) return []
+  const data = value as { connectors?: ConnectorListItem[] }
+  return Array.isArray(data.connectors) ? data.connectors : []
+}
+
+function formatTestResult(result: ConnectorTestResult): ConnectorTestState {
+  if (result.ok) {
+    return { status: 'success', message: result.message ?? 'Connection verified.' }
+  }
+
+  if (!result.tested) {
+    return {
+      status: 'error',
+      message: result.message ?? 'Connection was not tested against the external service.',
+    }
+  }
+
+  return { status: 'error', message: result.message ?? 'Connection test failed.' }
+}
+
+export function ConnectorsPanel({ slug, oauthReturnTo, ref }: ConnectorsPanelProps) {
+  const [connectors, setConnectors] = useState<ConnectorListItem[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [busyConnectorIds, setBusyConnectorIds] = useState<Record<string, boolean>>({})
+  const [testStates, setTestStates] = useState<Record<string, ConnectorTestState>>({})
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [settingsConnector, setSettingsConnector] = useState<ConnectorListItem | null>(null)
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      openAddModal: () => setIsModalOpen(true),
+    }),
+    [],
+  )
+
+  const markConnectorBusy = useCallback((id: string, busy: boolean) => {
+    setBusyConnectorIds((current) => {
+      if (!busy) {
+        const next = { ...current }
+        delete next[id]
+        return next
+      }
+      return { ...current, [id]: true }
+    })
+  }, [])
+
+  const loadConnectors = useCallback(async () => {
+    setIsLoading(true)
+    setLoadError(null)
+
+    try {
+      const response = await fetch(`/api/u/${slug}/connectors`, { cache: 'no-store' })
+      const data = (await response.json().catch(() => null)) as unknown
+
+      if (!response.ok) {
+        setLoadError(getConnectorErrorMessage(data, 'load_failed'))
+        return
+      }
+
+      setConnectors(toConnectorListItemArray(data))
+      setActionError(null)
+    } catch {
+      setLoadError(getConnectorErrorMessage(null, 'network_error'))
+    } finally {
+      setIsLoading(false)
+    }
+  }, [slug])
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const oauthStatus = params.get('oauth')
+    const message = params.get('message')
+
+    if (oauthStatus === 'error') {
+      setActionError(getConnectorErrorMessage({ error: message ?? 'oauth_error' }, 'oauth_error'))
+    }
+
+    if (oauthStatus === 'success') {
+      setActionError(null)
+      void loadConnectors()
+    }
+
+    if (oauthStatus || message) {
+      const cleanUrl = new URL(window.location.href)
+      cleanUrl.searchParams.delete('oauth')
+      cleanUrl.searchParams.delete('message')
+      window.history.replaceState({}, '', `${cleanUrl.pathname}${cleanUrl.search}`)
+    }
+  }, [loadConnectors])
+
+  useEffect(() => {
+    void loadConnectors()
+  }, [loadConnectors])
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      markConnectorBusy(id, true)
+      setActionError(null)
+
+      try {
+        const response = await fetch(`/api/u/${slug}/connectors/${id}`, {
+          method: 'DELETE',
+        })
+        const data = (await response.json().catch(() => null)) as unknown
+
+        if (!response.ok) {
+          setActionError(getConnectorErrorMessage(data, 'delete_failed'))
+          return
+        }
+
+        setConnectors((current) => current.filter((connector) => connector.id !== id))
+        setTestStates((current) => {
+          const next = { ...current }
+          delete next[id]
+          return next
+        })
+        notifyWorkspaceConfigChanged()
+      } catch {
+        setActionError(getConnectorErrorMessage(null, 'network_error'))
+      } finally {
+        markConnectorBusy(id, false)
+      }
+    },
+    [markConnectorBusy, slug],
+  )
+
+  const handleToggleEnabled = useCallback(
+    async (id: string, currentEnabled: boolean) => {
+      markConnectorBusy(id, true)
+      setActionError(null)
+
+      try {
+        const response = await fetch(`/api/u/${slug}/connectors/${id}`, {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ enabled: !currentEnabled }),
+        })
+        const data = (await response.json().catch(() => null)) as
+          | { enabled?: boolean; error?: string; message?: string }
+          | null
+
+        if (!response.ok) {
+          setActionError(getConnectorErrorMessage(data, 'update_failed'))
+          return
+        }
+
+        setConnectors((current) =>
+          current.map((connector) =>
+            connector.id === id
+              ? { ...connector, enabled: data?.enabled ?? !currentEnabled }
+              : connector,
+          ),
+        )
+        notifyWorkspaceConfigChanged()
+      } catch {
+        setActionError(getConnectorErrorMessage(null, 'network_error'))
+      } finally {
+        markConnectorBusy(id, false)
+      }
+    },
+    [markConnectorBusy, slug],
+  )
+
+  const handleTestConnection = useCallback(
+    async (id: string) => {
+      markConnectorBusy(id, true)
+
+      try {
+        const response = await fetch(`/api/u/${slug}/connectors/${id}/test`, {
+          method: 'POST',
+        })
+        const data = (await response.json().catch(() => null)) as
+          | (ConnectorTestResult & { error?: string; message?: string })
+          | null
+
+        if (!response.ok || !data) {
+          setTestStates((current) => ({
+            ...current,
+            [id]: {
+              status: 'error',
+              message: getConnectorErrorMessage(data, 'test_failed'),
+            },
+          }))
+          return
+        }
+
+        setTestStates((current) => ({ ...current, [id]: formatTestResult(data) }))
+      } catch {
+        setTestStates((current) => ({
+          ...current,
+          [id]: { status: 'error', message: getConnectorErrorMessage(null, 'network_error') },
+        }))
+      } finally {
+        markConnectorBusy(id, false)
+      }
+    },
+    [markConnectorBusy, slug],
+  )
+
+  const handleConnectOAuth = useCallback(
+    async (id: string) => {
+      markConnectorBusy(id, true)
+      setActionError(null)
+
+      try {
+        const requestUrl = new URL(`/api/u/${slug}/connectors/${id}/oauth/start`, window.location.origin)
+        if (oauthReturnTo) {
+          requestUrl.searchParams.set('returnTo', oauthReturnTo)
+        }
+
+        const response = await fetch(`${requestUrl.pathname}${requestUrl.search}`, {
+          method: 'POST',
+          headers: { accept: 'application/json' },
+        })
+        const data = (await response.json().catch(() => null)) as
+          | { authorizeUrl?: string; error?: string }
+          | null
+
+        if (!response.ok || !data?.authorizeUrl) {
+          setActionError(getConnectorErrorMessage(data, 'oauth_start_failed'))
+          return
+        }
+
+        window.location.href = data.authorizeUrl
+      } catch {
+        setActionError(getConnectorErrorMessage(null, 'network_error'))
+      } finally {
+        markConnectorBusy(id, false)
+      }
+    },
+    [markConnectorBusy, oauthReturnTo, slug],
+  )
+
+  return (
+    <div className="space-y-4">
+      {actionError ? (
+        <div className="rounded-lg border border-border/60 bg-card/50 p-4 text-sm text-destructive">
+          The action could not be completed: {actionError}
+        </div>
+      ) : null}
+
+      <ConnectorList
+        connectors={connectors}
+        loadError={loadError}
+        isLoading={isLoading}
+        busyConnectorIds={busyConnectorIds}
+        testStates={testStates}
+        onRetry={loadConnectors}
+        onCreateFirst={() => setIsModalOpen(true)}
+        onDelete={handleDelete}
+        onOpenSettings={setSettingsConnector}
+        onToggleEnabled={handleToggleEnabled}
+        onTestConnection={handleTestConnection}
+        onConnectOAuth={handleConnectOAuth}
+      />
+
+      <AddConnectorModal
+        slug={slug}
+        existingConnectors={connectors}
+        open={isModalOpen}
+        onOpenChange={setIsModalOpen}
+        onSaved={() => {
+          notifyWorkspaceConfigChanged()
+          void loadConnectors()
+        }}
+      />
+
+      <ZendeskConnectorSettingsDialog
+        open={Boolean(settingsConnector)}
+        slug={slug}
+        connectorId={settingsConnector?.id ?? null}
+        connectorName={settingsConnector?.name ?? null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSettingsConnector(null)
+          }
+        }}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/settings/slack-integration-settings-content.test.tsx
+++ b/apps/web/src/components/settings/slack-integration-settings-content.test.tsx
@@ -3,8 +3,8 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/components/connectors/connectors-manager', () => ({
-  ConnectorsManager: ({ slug, oauthReturnTo }: { slug: string; oauthReturnTo?: string }) => (
+vi.mock('@/components/connectors/connectors-panel', () => ({
+  ConnectorsPanel: ({ slug, oauthReturnTo }: { slug: string; oauthReturnTo?: string }) => (
     <div>Connectors {slug} {oauthReturnTo}</div>
   ),
 }))

--- a/apps/web/src/components/settings/slack-integration-settings-content.tsx
+++ b/apps/web/src/components/settings/slack-integration-settings-content.tsx
@@ -1,12 +1,16 @@
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
-import { ConnectorsManager } from '@/components/connectors/connectors-manager'
+import {
+  ConnectorsPanel,
+  type ConnectorsPanelHandle,
+} from '@/components/connectors/connectors-panel'
 import { ProviderCredentialsPanel } from '@/components/providers/provider-credentials-panel'
 import { SettingsSection } from '@/components/settings/settings-section'
 import { SlackIntegrationDangerZone } from '@/components/settings/slack-integration-danger-zone'
 import { SlackIntegrationPanel } from '@/components/settings/slack-integration-panel'
+import { Button } from '@/components/ui/button'
 
 type SlackIntegrationSettingsContentProps = {
   serviceUserSlug: string
@@ -20,6 +24,7 @@ export function SlackIntegrationSettingsContent({
   showProviderCredentials,
 }: SlackIntegrationSettingsContentProps) {
   const [refreshVersion, setRefreshVersion] = useState(0)
+  const connectorsPanelRef = useRef<ConnectorsPanelHandle>(null)
 
   function handleIntegrationMutated() {
     setRefreshVersion((current) => current + 1)
@@ -47,12 +52,18 @@ export function SlackIntegrationSettingsContent({
           <SettingsSection
             title="Connectors for Slack bot"
             description="Create, enable, and test the connectors available to the reserved slack-bot service workspace."
+            action={
+              <Button
+                variant="outline"
+                onClick={() => connectorsPanelRef.current?.openAddModal()}
+              >
+                Add connector
+              </Button>
+            }
           >
-            <ConnectorsManager
+            <ConnectorsPanel
+              ref={connectorsPanelRef}
               slug={serviceUserSlug}
-              embedded
-              title="Slack bot connectors"
-              description="These connectors are available to the slack-bot service workspace when an agent capability allows them."
               oauthReturnTo={`/u/${slug}/settings/integrations/slack`}
             />
           </SettingsSection>


### PR DESCRIPTION
## Summary
- Extract the connector list, empty state, and modals from `ConnectorsManager` into a new headerless `ConnectorsPanel` exposing an imperative `openAddModal()` handle
- Drop the duplicated "Slack bot connectors" heading/description on the Slack integration settings page by embedding `ConnectorsPanel` directly under its `SettingsSection` ("Connectors for Slack bot"), with the "Add connector" button moved into the section's action slot
- Keep `ConnectorsManager` as a thin wrapper around `ConnectorsPanel` so the standalone connectors page and the desktop settings dialog continue to render their own header unchanged

## Test plan
- [ ] `pnpm -C apps/web test` (unit tests — covers `slack-integration-settings-content.test.tsx` and `desktop-settings-dialog.test.tsx`)
- [ ] Manually open `/u/<slug>/settings/integrations/slack` and verify only a single "Connectors for Slack bot" header is rendered, with the "Add connector" button in the section header
- [ ] Verify the standalone connectors page and the desktop settings dialog still render their full header + Add connector button

🤖 Generated with [Claude Code](https://claude.com/claude-code)