### PR TITLE
feat(connectors): allow Linear app actor client overrides

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -63,14 +63,9 @@ ARCHE_CONNECTOR_LINEAR_SCOPE=""
 ARCHE_CONNECTOR_NOTION_SCOPE=""
 
 # Optional static OAuth clients.
-# For Linear app actor mode, Arche first prefers connector-level client credentials,
-# then these env vars, then OAuth 2.1 Dynamic Client Registration.
-# Create a Linear OAuth2 application and use
-# https://your-arche-host/api/connectors/oauth/callback as the callback URL.
+# Notion uses these as a fallback when dynamic client registration is unavailable.
 ARCHE_CONNECTOR_NOTION_CLIENT_ID=""
 ARCHE_CONNECTOR_NOTION_CLIENT_SECRET=""
-ARCHE_CONNECTOR_LINEAR_CLIENT_ID=""
-ARCHE_CONNECTOR_LINEAR_CLIENT_SECRET=""
 
 # Optional connector gateway settings (web-managed OAuth bridge to workspace MCP)
 ARCHE_CONNECTOR_GATEWAY_BASE_URL="http://web:3000/api/internal/mcp/connectors"

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -62,10 +62,11 @@ ARCHE_CONNECTOR_NOTION_MCP_URL="https://mcp.notion.com/mcp"
 ARCHE_CONNECTOR_LINEAR_SCOPE=""
 ARCHE_CONNECTOR_NOTION_SCOPE=""
 
-# Optional static OAuth clients (fallback if dynamic client registration is unavailable)
-# For Linear app actor mode, create a Linear OAuth2 application and use
+# Optional static OAuth clients.
+# For Linear app actor mode, Arche first prefers connector-level client credentials,
+# then these env vars, then OAuth 2.1 Dynamic Client Registration.
+# Create a Linear OAuth2 application and use
 # https://your-arche-host/api/connectors/oauth/callback as the callback URL.
-# If omitted, Arche uses OAuth 2.1 Dynamic Client Registration automatically.
 ARCHE_CONNECTOR_NOTION_CLIENT_ID=""
 ARCHE_CONNECTOR_NOTION_CLIENT_SECRET=""
 ARCHE_CONNECTOR_LINEAR_CLIENT_ID=""

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -99,7 +99,7 @@ This repo uses `pnpm` by default.
 - Linear connectors support standard user OAuth and app actor OAuth.
 - App actor mode adds `actor=app` to the Linear authorization URL, so actions appear in Linear as the OAuth application instead of as the user who completed consent.
 - The visible author name and icon come from the Linear OAuth application configuration.
-- You can now paste the Linear app `client_id` and `client_secret` directly into the connector modal for app actor mode. Arche prefers those connector-level credentials before falling back to server-level env vars or dynamic registration.
+- In app actor mode, you paste the Linear app `client_id` and `client_secret` directly into the connector modal. User OAuth keeps using dynamic client registration.
 - Arche does not currently set Linear's optional `createAsUser` or `displayIconUrl` fields, so app actor changes appear as the OAuth application itself.
 
 ## UI

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -99,6 +99,7 @@ This repo uses `pnpm` by default.
 - Linear connectors support standard user OAuth and app actor OAuth.
 - App actor mode adds `actor=app` to the Linear authorization URL, so actions appear in Linear as the OAuth application instead of as the user who completed consent.
 - The visible author name and icon come from the Linear OAuth application configuration.
+- You can now paste the Linear app `client_id` and `client_secret` directly into the connector modal for app actor mode. Arche prefers those connector-level credentials before falling back to server-level env vars or dynamic registration.
 - Arche does not currently set Linear's optional `createAsUser` or `displayIconUrl` fields, so app actor changes appear as the OAuth application itself.
 
 ## UI

--- a/apps/web/src/app/api/u/[slug]/connectors/[id]/oauth/start/route.ts
+++ b/apps/web/src/app/api/u/[slug]/connectors/[id]/oauth/start/route.ts
@@ -80,6 +80,7 @@ export const POST = withAuth<
     const message = error instanceof Error ? error.message : 'oauth_start_failed'
     if (
       message === 'missing_endpoint'
+      || message === 'missing_linear_oauth_client_credentials'
       || message === 'invalid_endpoint'
       || message === 'blocked_endpoint'
       || message === 'oauth_state_too_large'

--- a/apps/web/src/app/api/u/[slug]/connectors/[id]/route.ts
+++ b/apps/web/src/app/api/u/[slug]/connectors/[id]/route.ts
@@ -1,9 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { auditEvent } from '@/lib/auth'
-import { encryptConfig, decryptConfig } from '@/lib/connectors/crypto'
+import { decryptConfig, encryptConfig } from '@/lib/connectors/crypto'
 import { resolveLinearOAuthActor, type LinearOAuthActor } from '@/lib/connectors/linear'
-import { getConnectorAuthType, getConnectorOAuthConfig } from '@/lib/connectors/oauth-config'
+import {
+  getConnectorAuthType,
+  getConnectorOAuthConfig,
+  mergeConnectorConfigWithPreservedOAuth,
+} from '@/lib/connectors/oauth-config'
 import type { ConnectorType } from '@/lib/connectors/types'
 import {
   validateConnectorConfig,
@@ -189,6 +193,7 @@ export const PATCH = withAuth<
 
   // Prepare data to update
   const updateData: { name?: string; config?: string; enabled?: boolean } = {}
+  let responseConfig: Record<string, unknown> | null = null
 
   if (name !== undefined) {
     const nameValidation = validateConnectorName(name)
@@ -211,6 +216,16 @@ export const PATCH = withAuth<
     updateData.enabled = enabled
   }
 
+  let existingDecryptedConfig: Record<string, unknown>
+  try {
+    existingDecryptedConfig = decryptConfig(existingConnector.config)
+  } catch {
+    return NextResponse.json(
+      { error: 'config_corrupted', message: 'Existing connector configuration is corrupted' },
+      { status: 500 }
+    )
+  }
+
   if (config !== undefined) {
     // Validate config is a non-null object
     if (config === null || typeof config !== 'object' || Array.isArray(config)) {
@@ -226,10 +241,13 @@ export const PATCH = withAuth<
         { status: 500 }
       )
     }
-    // NOTE: config is "full replace", not partial merge.
-    // Client must send the complete config with all required fields.
     const connectorType = existingConnector.type as ConnectorType
-    const configValidation = validateConnectorConfig(connectorType, config)
+    const mergedConfig = mergeConnectorConfigWithPreservedOAuth({
+      connectorType,
+      currentConfig: existingDecryptedConfig,
+      nextConfig: config,
+    })
+    const configValidation = validateConnectorConfig(connectorType, mergedConfig)
     if (!configValidation.valid) {
       return NextResponse.json(
         {
@@ -240,7 +258,8 @@ export const PATCH = withAuth<
       )
     }
     try {
-      updateData.config = encryptConfig(config)
+      updateData.config = encryptConfig(mergedConfig)
+      responseConfig = mergedConfig
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to encrypt config'
       return NextResponse.json(
@@ -258,19 +277,11 @@ export const PATCH = withAuth<
     )
   }
 
-  // If config is NOT being updated, validate that existing config can be decrypted
-  // BEFORE applying changes (prevents mutation + 500 if config is corrupted)
-  let existingDecryptedConfig: Record<string, unknown> | null = null
-  if (config === undefined) {
-    try {
-      existingDecryptedConfig = decryptConfig(existingConnector.config)
-    } catch {
-      return NextResponse.json(
-        { error: 'config_corrupted', message: 'Existing connector configuration is corrupted' },
-        { status: 500 }
-      )
-    }
+  if (responseConfig === null) {
+    responseConfig = existingDecryptedConfig
   }
+
+  const resolvedResponseConfig = responseConfig ?? existingDecryptedConfig
 
   // Update connector atomically while verifying ownership (prevents TOCTOU)
   const result = await connectorService.updateManyByIdAndUserId(id, targetUser.id, updateData)
@@ -295,23 +306,18 @@ export const PATCH = withAuth<
     metadata: { connectorId: connector.id, fields: Object.keys(updateData) },
   })
 
-  // For response: use request config if updated, otherwise use existing decrypted config
-  const responseConfig = config !== undefined
-    ? config  // Already validated, use input directly
-    : existingDecryptedConfig!  // Already decrypted before update
-
   const connectorType = validateConnectorType(connector.type) ? connector.type : null
-  const authType = getConnectorAuthType(responseConfig)
-  const oauthConfig = connectorType ? getConnectorOAuthConfig(connectorType, responseConfig) : null
+  const authType = getConnectorAuthType(resolvedResponseConfig)
+  const oauthConfig = connectorType ? getConnectorOAuthConfig(connectorType, resolvedResponseConfig) : null
 
   return NextResponse.json({
     id: connector.id,
     type: connector.type,
     name: connector.name,
-    config: connectorType ? sanitizeConfigForResponse(connectorType, responseConfig) : responseConfig,
+    config: connectorType ? sanitizeConfigForResponse(connectorType, resolvedResponseConfig) : resolvedResponseConfig,
     enabled: connector.enabled,
     authType,
-    oauthActor: connectorType ? resolveLinearOAuthActor(connectorType, authType, responseConfig) : undefined,
+    oauthActor: connectorType ? resolveLinearOAuthActor(connectorType, authType, resolvedResponseConfig) : undefined,
     oauthConnected: Boolean(oauthConfig?.accessToken),
     oauthExpiresAt: oauthConfig?.expiresAt,
     createdAt: connector.createdAt.toISOString(),

--- a/apps/web/src/app/api/u/[slug]/connectors/[id]/route.ts
+++ b/apps/web/src/app/api/u/[slug]/connectors/[id]/route.ts
@@ -36,7 +36,7 @@ function sanitizeConfigForResponse(type: ConnectorType, config: Record<string, u
   if (getConnectorAuthType(config) !== 'oauth') return config
 
   const sanitizedConfig = { ...config }
-  if (type === 'custom') {
+  if (type === 'custom' || type === 'linear') {
     delete sanitizedConfig.oauthClientSecret
   }
 

--- a/apps/web/src/components/connectors/__tests__/add-connector-modal.test.tsx
+++ b/apps/web/src/components/connectors/__tests__/add-connector-modal.test.tsx
@@ -55,6 +55,13 @@ describe('AddConnectorModal', () => {
       'https://linear.app/developers/oauth-actor-authorization'
     )
 
+    fireEvent.change(screen.getByLabelText('Client ID (optional override)'), {
+      target: { value: 'linear-client-id' },
+    })
+    fireEvent.change(screen.getByLabelText('Client secret (optional override)'), {
+      target: { value: 'linear-client-secret' },
+    })
+
     fireEvent.click(screen.getByRole('button', { name: 'Save connector' }))
 
     await waitFor(() => {
@@ -70,6 +77,8 @@ describe('AddConnectorModal', () => {
       config: {
         authType: 'oauth',
         oauthActor: 'app',
+        oauthClientId: 'linear-client-id',
+        oauthClientSecret: 'linear-client-secret',
       },
     })
     expect(onSaved).toHaveBeenCalledTimes(1)

--- a/apps/web/src/components/connectors/__tests__/add-connector-modal.test.tsx
+++ b/apps/web/src/components/connectors/__tests__/add-connector-modal.test.tsx
@@ -55,12 +55,16 @@ describe('AddConnectorModal', () => {
       'https://linear.app/developers/oauth-actor-authorization'
     )
 
-    fireEvent.change(screen.getByLabelText('Client ID (optional override)'), {
+    expect(screen.getByRole('button', { name: 'Save connector' }).hasAttribute('disabled')).toBe(true)
+
+    fireEvent.change(screen.getByLabelText('Client ID'), {
       target: { value: 'linear-client-id' },
     })
-    fireEvent.change(screen.getByLabelText('Client secret (optional override)'), {
+    fireEvent.change(screen.getByLabelText('Client secret'), {
       target: { value: 'linear-client-secret' },
     })
+
+    expect(screen.getByRole('button', { name: 'Save connector' }).hasAttribute('disabled')).toBe(false)
 
     fireEvent.click(screen.getByRole('button', { name: 'Save connector' }))
 

--- a/apps/web/src/components/connectors/add-connector-modal.tsx
+++ b/apps/web/src/components/connectors/add-connector-modal.tsx
@@ -118,6 +118,8 @@ export function AddConnectorModal({
   const [error, setError] = useState<string | null>(null)
 
   const usesGeneratedName = selectedType !== 'custom'
+  const showsLinearAppOAuthClientFields =
+    selectedType === 'linear' && authType === 'oauth' && linearOAuthActor === 'app'
 
   const availableTypeOptions = useMemo(
     () =>
@@ -186,7 +188,13 @@ export function AddConnectorModal({
           ok: true,
           value: {
             authType: 'oauth',
-            ...(selectedType === 'linear' && linearOAuthActor === 'app' ? { oauthActor: 'app' } : {}),
+            ...(selectedType === 'linear' && linearOAuthActor === 'app'
+              ? {
+                  oauthActor: 'app',
+                  oauthClientId: oauthClientId.trim() || undefined,
+                  oauthClientSecret: oauthClientSecret.trim() || undefined,
+                }
+              : {}),
           },
         }
       }
@@ -473,7 +481,7 @@ export function AddConnectorModal({
             </p>
           ) : null}
 
-          {selectedType === 'linear' && authType === 'oauth' && linearOAuthActor === 'app' ? (
+          {showsLinearAppOAuthClientFields ? (
             <div className="space-y-3 rounded-lg border border-border/50 bg-muted/20 px-4 py-3 text-sm">
               <div className="space-y-1">
                 <p className="font-medium text-foreground">Create a Linear OAuth application first</p>
@@ -487,7 +495,7 @@ export function AddConnectorModal({
                 <li>Open Linear Settings -&gt; API -&gt; Applications.</li>
                 <li>Create a new OAuth2 application for Arche with the name and icon you want to appear in Linear.</li>
                 <li>Add <code>{LINEAR_CALLBACK_URL_HINT}</code> as a callback URL, replacing the host with your Arche URL.</li>
-                <li>Configure the Linear client ID and client secret in Arche before starting OAuth.</li>
+                <li>Paste the Linear client ID and client secret below, or use server-level env vars, before starting OAuth.</li>
                 <li>Save this connector, then connect OAuth as a Linear workspace admin.</li>
               </ol>
 
@@ -510,6 +518,38 @@ export function AddConnectorModal({
                 </a>
               </div>
             </div>
+          ) : null}
+
+          {showsLinearAppOAuthClientFields ? (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="linear-oauth-client-id" className="text-foreground">
+                  Client ID <span className="font-normal text-muted-foreground">(optional override)</span>
+                </Label>
+                <Input
+                  id="linear-oauth-client-id"
+                  value={oauthClientId}
+                  onChange={(event) => setOauthClientId(event.target.value)}
+                  placeholder="Linear OAuth client id"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="linear-oauth-client-secret" className="text-foreground">
+                  Client secret <span className="font-normal text-muted-foreground">(optional override)</span>
+                </Label>
+                <Input
+                  id="linear-oauth-client-secret"
+                  type="password"
+                  value={oauthClientSecret}
+                  onChange={(event) => setOauthClientSecret(event.target.value)}
+                  placeholder="Linear OAuth client secret"
+                />
+                <p className="text-xs text-muted-foreground">
+                  If left blank, Arche falls back to server-level Linear OAuth credentials when available.
+                </p>
+              </div>
+            </>
           ) : null}
 
           {/* Manual API key (official types) */}

--- a/apps/web/src/components/connectors/add-connector-modal.tsx
+++ b/apps/web/src/components/connectors/add-connector-modal.tsx
@@ -184,6 +184,12 @@ export function AddConnectorModal({
   function buildConfig(): { ok: true; value: Record<string, unknown> } | { ok: false; message: string } {
     if (selectedType === 'linear' || selectedType === 'notion') {
       if (authType === 'oauth') {
+        if (selectedType === 'linear' && linearOAuthActor === 'app') {
+          if (!oauthClientId.trim() || !oauthClientSecret.trim()) {
+            return { ok: false, message: 'Linear app actor OAuth requires client ID and client secret.' }
+          }
+        }
+
         return {
           ok: true,
           value: {
@@ -296,6 +302,10 @@ export function AddConnectorModal({
     }
 
     if (selectedType === 'linear' || selectedType === 'notion') {
+      if (selectedType === 'linear' && authType === 'oauth' && linearOAuthActor === 'app') {
+        return Boolean(oauthClientId.trim() && oauthClientSecret.trim())
+      }
+
       return authType === 'oauth' || Boolean(apiKey.trim())
     }
 
@@ -495,7 +505,7 @@ export function AddConnectorModal({
                 <li>Open Linear Settings -&gt; API -&gt; Applications.</li>
                 <li>Create a new OAuth2 application for Arche with the name and icon you want to appear in Linear.</li>
                 <li>Add <code>{LINEAR_CALLBACK_URL_HINT}</code> as a callback URL, replacing the host with your Arche URL.</li>
-                <li>Paste the Linear client ID and client secret below, or use server-level env vars, before starting OAuth.</li>
+                <li>Paste the Linear client ID and client secret below before starting OAuth.</li>
                 <li>Save this connector, then connect OAuth as a Linear workspace admin.</li>
               </ol>
 
@@ -524,7 +534,7 @@ export function AddConnectorModal({
             <>
               <div className="space-y-2">
                 <Label htmlFor="linear-oauth-client-id" className="text-foreground">
-                  Client ID <span className="font-normal text-muted-foreground">(optional override)</span>
+                  Client ID
                 </Label>
                 <Input
                   id="linear-oauth-client-id"
@@ -536,7 +546,7 @@ export function AddConnectorModal({
 
               <div className="space-y-2">
                 <Label htmlFor="linear-oauth-client-secret" className="text-foreground">
-                  Client secret <span className="font-normal text-muted-foreground">(optional override)</span>
+                  Client secret
                 </Label>
                 <Input
                   id="linear-oauth-client-secret"
@@ -546,7 +556,7 @@ export function AddConnectorModal({
                   placeholder="Linear OAuth client secret"
                 />
                 <p className="text-xs text-muted-foreground">
-                  If left blank, Arche falls back to server-level Linear OAuth credentials when available.
+                  Linear app actor mode uses the credentials stored on this connector only.
                 </p>
               </div>
             </>

--- a/apps/web/src/lib/connectors/linear.ts
+++ b/apps/web/src/lib/connectors/linear.ts
@@ -2,12 +2,33 @@ export const LINEAR_OAUTH_ACTORS = ['user', 'app'] as const
 
 export type LinearOAuthActor = (typeof LINEAR_OAUTH_ACTORS)[number]
 
+type LinearOAuthClientRegistration = {
+  clientId: string
+  clientSecret?: string
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
 export function isLinearOAuthActor(value: unknown): value is LinearOAuthActor {
   return LINEAR_OAUTH_ACTORS.includes(value as LinearOAuthActor)
 }
 
 export function getLinearOAuthActor(config: Record<string, unknown>): LinearOAuthActor {
   return isLinearOAuthActor(config.oauthActor) ? config.oauthActor : 'user'
+}
+
+export function getLinearOAuthClientRegistration(
+  config: Record<string, unknown>
+): LinearOAuthClientRegistration | null {
+  const clientId = getString(config.oauthClientId)
+  if (!clientId) return null
+
+  return {
+    clientId,
+    clientSecret: getString(config.oauthClientSecret),
+  }
 }
 
 export function resolveLinearOAuthActor(

--- a/apps/web/src/lib/connectors/linear.ts
+++ b/apps/web/src/lib/connectors/linear.ts
@@ -2,9 +2,9 @@ export const LINEAR_OAUTH_ACTORS = ['user', 'app'] as const
 
 export type LinearOAuthActor = (typeof LINEAR_OAUTH_ACTORS)[number]
 
-type LinearOAuthClientRegistration = {
+type LinearOAuthClientCredentials = {
   clientId: string
-  clientSecret?: string
+  clientSecret: string
 }
 
 function getString(value: unknown): string | undefined {
@@ -19,15 +19,16 @@ export function getLinearOAuthActor(config: Record<string, unknown>): LinearOAut
   return isLinearOAuthActor(config.oauthActor) ? config.oauthActor : 'user'
 }
 
-export function getLinearOAuthClientRegistration(
+export function getLinearOAuthClientCredentials(
   config: Record<string, unknown>
-): LinearOAuthClientRegistration | null {
+): LinearOAuthClientCredentials | null {
   const clientId = getString(config.oauthClientId)
-  if (!clientId) return null
+  const clientSecret = getString(config.oauthClientSecret)
+  if (!clientId || !clientSecret) return null
 
   return {
     clientId,
-    clientSecret: getString(config.oauthClientSecret),
+    clientSecret,
   }
 }
 

--- a/apps/web/src/lib/connectors/oauth-config.ts
+++ b/apps/web/src/lib/connectors/oauth-config.ts
@@ -92,6 +92,43 @@ export function buildConfigWithOAuth(input: {
   return next
 }
 
+export function mergeConnectorConfigWithPreservedOAuth(input: {
+  connectorType: ConnectorType
+  currentConfig: ConnectorConfigRecord
+  nextConfig: ConnectorConfigRecord
+}): ConnectorConfigRecord {
+  const next = { ...input.nextConfig }
+
+  if (getConnectorAuthType(next) !== 'oauth' || !isOAuthConnectorType(input.connectorType)) {
+    return next
+  }
+
+  if ((input.connectorType === 'custom' || input.connectorType === 'linear') && next.oauthClientSecret === undefined) {
+    const currentClientSecret = getString(input.currentConfig.oauthClientSecret)
+    if (currentClientSecret) {
+      next.oauthClientSecret = currentClientSecret
+    }
+  }
+
+  if (!isObject(input.currentConfig.oauth)) {
+    return next
+  }
+
+  if (next.oauth === undefined) {
+    next.oauth = { ...input.currentConfig.oauth }
+    return next
+  }
+
+  if (isObject(next.oauth)) {
+    next.oauth = {
+      ...input.currentConfig.oauth,
+      ...next.oauth,
+    }
+  }
+
+  return next
+}
+
 export function clearConnectorOAuthConfig(currentConfig: ConnectorConfigRecord): ConnectorConfigRecord {
   const next = { ...currentConfig }
   delete next.oauth

--- a/apps/web/src/lib/connectors/oauth.ts
+++ b/apps/web/src/lib/connectors/oauth.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto'
 
-import { getLinearOAuthActor } from '@/lib/connectors/linear'
+import { getLinearOAuthActor, getLinearOAuthClientRegistration } from '@/lib/connectors/linear'
 import { OAUTH_CONNECTOR_TYPES, type ConnectorType, type OAuthConnectorType } from '@/lib/connectors/types'
 import { validateConnectorTestEndpoint } from '@/lib/security/ssrf'
 
@@ -53,6 +53,7 @@ type OAuthPreparationContext = {
   mcpServerUrl: string
   scope?: string
   staticClientRegistration: OAuthClientRegistration | null
+  staticClientRegistrationMode: 'fallback' | 'preferred'
   metadataOverrides: OAuthMetadataOverrides
   validateMetadataEndpoints: boolean
 }
@@ -302,6 +303,11 @@ function getStaticOAuthClientRegistration(
   }
 
   if (type === 'linear') {
+    const connectorClient = connectorConfig ? getLinearOAuthClientRegistration(connectorConfig) : null
+    if (connectorClient) {
+      return connectorClient
+    }
+
     const clientId = process.env.ARCHE_CONNECTOR_LINEAR_CLIENT_ID
     if (!clientId || !clientId.trim()) return null
     const clientSecret = process.env.ARCHE_CONNECTOR_LINEAR_CLIENT_SECRET
@@ -320,6 +326,15 @@ function getStaticOAuthClientRegistration(
   }
 }
 
+function getStaticOAuthClientRegistrationMode(
+  type: OAuthConnectorType,
+  connectorConfig?: Record<string, unknown>,
+): 'fallback' | 'preferred' {
+  return type === 'linear' && connectorConfig && getLinearOAuthActor(connectorConfig) === 'app'
+    ? 'preferred'
+    : 'fallback'
+}
+
 async function resolveOAuthPreparationContext(input: {
   connectorType: OAuthConnectorType
   connectorConfig?: Record<string, unknown>
@@ -328,7 +343,8 @@ async function resolveOAuthPreparationContext(input: {
     return {
       mcpServerUrl: getOfficialMcpServerUrl(input.connectorType),
       scope: getOptionalScope(input.connectorType),
-      staticClientRegistration: getStaticOAuthClientRegistration(input.connectorType),
+      staticClientRegistration: getStaticOAuthClientRegistration(input.connectorType, input.connectorConfig),
+      staticClientRegistrationMode: getStaticOAuthClientRegistrationMode(input.connectorType, input.connectorConfig),
       metadataOverrides: {},
       validateMetadataEndpoints: false,
     }
@@ -348,6 +364,7 @@ async function resolveOAuthPreparationContext(input: {
     mcpServerUrl: await validateConnectorUrl(endpoint),
     scope: getString(connectorConfig?.oauthScope),
     staticClientRegistration: getStaticOAuthClientRegistration(input.connectorType, connectorConfig),
+    staticClientRegistrationMode: getStaticOAuthClientRegistrationMode(input.connectorType, connectorConfig),
     metadataOverrides: {
       authorizationEndpoint: authorizationEndpoint
         ? await validateConnectorUrl(authorizationEndpoint)
@@ -391,7 +408,12 @@ async function registerOAuthClient(
   redirectUri: string,
   connectorType: OAuthConnectorType,
   staticRegistration: OAuthClientRegistration | null,
+  staticRegistrationMode: 'fallback' | 'preferred',
 ): Promise<OAuthClientRegistration> {
+  if (staticRegistration && staticRegistrationMode === 'preferred') {
+    return staticRegistration
+  }
+
   if (!metadata.registrationEndpoint) {
     if (staticRegistration) return staticRegistration
     throw new Error('oauth_registration_failed:missing_registration_endpoint')
@@ -521,6 +543,7 @@ export async function prepareConnectorOAuthAuthorization(input: {
     input.redirectUri,
     input.connectorType,
     context.staticClientRegistration,
+    context.staticClientRegistrationMode,
   )
 
   const codeVerifier = createPkceCodeVerifier()

--- a/apps/web/src/lib/connectors/oauth.ts
+++ b/apps/web/src/lib/connectors/oauth.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto'
 
-import { getLinearOAuthActor, getLinearOAuthClientRegistration } from '@/lib/connectors/linear'
+import { getLinearOAuthActor, getLinearOAuthClientCredentials } from '@/lib/connectors/linear'
 import { OAUTH_CONNECTOR_TYPES, type ConnectorType, type OAuthConnectorType } from '@/lib/connectors/types'
 import { validateConnectorTestEndpoint } from '@/lib/security/ssrf'
 
@@ -53,7 +53,7 @@ type OAuthPreparationContext = {
   mcpServerUrl: string
   scope?: string
   staticClientRegistration: OAuthClientRegistration | null
-  staticClientRegistrationMode: 'fallback' | 'preferred'
+  preferStaticClientRegistration: boolean
   metadataOverrides: OAuthMetadataOverrides
   validateMetadataEndpoints: boolean
 }
@@ -303,18 +303,8 @@ function getStaticOAuthClientRegistration(
   }
 
   if (type === 'linear') {
-    const connectorClient = connectorConfig ? getLinearOAuthClientRegistration(connectorConfig) : null
-    if (connectorClient) {
-      return connectorClient
-    }
-
-    const clientId = process.env.ARCHE_CONNECTOR_LINEAR_CLIENT_ID
-    if (!clientId || !clientId.trim()) return null
-    const clientSecret = process.env.ARCHE_CONNECTOR_LINEAR_CLIENT_SECRET
-    return {
-      clientId: clientId.trim(),
-      clientSecret: clientSecret?.trim() || undefined,
-    }
+    if (!connectorConfig || getLinearOAuthActor(connectorConfig) !== 'app') return null
+    return getLinearOAuthClientCredentials(connectorConfig)
   }
 
   const clientId = process.env.ARCHE_CONNECTOR_NOTION_CLIENT_ID
@@ -326,25 +316,25 @@ function getStaticOAuthClientRegistration(
   }
 }
 
-function getStaticOAuthClientRegistrationMode(
-  type: OAuthConnectorType,
-  connectorConfig?: Record<string, unknown>,
-): 'fallback' | 'preferred' {
-  return type === 'linear' && connectorConfig && getLinearOAuthActor(connectorConfig) === 'app'
-    ? 'preferred'
-    : 'fallback'
-}
-
 async function resolveOAuthPreparationContext(input: {
   connectorType: OAuthConnectorType
   connectorConfig?: Record<string, unknown>
 }): Promise<OAuthPreparationContext> {
   if (input.connectorType !== 'custom') {
+    const preferStaticClientRegistration = input.connectorType === 'linear'
+      && input.connectorConfig !== undefined
+      && getLinearOAuthActor(input.connectorConfig) === 'app'
+    const staticClientRegistration = getStaticOAuthClientRegistration(input.connectorType, input.connectorConfig)
+
+    if (preferStaticClientRegistration && !staticClientRegistration) {
+      throw new Error('missing_linear_oauth_client_credentials')
+    }
+
     return {
       mcpServerUrl: getOfficialMcpServerUrl(input.connectorType),
       scope: getOptionalScope(input.connectorType),
-      staticClientRegistration: getStaticOAuthClientRegistration(input.connectorType, input.connectorConfig),
-      staticClientRegistrationMode: getStaticOAuthClientRegistrationMode(input.connectorType, input.connectorConfig),
+      staticClientRegistration,
+      preferStaticClientRegistration,
       metadataOverrides: {},
       validateMetadataEndpoints: false,
     }
@@ -364,7 +354,7 @@ async function resolveOAuthPreparationContext(input: {
     mcpServerUrl: await validateConnectorUrl(endpoint),
     scope: getString(connectorConfig?.oauthScope),
     staticClientRegistration: getStaticOAuthClientRegistration(input.connectorType, connectorConfig),
-    staticClientRegistrationMode: getStaticOAuthClientRegistrationMode(input.connectorType, connectorConfig),
+    preferStaticClientRegistration: false,
     metadataOverrides: {
       authorizationEndpoint: authorizationEndpoint
         ? await validateConnectorUrl(authorizationEndpoint)
@@ -408,9 +398,9 @@ async function registerOAuthClient(
   redirectUri: string,
   connectorType: OAuthConnectorType,
   staticRegistration: OAuthClientRegistration | null,
-  staticRegistrationMode: 'fallback' | 'preferred',
+  preferStaticClientRegistration: boolean,
 ): Promise<OAuthClientRegistration> {
-  if (staticRegistration && staticRegistrationMode === 'preferred') {
+  if (staticRegistration && preferStaticClientRegistration) {
     return staticRegistration
   }
 
@@ -543,7 +533,7 @@ export async function prepareConnectorOAuthAuthorization(input: {
     input.redirectUri,
     input.connectorType,
     context.staticClientRegistration,
-    context.staticClientRegistrationMode,
+    context.preferStaticClientRegistration,
   )
 
   const codeVerifier = createPkceCodeVerifier()

--- a/apps/web/src/lib/connectors/validators.ts
+++ b/apps/web/src/lib/connectors/validators.ts
@@ -64,7 +64,7 @@ function isValidConfigValue(value: unknown): boolean {
   return true
 }
 
-function validateOptionalNonEmptyString(label: string, value: unknown): string | undefined {
+function getOptionalNonEmptyStringError(label: string, value: unknown): string | undefined {
   if (value === undefined) return undefined
   return typeof value === 'string' && value.trim()
     ? undefined
@@ -81,18 +81,18 @@ export function validateConnectorConfig(
     }
 
     if (type === 'linear' && config.oauthActor === 'app') {
-      const clientIdError = validateOptionalNonEmptyString('Linear OAuth client ID', config.oauthClientId)
+      const clientIdError = getOptionalNonEmptyStringError('Linear OAuth client ID', config.oauthClientId)
       if (clientIdError) {
         return { valid: false, message: clientIdError }
       }
 
-      const clientSecretError = validateOptionalNonEmptyString('Linear OAuth client secret', config.oauthClientSecret)
+      const clientSecretError = getOptionalNonEmptyStringError('Linear OAuth client secret', config.oauthClientSecret)
       if (clientSecretError) {
         return { valid: false, message: clientSecretError }
       }
 
-      if (config.oauthClientSecret !== undefined && !isValidConfigValue(config.oauthClientId)) {
-        return { valid: false, message: 'Linear OAuth client ID is required when client secret is set' }
+      if (!isValidConfigValue(config.oauthClientId) || !isValidConfigValue(config.oauthClientSecret)) {
+        return { valid: false, message: 'Linear app actor OAuth requires both client ID and client secret' }
       }
     }
 

--- a/apps/web/src/lib/connectors/validators.ts
+++ b/apps/web/src/lib/connectors/validators.ts
@@ -19,7 +19,7 @@ export interface ConnectorConfigSchema {
 export type { ConnectorConfigValidationResult } from '@/lib/connectors/config-validation'
 
 export const CONNECTOR_SCHEMAS: Record<ConnectorType, ConnectorConfigSchema> = {
-  linear: { required: ['apiKey'] },
+  linear: { required: ['apiKey'], optional: ['oauthActor', 'oauthClientId', 'oauthClientSecret'] },
   notion: { required: ['apiKey'] },
   zendesk: { required: ['subdomain', 'email', 'apiToken'] },
   custom: {
@@ -64,6 +64,13 @@ function isValidConfigValue(value: unknown): boolean {
   return true
 }
 
+function validateOptionalNonEmptyString(label: string, value: unknown): string | undefined {
+  if (value === undefined) return undefined
+  return typeof value === 'string' && value.trim()
+    ? undefined
+    : `${label} must be a non-empty string`
+}
+
 export function validateConnectorConfig(
   type: ConnectorType,
   config: Record<string, unknown>
@@ -71,6 +78,22 @@ export function validateConnectorConfig(
   if (getConnectorAuthType(config) === 'oauth' && isOAuthConnectorType(type)) {
     if (type === 'linear' && config.oauthActor !== undefined && !isLinearOAuthActor(config.oauthActor)) {
       return { valid: false, message: 'Linear OAuth actor must be user or app' }
+    }
+
+    if (type === 'linear' && config.oauthActor === 'app') {
+      const clientIdError = validateOptionalNonEmptyString('Linear OAuth client ID', config.oauthClientId)
+      if (clientIdError) {
+        return { valid: false, message: clientIdError }
+      }
+
+      const clientSecretError = validateOptionalNonEmptyString('Linear OAuth client secret', config.oauthClientSecret)
+      if (clientSecretError) {
+        return { valid: false, message: clientSecretError }
+      }
+
+      if (config.oauthClientSecret !== undefined && !isValidConfigValue(config.oauthClientId)) {
+        return { valid: false, message: 'Linear OAuth client ID is required when client secret is set' }
+      }
     }
 
     if (type === 'custom') {

--- a/apps/web/tests/connectors-detail-route.test.ts
+++ b/apps/web/tests/connectors-detail-route.test.ts
@@ -100,6 +100,8 @@ describe('GET /api/u/[slug]/connectors/[id]', () => {
         provider: 'linear',
         accessToken: 'linear-token',
         clientId: 'client-1',
+        clientSecret: 'linear-secret',
+        tokenEndpoint: 'https://api.linear.app/oauth/token',
         connectedAt: '2026-04-21T09:59:00.000Z',
       },
     })
@@ -153,6 +155,7 @@ describe('GET /api/u/[slug]/connectors/[id]', () => {
         config: {
           authType: 'oauth',
           oauthActor: 'app',
+          oauthClientId: 'linear-client-id',
           oauth: {
             provider: 'linear',
             connected: true,
@@ -168,10 +171,16 @@ describe('GET /api/u/[slug]/connectors/[id]', () => {
     expect(mockEncryptConfig).toHaveBeenCalledWith({
       authType: 'oauth',
       oauthActor: 'app',
+      oauthClientId: 'linear-client-id',
+      oauthClientSecret: 'linear-client-secret',
       oauth: {
         provider: 'linear',
         connected: true,
+        accessToken: 'linear-token',
+        clientId: 'client-1',
+        clientSecret: 'linear-secret',
         connectedAt: '2026-04-21T09:59:00.000Z',
+        tokenEndpoint: 'https://api.linear.app/oauth/token',
       },
     })
 
@@ -179,19 +188,20 @@ describe('GET /api/u/[slug]/connectors/[id]', () => {
       id: 'linear-app',
       type: 'linear',
       name: 'Linear',
-      config: {
-        authType: 'oauth',
-        oauthActor: 'app',
-        oauth: {
-          provider: 'linear',
-          connected: true,
+        config: {
+          authType: 'oauth',
+          oauthActor: 'app',
+          oauthClientId: 'linear-client-id',
+          oauth: {
+            provider: 'linear',
+            connected: true,
           connectedAt: '2026-04-21T09:59:00.000Z',
         },
       },
       enabled: true,
       authType: 'oauth',
       oauthActor: 'app',
-      oauthConnected: false,
+      oauthConnected: true,
       oauthExpiresAt: undefined,
       createdAt: '2026-04-21T10:00:00.000Z',
       updatedAt: '2026-04-21T10:06:00.000Z',

--- a/apps/web/tests/connectors-detail-route.test.ts
+++ b/apps/web/tests/connectors-detail-route.test.ts
@@ -94,6 +94,8 @@ describe('GET /api/u/[slug]/connectors/[id]', () => {
     mockDecryptConfig.mockReturnValue({
       authType: 'oauth',
       oauthActor: 'app',
+      oauthClientId: 'linear-client-id',
+      oauthClientSecret: 'linear-client-secret',
       oauth: {
         provider: 'linear',
         accessToken: 'linear-token',
@@ -103,7 +105,7 @@ describe('GET /api/u/[slug]/connectors/[id]', () => {
     })
   })
 
-  it('returns Linear OAuth actor mode at the top level and inside config for editing', async () => {
+  it('returns Linear OAuth actor mode and hides stored client secrets from the edit payload', async () => {
     const { GET } = await loadRoute()
     const response = await GET(new Request('http://localhost/api/u/alice/connectors/linear-app') as never, {
       params: Promise.resolve({ slug: 'alice', id: 'linear-app' }),
@@ -116,6 +118,7 @@ describe('GET /api/u/[slug]/connectors/[id]', () => {
     expect(body.config).toEqual({
       authType: 'oauth',
       oauthActor: 'app',
+      oauthClientId: 'linear-client-id',
       oauth: {
         provider: 'linear',
         connected: true,

--- a/apps/web/tests/connectors-oauth-start-route.test.ts
+++ b/apps/web/tests/connectors-oauth-start-route.test.ts
@@ -101,7 +101,12 @@ describe('POST /api/u/[slug]/connectors/[id]/oauth/start', () => {
       type: 'linear',
       config: 'encrypted-config',
     })
-    mockDecryptConfig.mockReturnValue({ authType: 'oauth', oauthActor: 'app' })
+    mockDecryptConfig.mockReturnValue({
+      authType: 'oauth',
+      oauthActor: 'app',
+      oauthClientId: 'linear-client-id',
+      oauthClientSecret: 'linear-client-secret',
+    })
     mockPrepareConnectorOAuthAuthorization.mockResolvedValue({
       authorizeUrl: 'https://linear.app/oauth/authorize?actor=app',
       state: 'state-token',
@@ -133,7 +138,12 @@ describe('POST /api/u/[slug]/connectors/[id]/oauth/start', () => {
       userId: 'user-1',
       connectorType: 'linear',
       redirectUri: 'https://arche.example.com/api/connectors/oauth/callback',
-      connectorConfig: { authType: 'oauth', oauthActor: 'app' },
+      connectorConfig: {
+        authType: 'oauth',
+        oauthActor: 'app',
+        oauthClientId: 'linear-client-id',
+        oauthClientSecret: 'linear-client-secret',
+      },
     })
   })
 })

--- a/apps/web/tests/connectors-oauth-start-route.test.ts
+++ b/apps/web/tests/connectors-oauth-start-route.test.ts
@@ -146,4 +146,24 @@ describe('POST /api/u/[slug]/connectors/[id]/oauth/start', () => {
       },
     })
   })
+
+  it('returns 400 when Linear app actor credentials are missing', async () => {
+    mockDecryptConfig.mockReturnValue({ authType: 'oauth', oauthActor: 'app' })
+    mockPrepareConnectorOAuthAuthorization.mockRejectedValue(new Error('missing_linear_oauth_client_credentials'))
+
+    const { POST } = await loadRoute()
+    const request = {
+      headers: new Headers({ host: 'localhost', origin: 'http://localhost' }),
+      nextUrl: new URL('http://localhost/api/u/alice/connectors/conn-1/oauth/start'),
+    }
+
+    const response = await POST(request as never, {
+      params: Promise.resolve({ slug: 'alice', id: 'conn-1' }),
+    })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'missing_linear_oauth_client_credentials',
+    })
+  })
 })

--- a/apps/web/tests/connectors-oauth.test.ts
+++ b/apps/web/tests/connectors-oauth.test.ts
@@ -16,9 +16,6 @@ vi.mock('@/lib/security/ssrf', () => ({
 }))
 
 const originalOAuthMaxAuthorizeUrlLength = process.env.ARCHE_CONNECTOR_OAUTH_MAX_AUTHORIZE_URL_LENGTH
-const originalLinearClientId = process.env.ARCHE_CONNECTOR_LINEAR_CLIENT_ID
-const originalLinearClientSecret = process.env.ARCHE_CONNECTOR_LINEAR_CLIENT_SECRET
-
 describe('connectors oauth state', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -35,18 +32,6 @@ describe('connectors oauth state', () => {
       delete process.env.ARCHE_CONNECTOR_OAUTH_MAX_AUTHORIZE_URL_LENGTH
     } else {
       process.env.ARCHE_CONNECTOR_OAUTH_MAX_AUTHORIZE_URL_LENGTH = originalOAuthMaxAuthorizeUrlLength
-    }
-
-    if (originalLinearClientId === undefined) {
-      delete process.env.ARCHE_CONNECTOR_LINEAR_CLIENT_ID
-    } else {
-      process.env.ARCHE_CONNECTOR_LINEAR_CLIENT_ID = originalLinearClientId
-    }
-
-    if (originalLinearClientSecret === undefined) {
-      delete process.env.ARCHE_CONNECTOR_LINEAR_CLIENT_SECRET
-    } else {
-      process.env.ARCHE_CONNECTOR_LINEAR_CLIENT_SECRET = originalLinearClientSecret
     }
   })
 
@@ -198,9 +183,6 @@ describe('connectors oauth state', () => {
   })
 
   it('adds actor=app only for Linear app actor OAuth', async () => {
-    process.env.ARCHE_CONNECTOR_LINEAR_CLIENT_ID = 'linear-client-id'
-    process.env.ARCHE_CONNECTOR_LINEAR_CLIENT_SECRET = 'linear-client-secret'
-
     vi.stubGlobal(
       'fetch',
       vi
@@ -209,7 +191,14 @@ describe('connectors oauth state', () => {
           new Response(JSON.stringify({
             authorization_endpoint: 'https://linear.app/oauth/authorize',
             token_endpoint: 'https://api.linear.app/oauth/token',
+            registration_endpoint: 'https://api.linear.app/oauth/register',
           }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ client_id: 'dynamic-user-client' }), {
             status: 200,
             headers: { 'content-type': 'application/json' },
           })
@@ -240,11 +229,43 @@ describe('connectors oauth state', () => {
       userId: 'user-1',
       connectorType: 'linear',
       redirectUri: 'https://arche.example.com/api/connectors/oauth/callback',
-      connectorConfig: { authType: 'oauth', oauthActor: 'app' },
+      connectorConfig: {
+        authType: 'oauth',
+        oauthActor: 'app',
+        oauthClientId: 'linear-app-client-id',
+        oauthClientSecret: 'linear-app-client-secret',
+      },
     })
 
     expect(new URL(userPrepared.authorizeUrl).searchParams.get('actor')).toBeNull()
     expect(new URL(appPrepared.authorizeUrl).searchParams.get('actor')).toBe('app')
+  })
+
+  it('requires Linear app actor client credentials', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({
+          authorization_endpoint: 'https://linear.app/oauth/authorize',
+          token_endpoint: 'https://api.linear.app/oauth/token',
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      )
+    )
+
+    await expect(prepareConnectorOAuthAuthorization({
+      connectorId: 'linear-app',
+      slug: 'alice',
+      userId: 'user-1',
+      connectorType: 'linear',
+      redirectUri: 'https://arche.example.com/api/connectors/oauth/callback',
+      connectorConfig: {
+        authType: 'oauth',
+        oauthActor: 'app',
+      },
+    })).rejects.toThrow('missing_linear_oauth_client_credentials')
   })
 
   it('uses Linear app actor client credentials from connector config before dynamic registration', async () => {

--- a/apps/web/tests/connectors-oauth.test.ts
+++ b/apps/web/tests/connectors-oauth.test.ts
@@ -247,6 +247,43 @@ describe('connectors oauth state', () => {
     expect(new URL(appPrepared.authorizeUrl).searchParams.get('actor')).toBe('app')
   })
 
+  it('uses Linear app actor client credentials from connector config before dynamic registration', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        authorization_endpoint: 'https://linear.app/oauth/authorize',
+        token_endpoint: 'https://api.linear.app/oauth/token',
+        registration_endpoint: 'https://api.linear.app/oauth/register',
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const prepared = await prepareConnectorOAuthAuthorization({
+      connectorId: 'linear-app',
+      slug: 'alice',
+      userId: 'user-1',
+      connectorType: 'linear',
+      redirectUri: 'https://arche.example.com/api/connectors/oauth/callback',
+      connectorConfig: {
+        authType: 'oauth',
+        oauthActor: 'app',
+        oauthClientId: 'connector-client-id',
+        oauthClientSecret: 'connector-client-secret',
+      },
+    })
+
+    const authorizeUrl = new URL(prepared.authorizeUrl)
+    expect(authorizeUrl.searchParams.get('client_id')).toBe('connector-client-id')
+    expect(authorizeUrl.searchParams.get('actor')).toBe('app')
+
+    const state = verifyConnectorOAuthState(prepared.state)
+    expect(state.clientId).toBe('connector-client-id')
+    expect(state.clientSecret).toBe('connector-client-secret')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('falls back to static custom OAuth client when dynamic registration fails', async () => {
     vi.stubGlobal(
       'fetch',

--- a/apps/web/tests/connectors.test.ts
+++ b/apps/web/tests/connectors.test.ts
@@ -89,9 +89,36 @@ describe('connectors/validators', () => {
         valid: true,
       })
 
+      expect(validateConnectorConfig('linear', {
+        authType: 'oauth',
+        oauthActor: 'app',
+        oauthClientId: 'client-123',
+        oauthClientSecret: 'secret-123',
+      })).toEqual({
+        valid: true,
+      })
+
       expect(validateConnectorConfig('linear', { authType: 'oauth', oauthActor: 'robot' })).toEqual({
         valid: false,
         message: 'Linear OAuth actor must be user or app',
+      })
+
+      expect(validateConnectorConfig('linear', {
+        authType: 'oauth',
+        oauthActor: 'app',
+        oauthClientSecret: 'secret-123',
+      })).toEqual({
+        valid: false,
+        message: 'Linear OAuth client ID is required when client secret is set',
+      })
+
+      expect(validateConnectorConfig('linear', {
+        authType: 'oauth',
+        oauthActor: 'app',
+        oauthClientId: '   ',
+      })).toEqual({
+        valid: false,
+        message: 'Linear OAuth client ID must be a non-empty string',
       })
     })
 

--- a/apps/web/tests/connectors.test.ts
+++ b/apps/web/tests/connectors.test.ts
@@ -86,7 +86,8 @@ describe('connectors/validators', () => {
 
     it('validates optional Linear OAuth actor mode', () => {
       expect(validateConnectorConfig('linear', { authType: 'oauth', oauthActor: 'app' })).toEqual({
-        valid: true,
+        valid: false,
+        message: 'Linear app actor OAuth requires both client ID and client secret',
       })
 
       expect(validateConnectorConfig('linear', {
@@ -109,7 +110,16 @@ describe('connectors/validators', () => {
         oauthClientSecret: 'secret-123',
       })).toEqual({
         valid: false,
-        message: 'Linear OAuth client ID is required when client secret is set',
+        message: 'Linear app actor OAuth requires both client ID and client secret',
+      })
+
+      expect(validateConnectorConfig('linear', {
+        authType: 'oauth',
+        oauthActor: 'app',
+        oauthClientId: 'client-123',
+      })).toEqual({
+        valid: false,
+        message: 'Linear app actor OAuth requires both client ID and client secret',
       })
 
       expect(validateConnectorConfig('linear', {


### PR DESCRIPTION
## Summary
- add `client_id` and `client_secret` fields to the Linear app actor connector flow so app actor OAuth can be configured per connector from the add-connector modal
- prefer connector-level or server-level static Linear credentials before dynamic client registration, while still hiding saved secrets from connector edit responses
- cover the new flow with modal, validator, OAuth preparation, route, and documentation updates

## Testing
- `pnpm test`
- `pnpm lint`
- `bash scripts/check-podman-images.sh`