### PR TITLE
fix(ui): polish dialog scrollbars, focus ring, and form alignments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ archectl_*
 # Infrastructure secrets (never commit .env or .env.local*)
 infra/**/.env
 infra/**/.env.local*
+
+# Claude AI local config
+.claude/

--- a/apps/web/src/components/agents/agents-page.tsx
+++ b/apps/web/src/components/agents/agents-page.tsx
@@ -118,42 +118,44 @@ export function AgentsPageClient({
       ) : null}
 
       {!isLoading && !loadError ? (
-        <div className="rounded-xl border border-border/60 bg-card/40 p-4">
-          <div className="flex flex-col gap-3 md:flex-row md:items-end">
-            <div className="min-w-0 flex-1 space-y-2">
-              <Label htmlFor="workspace-default-model">Default model</Label>
-              {isAdmin ? (
-                <>
-                  <Input
-                    id="workspace-default-model"
-                    list="workspace-default-model-options"
-                    value={defaultModelInput}
-                    onChange={(event) => setDefaultModelInput(event.target.value)}
-                    placeholder="Select or type a model"
-                  />
-                  <datalist id="workspace-default-model-options">
-                    {modelOptions.map((option) => (
-                      <option key={option.id} value={option.id}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </datalist>
-                </>
-              ) : (
-                <p className="text-sm text-muted-foreground">{defaultModel ?? 'No default model configured.'}</p>
-              )}
-              <p className="text-xs text-muted-foreground">
-                Agents without an override inherit this workspace model.
-              </p>
-            </div>
-            {isAdmin ? (
-              <Button type="button" onClick={handleSaveDefaultModel} disabled={isSavingDefaultModel}>
-                {isSavingDefaultModel ? 'Saving...' : 'Save default model'}
-              </Button>
-            ) : null}
-          </div>
-          {defaultModelMessage ? <p className="mt-3 text-sm text-muted-foreground">{defaultModelMessage}</p> : null}
-          {defaultModelError ? <p className="mt-3 text-sm text-destructive">Error: {defaultModelError}</p> : null}
+        <div className="space-y-2 rounded-xl border border-border/60 bg-card/60 p-4">
+          <Label htmlFor="workspace-default-model">Default model</Label>
+          {isAdmin ? (
+            <>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <Input
+                  id="workspace-default-model"
+                  list="workspace-default-model-options"
+                  value={defaultModelInput}
+                  onChange={(event) => setDefaultModelInput(event.target.value)}
+                  placeholder="Select or type a model"
+                  className="sm:flex-1"
+                />
+                <Button
+                  type="button"
+                  onClick={handleSaveDefaultModel}
+                  disabled={isSavingDefaultModel}
+                  className="sm:shrink-0"
+                >
+                  {isSavingDefaultModel ? 'Saving...' : 'Save default model'}
+                </Button>
+              </div>
+              <datalist id="workspace-default-model-options">
+                {modelOptions.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </datalist>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">{defaultModel ?? 'No default model configured.'}</p>
+          )}
+          <p className="text-xs text-muted-foreground">
+            Agents without an override inherit this workspace model.
+          </p>
+          {defaultModelMessage ? <p className="text-sm text-muted-foreground">{defaultModelMessage}</p> : null}
+          {defaultModelError ? <p className="text-sm text-destructive">Error: {defaultModelError}</p> : null}
         </div>
       ) : null}
 

--- a/apps/web/src/components/connectors/connector-card.tsx
+++ b/apps/web/src/components/connectors/connector-card.tsx
@@ -223,7 +223,7 @@ export function ConnectorCard({
     <Card className="border-border/60 bg-card/70 transition-colors hover:border-border">
       <ConnectorCardHeader connector={connector} isBusy={isBusy} onToggleEnabled={onToggleEnabled} />
 
-      <CardContent className="space-y-3 pt-0">
+      <CardContent className="space-y-3 pb-4 pt-0">
         <ConnectorTestResult testState={testState} />
         <div ref={popoverRef}>
           <ConnectorActions

--- a/apps/web/src/components/connectors/connector-tool-permissions-dialog.tsx
+++ b/apps/web/src/components/connectors/connector-tool-permissions-dialog.tsx
@@ -26,7 +26,7 @@ export function ConnectorToolPermissionsDialog({
 }: ConnectorToolPermissionsDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+      <DialogContent className="scrollbar-custom max-h-[90vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Connector settings</DialogTitle>
           <DialogDescription>

--- a/apps/web/src/components/connectors/meta-ads-connector-settings-dialog.tsx
+++ b/apps/web/src/components/connectors/meta-ads-connector-settings-dialog.tsx
@@ -231,7 +231,7 @@ export function MetaAdsConnectorSettingsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+      <DialogContent className="scrollbar-custom max-h-[90vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Meta Ads settings</DialogTitle>
           <DialogDescription>

--- a/apps/web/src/components/connectors/zendesk-connector-settings-dialog.tsx
+++ b/apps/web/src/components/connectors/zendesk-connector-settings-dialog.tsx
@@ -172,7 +172,7 @@ export function ZendeskConnectorSettingsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+      <DialogContent className="scrollbar-custom max-h-[90vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Zendesk settings</DialogTitle>
           <DialogDescription>

--- a/apps/web/src/components/desktop/desktop-settings-dialog.tsx
+++ b/apps/web/src/components/desktop/desktop-settings-dialog.tsx
@@ -138,7 +138,7 @@ export function DesktopSettingsDialog({ slug, currentSection }: DesktopSettingsD
               </nav>
             </aside>
 
-            <div className="min-h-0 overflow-y-auto p-6">{renderSection(currentSection)}</div>
+            <div className="scrollbar-custom min-h-0 overflow-y-auto p-6">{renderSection(currentSection)}</div>
           </div>
         </div>
       </DialogContent>

--- a/apps/web/src/components/settings/agents-settings-panel.tsx
+++ b/apps/web/src/components/settings/agents-settings-panel.tsx
@@ -154,34 +154,38 @@ export function AgentsSettingsPanel({ slug }: AgentsSettingsPanelProps) {
 
       {!isLoading && !loadError ? (
         <>
-          <div className="rounded-xl border border-border/60 bg-card/40 p-5">
-            <div className="flex flex-col gap-3 md:flex-row md:items-end">
-              <div className="min-w-0 flex-1 space-y-2">
-                <Label htmlFor="desktop-workspace-default-model">Default model</Label>
-                <Input
-                  id="desktop-workspace-default-model"
-                  list="desktop-workspace-default-model-options"
-                  value={defaultModelInput}
-                  onChange={(event) => setDefaultModelInput(event.target.value)}
-                  placeholder="Select or type a model"
-                />
-                <datalist id="desktop-workspace-default-model-options">
-                  {modelOptions.map((option) => (
-                    <option key={option.id} value={option.id}>
-                      {option.label}
-                    </option>
-                  ))}
-                </datalist>
-                <p className="text-xs text-muted-foreground">
-                  Agents without an override inherit this workspace model.
-                </p>
-              </div>
-              <Button type="button" onClick={handleSaveDefaultModel} disabled={isSavingDefaultModel}>
+          <div className="space-y-2 rounded-xl border border-border/60 bg-card/60 p-5">
+            <Label htmlFor="desktop-workspace-default-model">Default model</Label>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <Input
+                id="desktop-workspace-default-model"
+                list="desktop-workspace-default-model-options"
+                value={defaultModelInput}
+                onChange={(event) => setDefaultModelInput(event.target.value)}
+                placeholder="Select or type a model"
+                className="sm:flex-1"
+              />
+              <Button
+                type="button"
+                onClick={handleSaveDefaultModel}
+                disabled={isSavingDefaultModel}
+                className="sm:shrink-0"
+              >
                 {isSavingDefaultModel ? 'Saving...' : 'Save default model'}
               </Button>
             </div>
-            {defaultModelMessage ? <p className="mt-3 text-sm text-muted-foreground">{defaultModelMessage}</p> : null}
-            {defaultModelError ? <p className="mt-3 text-sm text-destructive">Error: {defaultModelError}</p> : null}
+            <datalist id="desktop-workspace-default-model-options">
+              {modelOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+            </datalist>
+            <p className="text-xs text-muted-foreground">
+              Agents without an override inherit this workspace model.
+            </p>
+            {defaultModelMessage ? <p className="text-sm text-muted-foreground">{defaultModelMessage}</p> : null}
+            {defaultModelError ? <p className="text-sm text-destructive">Error: {defaultModelError}</p> : null}
           </div>
 
           <div className="space-y-4 rounded-xl border border-border/60 bg-card/40 p-5">

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -49,7 +49,7 @@ const DialogContent = React.forwardRef<
       >
       {children}
       {showCloseButton ? (
-        <DialogPrimitive.Close className="absolute right-5 top-5 rounded-full p-1 text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <DialogPrimitive.Close className="absolute right-5 top-5 rounded-full p-1 text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none">
           <X className="h-4 w-4" />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>

--- a/apps/web/src/components/workspace/conflict-resolver-dialog.tsx
+++ b/apps/web/src/components/workspace/conflict-resolver-dialog.tsx
@@ -175,7 +175,7 @@ export function ConflictResolverDialog({
                   <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
                     Local version
                   </p>
-                  <pre className="max-h-48 max-w-full overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/40 bg-muted/20 px-3 py-2 text-[11px] font-mono leading-relaxed text-foreground/80">
+                  <pre className="scrollbar-custom max-h-48 max-w-full overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/40 bg-muted/20 px-3 py-2 text-[11px] font-mono leading-relaxed text-foreground/80">
                     {conflict?.ours || "(empty)"}
                   </pre>
                 </div>
@@ -183,7 +183,7 @@ export function ConflictResolverDialog({
                   <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
                     KB version
                   </p>
-                  <pre className="max-h-48 max-w-full overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/40 bg-muted/20 px-3 py-2 text-[11px] font-mono leading-relaxed text-foreground/80">
+                  <pre className="scrollbar-custom max-h-48 max-w-full overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/40 bg-muted/20 px-3 py-2 text-[11px] font-mono leading-relaxed text-foreground/80">
                     {conflict?.theirs || "(empty)"}
                   </pre>
                 </div>

--- a/apps/web/src/components/workspace/workspace-command-palette.tsx
+++ b/apps/web/src/components/workspace/workspace-command-palette.tsx
@@ -357,7 +357,7 @@ export function WorkspaceCommandPalette({
             className="h-11 border-0 bg-muted/40 text-base focus-visible:ring-0 focus-visible:ring-offset-0"
           />
         </div>
-        <div className="max-h-[min(28rem,60vh)] overflow-y-auto p-2">
+        <div className="scrollbar-custom max-h-[min(28rem,60vh)] overflow-y-auto p-2">
           {visibleItems.length === 0 ? (
             <div className="px-4 py-8 text-center text-sm text-muted-foreground">
               {isSearchingSessions ? "Searching sessions..." : "No commands or sessions found."}


### PR DESCRIPTION
## Summary
- Align the Default model input and Save button in the Agents page and desktop Settings panel; helper text moved below the row so the elements line up correctly.
- Reduce bottom padding on `ConnectorCard` so the actions row no longer floats far from the edge.
- Apply the existing `scrollbar-custom` utility (theme-aware, thin, transparent track) to scrollable Dialog surfaces: connector settings dialogs (tool permissions, Zendesk, Meta Ads), desktop Settings inner pane, command palette results, and the conflict resolver code previews. Fixes the always-white scrollbar in dark mode and the bar visually clipping past the rounded container.
- Swap `DialogContent` close button focus styles from `focus:` to `focus-visible:` so the orange focus ring stops flashing on every dialog open via Radix's auto-focus.

## Test plan
- [ ] Agents page (`/u/<slug>/agents`): Default model input + Save button sit on the same row; helper text sits below; alignment holds at sm and md widths.
- [ ] Desktop Settings → Agents section: same alignment fix.
- [ ] Connector cards: bottom padding feels balanced relative to the header.
- [ ] In dark mode, open: command palette, desktop Settings, Zendesk / Meta Ads / connector tool-permissions dialogs, conflict resolver — scrollbars are themed and respect the rounded container.
- [ ] Open any dialog with a close button: the orange focus ring does not flash on open. Pressing Tab still shows the ring as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)