### PR TITLE
fix(workspace): keep agent sessions running after tab close

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -217,7 +217,7 @@ The spawner can connect to the container runtime in two ways:
 | `OPENCODE_NETWORK` | Internal container network | `arche-internal` |
 | `ARCHE_ENCRYPTION_KEY` | AES-256 key (base64, 32 bytes) | See `.env.example` |
 | `ARCHE_START_TIMEOUT_MS` | Startup timeout | `120000` |
-| `ARCHE_IDLE_TIMEOUT_MINUTES` | Idle time before stop | `30` |
+| `ARCHE_IDLE_TIMEOUT_MINUTES` | Idle time before stop | `120` |
 | `KB_CONTENT_HOST_PATH` | Path to KB content bare repo | `~/.arche/kb-content` |
 | `KB_CONFIG_HOST_PATH` | Path to config bare repo | `~/.arche/kb-config` |
 

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -296,6 +296,7 @@ export const POST = withAuth(
       let aborted = false
       let promptSent = Boolean(resume)
       let promptAcknowledged = Boolean(resume)
+      const upstreamEventsController = new AbortController()
 
       // Shared reference so the abort path and finally block can always
       // clean up the active reader when it exists.
@@ -304,16 +305,16 @@ export const POST = withAuth(
       const handleAbort = () => {
         clientGone = true
         aborted = true
+        upstreamEventsController.abort()
         void eventReader?.cancel().catch(() => undefined)
         try { controller.close() } catch { /* already closed/errored */ }
       }
 
       if (request.signal.aborted) {
         handleAbort()
-        return
+      } else {
+        request.signal.addEventListener('abort', handleAbort, { once: true })
       }
-
-      request.signal.addEventListener('abort', handleAbort, { once: true })
 
       const sendEvent = (event: string, data: unknown) => {
         if (clientGone) return
@@ -335,28 +336,41 @@ export const POST = withAuth(
           // Subscribe first so we don't miss fast session events.
           const eventsUrl = `${baseUrl}/event`
 
-        const eventsResponse = await fetch(eventsUrl, {
-          method: 'GET',
-          headers: {
-            'Authorization': authHeader,
-            'Accept': 'text/event-stream',
-            'Cache-Control': 'no-cache'
-          },
-          signal: request.signal,
-        })
+        let reader: ReadableStreamDefaultReader<Uint8Array> | null = null
+        if (!clientGone) {
+          try {
+            const eventsResponse = await fetch(eventsUrl, {
+              method: 'GET',
+              headers: {
+                'Authorization': authHeader,
+                'Accept': 'text/event-stream',
+                'Cache-Control': 'no-cache'
+              },
+              signal: upstreamEventsController.signal,
+            })
 
-        if (!eventsResponse.ok || !eventsResponse.body) {
-          sendEvent('error', { error: 'Failed to connect to event stream' })
-          return
+            if (!eventsResponse.ok || !eventsResponse.body) {
+              sendEvent('error', { error: 'Failed to connect to event stream' })
+              return
+            }
+
+            reader = eventsResponse.body.getReader()
+            eventReader = reader
+          } catch (error) {
+            if (!clientGone && !isAbortError(error)) {
+              sendEvent('error', {
+                error: error instanceof Error ? error.message : 'Unknown error'
+              })
+              return
+            }
+          }
         }
 
-        const reader = eventsResponse.body.getReader()
-        eventReader = reader
         const decoder = new TextDecoder()
         let parseState = INITIAL_SSE_PARSE_STATE
 
         const cancelReader = async () => {
-          await reader.cancel().catch(() => undefined)
+          await reader?.cancel().catch(() => undefined)
         }
 
         if (!resume) {
@@ -535,7 +549,6 @@ export const POST = withAuth(
               'Authorization': authHeader
             },
             body: JSON.stringify(promptBody),
-            signal: request.signal,
           })
 
           if (!promptResponse.ok) {
@@ -549,6 +562,10 @@ export const POST = withAuth(
         }
 
         sendEvent('status', { status: 'thinking' })
+
+        if (!reader || clientGone || aborted) {
+          return
+        }
 
         // Track state for the assistant response
         let currentStatus: string | null = null
@@ -983,6 +1000,7 @@ export const POST = withAuth(
         }
       } finally {
         request.signal.removeEventListener('abort', handleAbort)
+        upstreamEventsController.abort()
         if (eventReader) {
           await eventReader.cancel().catch(() => undefined)
         }

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -49,6 +49,7 @@ const MAX_CONTEXT_REFERENCES_PER_MESSAGE = 20
 const STREAM_RELEVANT_EVENT_TICK_MS = 1000
 const SEND_STREAM_RELEVANT_EVENT_TIMEOUT_MS = 20_000
 const RESUME_STREAM_RELEVANT_EVENT_TIMEOUT_MS = 12_000
+const PROMPT_START_TIMEOUT_MS = 60_000
 
 function jsonErrorResponse(status: number, error: string) {
   return NextResponse.json({ error }, { status })
@@ -56,6 +57,10 @@ function jsonErrorResponse(status: number, error: string) {
 
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError'
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'TimeoutError'
 }
 
 function normalizeContextPaths(value: unknown): string[] {
@@ -542,14 +547,26 @@ export const POST = withAuth(
 
           const promptUrl = `${baseUrl}/session/${sessionId}/prompt_async`
 
-          const promptResponse = await fetch(promptUrl, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': authHeader
-            },
-            body: JSON.stringify(promptBody),
-          })
+          const promptStartSignal = AbortSignal.timeout(PROMPT_START_TIMEOUT_MS)
+          let promptResponse: Response
+          try {
+            promptResponse = await fetch(promptUrl, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': authHeader
+              },
+              body: JSON.stringify(promptBody),
+              signal: promptStartSignal,
+            })
+          } catch (error) {
+            if (isTimeoutError(error) || (promptStartSignal.aborted && isAbortError(error))) {
+              sendEvent('error', { error: 'prompt_start_timeout' })
+              await cancelReader()
+              return
+            }
+            throw error
+          }
 
           if (!promptResponse.ok) {
             const errorText = await promptResponse.text()

--- a/apps/web/src/lib/spawner/__tests__/config.test.ts
+++ b/apps/web/src/lib/spawner/__tests__/config.test.ts
@@ -179,12 +179,12 @@ describe('config', () => {
   })
 
   describe('getIdleTimeoutMinutes', () => {
-    it('returns default 30 when not set', async () => {
+    it('returns default 120 when not set', async () => {
       delete process.env.ARCHE_IDLE_TIMEOUT_MINUTES
 
       const { getIdleTimeoutMinutes } = await import('../config')
 
-      expect(getIdleTimeoutMinutes()).toBe(30)
+      expect(getIdleTimeoutMinutes()).toBe(120)
     })
 
     it('parses custom value from env', async () => {

--- a/apps/web/src/lib/spawner/config.ts
+++ b/apps/web/src/lib/spawner/config.ts
@@ -47,7 +47,7 @@ export function getStartTimeoutMs(): number {
 export function getIdleTimeoutMinutes(): number {
   const raw = process.env.ARCHE_IDLE_TIMEOUT_MINUTES
   const parsed = raw ? Number(raw) : NaN
-  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 30
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 120
 }
 
 export function getKbContentHostPath(): string {
@@ -57,5 +57,4 @@ export function getKbContentHostPath(): string {
   }
   return value
 }
-
 

--- a/apps/web/tests/chat-stream-route.test.ts
+++ b/apps/web/tests/chat-stream-route.test.ts
@@ -260,7 +260,8 @@ describe('POST /api/w/[slug]/chat/stream', () => {
 
     expect(eventSignal).toBeInstanceOf(AbortSignal)
     expect(eventSignal).not.toBe(abortController.signal)
-    expect(promptSignal).toBeUndefined()
+    expect(promptSignal).toBeInstanceOf(AbortSignal)
+    expect(promptSignal).not.toBe(abortController.signal)
   })
 
   it('keeps the prompt request running when the client disconnects during startup', async () => {
@@ -330,7 +331,9 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     abortController.abort()
 
     expect(upstreamAborted).toBe(true)
-    expect(promptSignal).toBeUndefined()
+    expect(promptSignal).toBeInstanceOf(AbortSignal)
+    expect(promptSignal).not.toBe(abortController.signal)
+    expect(promptSignal?.aborted).toBe(false)
 
     const resolvePrompt = promptResolve
     if (!resolvePrompt) {
@@ -338,14 +341,67 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     }
     resolvePrompt(new Response('', { status: 200 }))
 
-    const result = await Promise.race([
-      responseTextPromise.then(() => 'closed'),
-      new Promise<string>((resolve) => {
-        setTimeout(() => resolve('timeout'), 100)
-      }),
-    ])
+    await responseTextPromise
+  })
 
-    expect(result).toBe('closed')
+  it('fails prompt startup when the detached prompt request times out', async () => {
+    const timeoutController = new AbortController()
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, 'timeout')
+      .mockReturnValue(timeoutController.signal)
+
+    try {
+      const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+
+        if (url.endsWith('/event')) {
+          return new Response(
+            new ReadableStream<Uint8Array>(),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'text/event-stream' },
+            },
+          )
+        }
+
+        if (url.includes('/prompt_async')) {
+          return new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener(
+              'abort',
+              () => reject(new DOMException('Timed out', 'AbortError')),
+              { once: true },
+            )
+          })
+        }
+
+        throw new Error(`Unexpected fetch url: ${url}`)
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const { POST } = await loadRoute()
+      const response = await POST(
+        createRequest(
+          'alice',
+          JSON.stringify({ sessionId: 'session-1', text: 'Hello' }),
+        ) as never,
+        {
+          params: Promise.resolve({ slug: 'alice' }),
+        },
+      )
+
+      expect(response.status).toBe(200)
+
+      const responseTextPromise = response.text()
+      await vi.waitFor(() => {
+        expect(timeoutSpy).toHaveBeenCalledWith(60_000)
+      })
+
+      timeoutController.abort()
+
+      await expect(responseTextPromise).resolves.toContain('prompt_start_timeout')
+    } finally {
+      timeoutSpy.mockRestore()
+    }
   })
 
   it('aborts the upstream event stream and closes the SSE response when the client disconnects', async () => {

--- a/apps/web/tests/chat-stream-route.test.ts
+++ b/apps/web/tests/chat-stream-route.test.ts
@@ -223,7 +223,7 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     await expect(response.json()).resolves.toEqual({ error: 'instance_unavailable' })
   })
 
-  it('passes the client abort signal to upstream event and prompt requests', async () => {
+  it('does not pass the client abort signal to upstream OpenCode requests', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
 
@@ -259,14 +259,93 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     const promptSignal = fetchMock.mock.calls[1]?.[1]?.signal
 
     expect(eventSignal).toBeInstanceOf(AbortSignal)
-    expect(promptSignal).toBeInstanceOf(AbortSignal)
-    expect(eventSignal?.aborted).toBe(false)
-    expect(promptSignal?.aborted).toBe(false)
+    expect(eventSignal).not.toBe(abortController.signal)
+    expect(promptSignal).toBeUndefined()
+  })
+
+  it('keeps the prompt request running when the client disconnects during startup', async () => {
+    let upstreamAborted = false
+    let promptResolve: ((response: Response) => void) | null = null
+    let promptSignal: AbortSignal | null | undefined
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.endsWith('/event')) {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              init?.signal?.addEventListener(
+                'abort',
+                () => {
+                  upstreamAborted = true
+                  try {
+                    controller.close()
+                  } catch {
+                    // The route may already have closed the mock upstream stream.
+                  }
+                },
+                { once: true },
+              )
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+          },
+        )
+      }
+
+      if (url.includes('/prompt_async')) {
+        promptSignal = init?.signal
+        return new Promise<Response>((resolve) => {
+          promptResolve = resolve
+        })
+      }
+
+      throw new Error(`Unexpected fetch url: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const abortController = new AbortController()
+    const { POST } = await loadRoute()
+    const response = await POST(
+      createRequest(
+        'alice',
+        JSON.stringify({ sessionId: 'session-1', text: 'Hello' }),
+        { signal: abortController.signal },
+      ) as never,
+      {
+        params: Promise.resolve({ slug: 'alice' }),
+      },
+    )
+
+    expect(response.status).toBe(200)
+
+    const responseTextPromise = response.text()
+    await vi.waitFor(() => {
+      expect(promptResolve).toBeTypeOf('function')
+    })
 
     abortController.abort()
 
-    expect(eventSignal?.aborted).toBe(true)
-    expect(promptSignal?.aborted).toBe(true)
+    expect(upstreamAborted).toBe(true)
+    expect(promptSignal).toBeUndefined()
+
+    const resolvePrompt = promptResolve
+    if (!resolvePrompt) {
+      throw new Error('Prompt request was not started')
+    }
+    resolvePrompt(new Response('', { status: 200 }))
+
+    const result = await Promise.race([
+      responseTextPromise.then(() => 'closed'),
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve('timeout'), 100)
+      }),
+    ])
+
+    expect(result).toBe('closed')
   })
 
   it('aborts the upstream event stream and closes the SSE response when the client disconnects', async () => {


### PR DESCRIPTION
## Summary
- Detaches chat execution from the browser request signal so closing a tab only closes the SSE subscription.
- Keeps explicit cancel behavior unchanged while allowing prompt startup to continue after disconnects.
- Raises the default idle reaper timeout to 120 minutes and updates docs/tests.

## Verification
- pnpm test
- pnpm coverage: 95.02% statements/lines, 95.03% functions
- pnpm lint
- bash scripts/check-podman-images.sh