### PR TITLE
fix(infra): add bounded container autostart

### DIFF
--- a/apps/web/src/lib/spawner/__tests__/docker.test.ts
+++ b/apps/web/src/lib/spawner/__tests__/docker.test.ts
@@ -148,7 +148,7 @@ describe('docker', () => {
         ]),
         HostConfig: {
           NetworkMode: 'test-network',
-          RestartPolicy: { Name: 'unless-stopped' },
+          RestartPolicy: { Name: 'on-failure', MaximumRetryCount: 5 },
           Binds: [
             'arche-workspace-user-slug:/workspace',
             'arche-opencode-share-user-slug:/home/workspace/.local/share/opencode',

--- a/apps/web/src/lib/spawner/docker.ts
+++ b/apps/web/src/lib/spawner/docker.ts
@@ -159,7 +159,7 @@ export async function createContainer(
     Env: env,
     HostConfig: {
       NetworkMode: getOpencodeNetwork(),
-      RestartPolicy: { Name: "unless-stopped" },
+      RestartPolicy: { Name: "on-failure", MaximumRetryCount: 5 },
       Binds: binds,
     },
     Labels: {

--- a/infra/deploy/README.md
+++ b/infra/deploy/README.md
@@ -215,6 +215,9 @@ cd /opt/arche && podman compose logs -f
 # Restart
 podman compose restart
 
+# Check reboot autostart (bounded to 5 service retries)
+systemctl status arche-autostart.service
+
 # Re-deploy (from local machine)
 ./deploy.sh --ip <IP> --domain <DOMAIN> --ssh-key <KEY> --acme-email <EMAIL> [--skip-ensure-dns-record]
 ```

--- a/infra/deploy/README.md
+++ b/infra/deploy/README.md
@@ -217,6 +217,11 @@ podman compose restart
 
 # Check reboot autostart (bounded to 5 service retries)
 systemctl status arche-autostart.service
+journalctl -u arche-autostart.service -n 100 --no-pager
+
+# Check current web and workspace containers
+podman ps -a --filter label=arche.role=web
+podman ps -a --filter label=arche.managed=true
 
 # Re-deploy (from local machine)
 ./deploy.sh --ip <IP> --domain <DOMAIN> --ssh-key <KEY> --acme-email <EMAIL> [--skip-ensure-dns-record]
@@ -229,5 +234,7 @@ systemctl status arche-autostart.service
 **ACME certificate not issued**: Check Traefik logs (`podman compose logs traefik`). Verify domain A/AAAA records point to the VPS and ports `80/443` are reachable.
 
 **Web service unhealthy**: Check web logs (`podman compose logs web`). Ensure `DATABASE_URL` is correct and Postgres is running.
+
+**Container stays stopped after repeated failures**: Arche containers use `on-failure:5`. After five crash restarts, Podman stops retrying until manual intervention or the next reboot autostart. Check `podman ps -a`, `journalctl -u arche-autostart.service`, and the container logs before starting it again.
 
 **Migrations fail**: Ensure the container image includes the `prisma/` directory. The Containerfile should have `COPY --from=build /app/prisma ./prisma`.

--- a/infra/deploy/ansible/roles/app/tasks/main.yml
+++ b/infra/deploy/ansible/roles/app/tasks/main.yml
@@ -149,6 +149,31 @@
     mode: "0600"
   no_log: true
 
+- name: Install Arche autostart script
+  ansible.builtin.template:
+    src: arche-autostart.sh.j2
+    dest: /usr/local/bin/arche-autostart
+    owner: root
+    group: root
+    mode: "0755"
+  when: deploy_mode == 'remote'
+
+- name: Install Arche autostart service
+  ansible.builtin.template:
+    src: arche-autostart.service.j2
+    dest: /etc/systemd/system/arche-autostart.service
+    owner: root
+    group: root
+    mode: "0644"
+  when: deploy_mode == 'remote'
+
+- name: Enable Arche autostart service
+  ansible.builtin.systemd:
+    name: arche-autostart.service
+    enabled: true
+    daemon_reload: true
+  when: deploy_mode == 'remote'
+
 - name: Ensure arche-internal network exists
   ansible.builtin.command:
     cmd: podman network create arche-internal
@@ -327,7 +352,7 @@
       --label traefik.docker.network={{ compose_default_network }} \
       --label arche.role=web \
       --label arche.version={{ web_version }} \
-      --restart unless-stopped \
+      --restart on-failure:5 \
       {{ web_image }}
   changed_when: true
   no_log: true

--- a/infra/deploy/ansible/roles/app/templates/arche-autostart.service.j2
+++ b/infra/deploy/ansible/roles/app/templates/arche-autostart.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=Start Arche containers after boot
-Wants=network-online.target podman.socket
-After=network-online.target podman.socket
+Wants=network-online.target
+After=network-online.target
 StartLimitIntervalSec=10min
 StartLimitBurst=5
 

--- a/infra/deploy/ansible/roles/app/templates/arche-autostart.service.j2
+++ b/infra/deploy/ansible/roles/app/templates/arche-autostart.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=Start Arche containers after boot
+Wants=network-online.target podman.socket
+After=network-online.target podman.socket
+StartLimitIntervalSec=10min
+StartLimitBurst=5
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/arche-autostart
+Restart=on-failure
+RestartSec=20s
+TimeoutStartSec=180s
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/deploy/ansible/roles/app/templates/arche-autostart.sh.j2
+++ b/infra/deploy/ansible/roles/app/templates/arche-autostart.sh.j2
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="{{ app_dir }}"
+COMPOSE_FILE="$APP_DIR/compose.yml"
+ENV_FILE="$APP_DIR/.env"
+PROJECT="arche"
+
+compose() {
+  if podman compose version >/dev/null 2>&1; then
+    podman compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" -p "$PROJECT" "$@"
+    return
+  fi
+
+  podman-compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" -p "$PROJECT" "$@"
+}
+
+start_container_if_needed() {
+  local container_id="$1"
+
+  if [ -z "$container_id" ]; then
+    return 0
+  fi
+
+  if [ -n "$(podman ps -q --filter id="$container_id")" ]; then
+    return 0
+  fi
+
+  podman start "$container_id"
+}
+
+current_web_container_ids() {
+  local current_version=""
+
+  if [ -s "$APP_DIR/.current-version" ]; then
+    current_version="$(tr -d '[:space:]' < "$APP_DIR/.current-version")"
+  fi
+
+  if [ -n "$current_version" ]; then
+    podman ps -a -q --filter label=arche.role=web --filter label="arche.version=$current_version"
+    return
+  fi
+
+  podman ps -a -q --filter label=arche.role=web
+}
+
+compose up -d postgres traefik docker-socket-proxy{% if deploy_mode == 'remote' %} reaper{% endif %}
+
+# Web and workspace containers are managed outside compose.
+while IFS= read -r container_id; do
+  start_container_if_needed "$container_id"
+done < <(
+  {
+    current_web_container_ids
+    podman ps -a -q --filter label=arche.managed=true
+  } | sort -u
+)

--- a/infra/deploy/ansible/roles/app/templates/arche-autostart.sh.j2
+++ b/infra/deploy/ansible/roles/app/templates/arche-autostart.sh.j2
@@ -5,6 +5,27 @@ APP_DIR="{{ app_dir }}"
 COMPOSE_FILE="$APP_DIR/compose.yml"
 ENV_FILE="$APP_DIR/.env"
 PROJECT="arche"
+PODMAN_READY_ATTEMPTS=6
+PODMAN_READY_DELAY_SECONDS=5
+
+wait_for_podman() {
+  local attempt=1
+
+  while [ "$attempt" -le "$PODMAN_READY_ATTEMPTS" ]; do
+    if podman info >/dev/null 2>&1; then
+      return 0
+    fi
+
+    if [ "$attempt" -lt "$PODMAN_READY_ATTEMPTS" ]; then
+      sleep "$PODMAN_READY_DELAY_SECONDS"
+    fi
+
+    attempt=$((attempt + 1))
+  done
+
+  printf 'podman is not ready after %s attempts\n' "$PODMAN_READY_ATTEMPTS" >&2
+  return 1
+}
 
 compose() {
   if podman compose version >/dev/null 2>&1; then
@@ -36,22 +57,27 @@ current_web_container_ids() {
     current_version="$(tr -d '[:space:]' < "$APP_DIR/.current-version")"
   fi
 
-  if [ -n "$current_version" ]; then
-    podman ps -a -q --filter label=arche.role=web --filter label="arche.version=$current_version"
-    return
+  if [ -z "$current_version" ]; then
+    printf 'missing or empty %s/.current-version; refusing to autostart unknown web containers\n' "$APP_DIR" >&2
+    return 1
   fi
 
-  podman ps -a -q --filter label=arche.role=web
+  podman ps -a -q --filter label=arche.role=web --filter label="arche.version=$current_version"
 }
+
+wait_for_podman
 
 compose up -d postgres traefik docker-socket-proxy{% if deploy_mode == 'remote' %} reaper{% endif %}
 
 # Web and workspace containers are managed outside compose.
+web_container_ids="$(current_web_container_ids)"
+workspace_container_ids="$(podman ps -a -q --filter label=arche.managed=true)"
+
 while IFS= read -r container_id; do
   start_container_if_needed "$container_id"
 done < <(
   {
-    current_web_container_ids
-    podman ps -a -q --filter label=arche.managed=true
+    printf '%s\n' "$web_container_ids"
+    printf '%s\n' "$workspace_container_ids"
   } | sort -u
 )

--- a/infra/deploy/ansible/roles/app/templates/compose.yml.j2
+++ b/infra/deploy/ansible/roles/app/templates/compose.yml.j2
@@ -7,7 +7,7 @@ name: arche
 services:
   traefik:
     image: docker.io/traefik:v3.6.7
-    restart: unless-stopped
+    restart: "on-failure:5"
     command:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
@@ -51,7 +51,7 @@ services:
   
   docker-socket-proxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:latest
-    restart: unless-stopped
+    restart: "on-failure:5"
 {% if deploy_mode == 'local-dev' %}
     user: root
     security_opt:
@@ -76,7 +76,7 @@ services:
 
   postgres:
     image: docker.io/postgres:16
-    restart: unless-stopped
+    restart: "on-failure:5"
     environment:
       POSTGRES_DB: arche
       POSTGRES_USER: postgres
@@ -117,7 +117,7 @@ services:
 {% if deploy_mode == 'remote' %}
   reaper:
     image: {{ web_image }}
-    restart: unless-stopped
+    restart: "on-failure:5"
     command:
       - pnpm
       - run
@@ -142,7 +142,7 @@ services:
   web:
     image: node:24-bookworm-slim
     working_dir: /app
-    restart: unless-stopped
+    restart: "on-failure:5"
     env_file:
       - {{ env_file_name | default('.env') }}
     ports:

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -226,7 +226,7 @@ if [[ -n "$ROLLBACK_VERSION" ]]; then
     --network "$COMPOSE_NETWORK" \
     "${VOLUME_ARGS[@]}" \
     "${TRAEFIK_LABELS[@]}" \
-    --restart unless-stopped \
+    --restart on-failure:5 \
     "${IMAGE_PREFIX}web:${ROLLBACK_VERSION}"
 
   # Wait for health check


### PR DESCRIPTION
## Summary
- Add a remote systemd autostart service that starts compose services plus current blue-green web and managed workspace containers after reboot.
- Switch deploy, rollback, compose, and workspace container policies from `unless-stopped` to bounded `on-failure:5` retries.
- Document the autostart service status check.

## Tests
- `pnpm test` before changes
- `pnpm test src/lib/spawner/__tests__/docker.test.ts`
- `ANSIBLE_CONFIG="infra/deploy/ansible.cfg" ansible-playbook --syntax-check -i "arche," "infra/deploy/ansible/playbooks/site.yml"`
- Rendered autostart templates locally and ran `bash -n` on the rendered script
- `pnpm test`
- `pnpm lint` (0 errors, existing warnings only)
- `git diff --check`
- `bash scripts/check-podman-images.sh`