### PR TITLE
fix(web): verify coverage badges in pull requests

### DIFF
--- a/.github/badges/web-coverage.svg
+++ b/.github/badges/web-coverage.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="140" height="20" role="img" aria-label="web coverage: 59.6%">
-  <title>web coverage: 59.6%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="20" role="img" aria-label="web coverage: 59.7%">
+  <title>web coverage: 59.7%</title>
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -18,7 +18,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="47" y="15" fill="#010101" fill-opacity=".3">web coverage</text>
     <text x="47" y="14">web coverage</text>
-    <text x="117" y="15" fill="#010101" fill-opacity=".3">59.6%</text>
-    <text x="117" y="14">59.6%</text>
+    <text x="117" y="15" fill="#010101" fill-opacity=".3">59.7%</text>
+    <text x="117" y="14">59.7%</text>
   </g>
 </svg>

--- a/.github/badges/web-integration-coverage.svg
+++ b/.github/badges/web-integration-coverage.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="161" height="20" role="img" aria-label="web integration: 15.3%">
-  <title>web integration: 15.3%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="161" height="20" role="img" aria-label="web integration: 15.5%">
+  <title>web integration: 15.5%</title>
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -18,7 +18,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="58" y="15" fill="#010101" fill-opacity=".3">web integration</text>
     <text x="58" y="14">web integration</text>
-    <text x="138" y="15" fill="#010101" fill-opacity=".3">15.3%</text>
-    <text x="138" y="14">15.3%</text>
+    <text x="138" y="15" fill="#010101" fill-opacity=".3">15.5%</text>
+    <text x="138" y="14">15.5%</text>
   </g>
 </svg>

--- a/.github/workflows/coverage-badges.yml
+++ b/.github/workflows/coverage-badges.yml
@@ -1,21 +1,20 @@
-name: Coverage Badges
+name: Verify Web Coverage Badges
 
 on:
-  push:
+  pull_request:
     branches: [main]
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: coverage-badges-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  refresh-web-coverage-badges:
-    name: Refresh Web Coverage Badges
+  verify-web-coverage-badges:
+    name: Verify Web Coverage Badges
     if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
 
@@ -43,14 +42,10 @@ jobs:
       - name: Refresh coverage reports and badges
         run: pnpm coverage:refresh
 
-      - name: Create Pull Request for updated badges
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'chore(web): refresh coverage badges'
-          branch: chore/refresh-coverage-badges
-          delete-branch: true
-          add-paths: .github/badges
-          title: 'chore(web): refresh coverage badges'
-          body: |
-            Automated refresh of coverage badges.
+      - name: Verify coverage badges are up to date
+        working-directory: .
+        run: |
+          if ! git diff --quiet -- .github/badges; then
+            echo "::error::Coverage badges are stale. Run 'cd apps/web && pnpm coverage:refresh' and commit the updated badges."
+            exit 1
+          fi

--- a/.github/workflows/coverage-badges.yml
+++ b/.github/workflows/coverage-badges.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: coverage-badges-${{ github.ref }}
@@ -42,19 +43,14 @@ jobs:
       - name: Refresh coverage reports and badges
         run: pnpm coverage:refresh
 
-      - name: Commit updated badges
-        working-directory: .
-        env:
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-        run: |
-          if git diff --quiet -- .github/badges; then
-            exit 0
-          fi
-
-          git add .github/badges
-          git commit -m "chore(web): refresh coverage badges [skip ci]"
-          git pull --rebase origin main
-          git push
+      - name: Create Pull Request for updated badges
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore(web): refresh coverage badges'
+          branch: chore/refresh-coverage-badges
+          delete-branch: true
+          add-paths: .github/badges
+          title: 'chore(web): refresh coverage badges'
+          body: |
+            Automated refresh of coverage badges.


### PR DESCRIPTION
## Summary
- change the coverage badge workflow into a `pull_request` check instead of running after pushes to `main`
- regenerate coverage badges in CI and fail if `.github/badges` is stale
- avoid automated commits or PRs, so badge updates are included in the same contributor PR

## Testing
- `ruby -ryaml -e \"YAML.load_file('.github/workflows/coverage-badges.yml')\"`