### PR TITLE
fix(web): preserve rail colors/magnification and maximize Knowledge content space

### DIFF
--- a/apps/web/src/components/workspace/__tests__/file-preview-panel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/file-preview-panel.test.tsx
@@ -52,7 +52,7 @@ describe('FilePreviewPanel', () => {
   })
 
   it('keeps markdown properties inside the scrollable preview content', () => {
-    const { container } = render(
+    render(
       <FilePreviewPanel
         path="Notes/Plan.md"
         content={['---', 'owner: Ops', '---', '# Plan'].join('\n')}
@@ -61,7 +61,7 @@ describe('FilePreviewPanel', () => {
       />
     )
 
-    const scroller = container.querySelector('.overflow-y-auto') as HTMLElement
+    const scroller = screen.getByTestId('file-preview-scroller')
     const header = screen.getByText('Quickview').closest('div') as HTMLElement
 
     expect(scroller.textContent).toContain('owner')

--- a/apps/web/src/components/workspace/__tests__/file-preview-panel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/file-preview-panel.test.tsx
@@ -51,6 +51,24 @@ describe('FilePreviewPanel', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps markdown properties inside the scrollable preview content', () => {
+    const { container } = render(
+      <FilePreviewPanel
+        path="Notes/Plan.md"
+        content={['---', 'owner: Ops', '---', '# Plan'].join('\n')}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+      />
+    )
+
+    const scroller = container.querySelector('.overflow-y-auto') as HTMLElement
+    const header = screen.getByText('Quickview').closest('div') as HTMLElement
+
+    expect(scroller.textContent).toContain('owner')
+    expect(scroller.textContent).toContain('Ops')
+    expect(header.textContent).not.toContain('owner')
+  })
+
   it('copies with navigator clipboard when available', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     vi.stubGlobal('navigator', { clipboard: { writeText } })

--- a/apps/web/src/components/workspace/__tests__/markdown-editor.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/markdown-editor.test.tsx
@@ -191,6 +191,25 @@ describe("MarkdownEditor", () => {
     expect(onChange).toHaveBeenCalledWith(["---", "title: Beta", "---", "# Body"].join("\n"));
   });
 
+  it("keeps the toolbar fixed above properties and editor content", () => {
+    render(
+      <MarkdownEditor
+        value={["---", "title: Alpha", "---", "# Body"].join("\n")}
+        onChange={vi.fn()}
+        saveState="saved"
+      />
+    );
+
+    const scroller = document.querySelector(".workspace-tiptap") as HTMLElement;
+    const toolbarButton = screen.getByRole("button", { name: "Headings" });
+    const propertiesButton = screen.getByRole("button", { name: /Properties/ });
+
+    expect(scroller.contains(toolbarButton)).toBe(false);
+    expect(scroller.contains(propertiesButton)).toBe(true);
+    expect(scroller.textContent).toContain("Editor Content");
+    expect(toolbarButton.compareDocumentPosition(propertiesButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it("does not coerce cleared numeric properties to zero while typing", () => {
     const onChange = vi.fn();
 

--- a/apps/web/src/components/workspace/__tests__/markdown-editor.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/markdown-editor.test.tsx
@@ -201,9 +201,13 @@ describe("MarkdownEditor", () => {
     );
 
     const scroller = document.querySelector(".workspace-tiptap") as HTMLElement;
+    const toolbar = screen.getByTestId("markdown-editor-toolbar");
     const toolbarButton = screen.getByRole("button", { name: "Headings" });
     const propertiesButton = screen.getByRole("button", { name: /Properties/ });
 
+    expect(toolbar.className).toContain("border-b");
+    expect(toolbar.className).not.toContain("rounded");
+    expect(toolbar.className).not.toContain("bg-foreground");
     expect(scroller.contains(toolbarButton)).toBe(false);
     expect(scroller.contains(propertiesButton)).toBe(true);
     expect(scroller.textContent).toContain("Editor Content");

--- a/apps/web/src/components/workspace/__tests__/workspace-mode-toggle.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/workspace-mode-toggle.test.tsx
@@ -61,8 +61,10 @@ describe('WorkspaceModeToggle', () => {
 
   it('remeasures the active indicator when the knowledge badge disappears', () => {
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
-      const width = this instanceof HTMLButtonElement && this.textContent?.includes('Knowledge')
-        ? this.textContent.includes('3') ? 120 : 96
+      const isActiveButton = this instanceof HTMLButtonElement && this.getAttribute('aria-pressed') === 'true'
+      const hasPendingBadge = this instanceof HTMLButtonElement && this.querySelector('[aria-label="3 pending"]') !== null
+      const width = isActiveButton
+        ? hasPendingBadge ? 120 : 96
         : 240
 
       return {

--- a/apps/web/src/components/workspace/__tests__/workspace-mode-toggle.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/workspace-mode-toggle.test.tsx
@@ -16,6 +16,7 @@ describe('WorkspaceModeToggle', () => {
 
   afterEach(() => {
     cleanup()
+    vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
 
@@ -56,5 +57,46 @@ describe('WorkspaceModeToggle', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Sessions' }))
 
     expect(onModeChange).toHaveBeenCalledWith('chat')
+  })
+
+  it('remeasures the active indicator when the knowledge badge disappears', () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      const width = this instanceof HTMLButtonElement && this.textContent?.includes('Knowledge')
+        ? this.textContent.includes('3') ? 120 : 96
+        : 240
+
+      return {
+        bottom: 32,
+        height: 32,
+        left: 0,
+        right: width,
+        top: 0,
+        width,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }
+    })
+
+    const { container, rerender } = render(
+      <WorkspaceModeToggle
+        mode="knowledge"
+        knowledgePendingCount={3}
+        onModeChange={vi.fn()}
+      />
+    )
+    const indicator = container.querySelector('[aria-hidden="true"]') as HTMLElement
+
+    expect(indicator.style.width).toBe('120px')
+
+    rerender(
+      <WorkspaceModeToggle
+        mode="knowledge"
+        knowledgePendingCount={0}
+        onModeChange={vi.fn()}
+      />
+    )
+
+    expect(indicator.style.width).toBe('96px')
   })
 })

--- a/apps/web/src/components/workspace/__tests__/workspace-sessions-rail.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/workspace-sessions-rail.test.tsx
@@ -161,13 +161,59 @@ describe('WorkspaceSessionsRail', () => {
 
     fireEvent.mouseMove(rail, { clientY: 33 })
 
-    await waitFor(() => expect(focusedDot.className).toContain('bg-primary'))
+    await waitFor(() => expect(focusedDot.style.transform).toContain('translate3d(0,'))
     await waitFor(() => expect(previousDot.style.transform).toContain('translate3d(0, -'))
 
     expect(previousDot.className).not.toContain('bg-primary')
+    expect(focusedDot.className).toContain('bg-amber-400')
+    expect(focusedDot.className).not.toContain('bg-primary')
     expect(focusedDot.style.transform).toContain('translate3d(0,')
     expect(focusedButton.style.height).toBe('22px')
     expect(Number(focusedButton.style.opacity)).toBeGreaterThan(0)
+  })
+
+  it('preserves cursor magnification when sessions refresh while hovering', async () => {
+    const { rerender } = render(
+      <WorkspaceSessionsRail
+        kind="chats"
+        sessions={sessions}
+        activeSessionId={null}
+        unseenCompletedSessions={new Set<string>()}
+        onSelectSession={vi.fn()}
+      />
+    )
+
+    const rail = screen.getByLabelText('Chats')
+    Object.defineProperty(rail, 'scrollTop', { configurable: true, value: 0 })
+    rail.getBoundingClientRect = () => ({
+      bottom: 180,
+      height: 180,
+      left: 0,
+      right: 48,
+      top: 0,
+      width: 48,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    })
+
+    const previousDot = dotFor('Idle chat')
+    fireEvent.mouseMove(rail, { clientY: 33 })
+
+    await waitFor(() => expect(previousDot.style.transform).toContain('translate3d(0, -'))
+    const hoveringTransform = previousDot.style.transform
+
+    rerender(
+      <WorkspaceSessionsRail
+        kind="chats"
+        sessions={sessions.map((session) => ({ ...session }))}
+        activeSessionId={null}
+        unseenCompletedSessions={new Set<string>()}
+        onSelectSession={vi.fn()}
+      />
+    )
+
+    expect(previousDot.style.transform).toBe(hoveringTransform)
   })
 
   it('renders nothing when the selected rail kind has no sessions', () => {

--- a/apps/web/src/components/workspace/file-preview-panel.tsx
+++ b/apps/web/src/components/workspace/file-preview-panel.tsx
@@ -112,7 +112,7 @@ export function FilePreviewPanel({
         </button>
       </div>
 
-      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-none">
+      <div data-testid="file-preview-scroller" className="flex-1 min-h-0 overflow-y-auto scrollbar-none">
         {isLoading && !content ? (
           <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
             Loading…

--- a/apps/web/src/components/workspace/file-preview-panel.tsx
+++ b/apps/web/src/components/workspace/file-preview-panel.tsx
@@ -118,9 +118,7 @@ export function FilePreviewPanel({
             Loading…
           </div>
         ) : isMarkdown ? (
-          <div className="px-6 pb-6 [&_.markdown-content]:pt-0">
-            <MarkdownPreview content={content} />
-          </div>
+          <MarkdownPreview content={content} />
         ) : (
           <pre className="whitespace-pre-wrap break-words px-6 pb-6 pt-1 font-mono text-xs text-muted-foreground">
             {content}

--- a/apps/web/src/components/workspace/markdown-editor.tsx
+++ b/apps/web/src/components/workspace/markdown-editor.tsx
@@ -508,7 +508,10 @@ export function MarkdownEditor({
 
   return (
     <div className="flex h-full flex-col">
-      <div className="mx-4 mb-1 flex items-center justify-between gap-3 rounded-lg border border-border/40 bg-foreground/[0.02] px-3 py-1.5">
+      <div
+        data-testid="markdown-editor-toolbar"
+        className="flex shrink-0 items-center justify-between gap-3 border-b border-border/30 px-4 py-2"
+      >
         <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto scrollbar-none"  style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -688,7 +691,7 @@ export function MarkdownEditor({
 
       <div
         ref={editorScrollRef}
-        className="workspace-tiptap relative flex-1 overflow-y-auto pt-2 pb-5 scrollbar-none"
+        className="workspace-tiptap relative flex-1 overflow-y-auto pb-5 scrollbar-none"
         onMouseLeave={scheduleHoveredLinkHide}
         onMouseMove={handleWorkspaceMouseMove}
       >

--- a/apps/web/src/components/workspace/markdown-editor.tsx
+++ b/apps/web/src/components/workspace/markdown-editor.tsx
@@ -508,17 +508,6 @@ export function MarkdownEditor({
 
   return (
     <div className="flex h-full flex-col">
-      <MarkdownFrontmatterPanel
-        editable
-        frontmatter={frontmatter}
-        onPropertiesChange={handlePropertiesChange}
-        onRawChange={handleRawFrontmatterChange}
-      />
-
-      <div className="mx-4 pt-2 pb-4">
-        <div className="h-px bg-border/40" />
-      </div>
-
       <div className="mx-4 mb-1 flex items-center justify-between gap-3 rounded-lg border border-border/40 bg-foreground/[0.02] px-3 py-1.5">
         <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto scrollbar-none"  style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}>
           <DropdownMenu>
@@ -699,11 +688,24 @@ export function MarkdownEditor({
 
       <div
         ref={editorScrollRef}
-        className="workspace-tiptap relative flex-1 overflow-y-auto px-6 pt-2 pb-5 scrollbar-none"
+        className="workspace-tiptap relative flex-1 overflow-y-auto pt-2 pb-5 scrollbar-none"
         onMouseLeave={scheduleHoveredLinkHide}
         onMouseMove={handleWorkspaceMouseMove}
       >
-        <EditorContent editor={editor} />
+        <MarkdownFrontmatterPanel
+          editable
+          frontmatter={frontmatter}
+          onPropertiesChange={handlePropertiesChange}
+          onRawChange={handleRawFrontmatterChange}
+        />
+
+        <div className="mx-4 pt-2 pb-4">
+          <div className="h-px bg-border/40" />
+        </div>
+
+        <div className="px-6">
+          <EditorContent editor={editor} />
+        </div>
         <MarkdownTableControls containerRef={editorScrollRef} editor={editor} />
         {hoveredLink ? (
           <div

--- a/apps/web/src/components/workspace/markdown-preview.tsx
+++ b/apps/web/src/components/workspace/markdown-preview.tsx
@@ -11,11 +11,17 @@ type MarkdownPreviewProps = {
 
 export function MarkdownPreview({ content }: MarkdownPreviewProps) {
   const frontmatter = parseMarkdownFrontmatter(content);
+  const showProperties = frontmatter.mode !== "none";
 
   return (
     <div>
       <MarkdownFrontmatterPanel frontmatter={frontmatter} />
-      <div className="markdown-content pt-4">
+      {showProperties ? (
+        <div className="mx-4 pt-2 pb-4">
+          <div className="h-px bg-border/40" />
+        </div>
+      ) : null}
+      <div className="markdown-content px-6 pt-1 pb-6">
         <ReactMarkdown remarkPlugins={[remarkGfm]} components={workspaceMarkdownComponents}>
           {frontmatter.body}
         </ReactMarkdown>

--- a/apps/web/src/components/workspace/workspace-mode-toggle.tsx
+++ b/apps/web/src/components/workspace/workspace-mode-toggle.tsx
@@ -82,12 +82,13 @@ export function WorkspaceModeToggle({
   const chatRef = useRef<HTMLButtonElement>(null)
   const tasksRef = useRef<HTMLButtonElement>(null)
   const knowledgeRef = useRef<HTMLButtonElement>(null)
+  const activeButtonRef = mode === 'chat' ? chatRef : mode === 'tasks' ? tasksRef : knowledgeRef
 
   const [indicator, setIndicator] = useState<{ left: number; width: number } | null>(null)
   const [hasAnimated, setHasAnimated] = useState(false)
 
   const updateIndicator = useCallback(() => {
-    const button = (mode === 'chat' ? chatRef : mode === 'tasks' ? tasksRef : knowledgeRef).current
+    const button = activeButtonRef.current
     const container = containerRef.current
     if (!button || !container) return
 
@@ -97,14 +98,14 @@ export function WorkspaceModeToggle({
       left: buttonRect.left - containerRect.left,
       width: buttonRect.width,
     })
-  }, [mode])
+  }, [activeButtonRef])
 
   useIsomorphicLayoutEffect(() => {
     updateIndicator()
   }, [hideTasks, knowledgePendingCount, updateIndicator])
 
   useEffect(() => {
-    const button = (mode === 'chat' ? chatRef : mode === 'tasks' ? tasksRef : knowledgeRef).current
+    const button = activeButtonRef.current
     const container = containerRef.current
     if (!button || !container || typeof ResizeObserver === 'undefined') return
 
@@ -112,7 +113,7 @@ export function WorkspaceModeToggle({
     observer.observe(button)
     observer.observe(container)
     return () => observer.disconnect()
-  }, [mode, updateIndicator])
+  }, [activeButtonRef, updateIndicator])
 
   useEffect(() => {
     if (!indicator || hasAnimated) return

--- a/apps/web/src/components/workspace/workspace-mode-toggle.tsx
+++ b/apps/web/src/components/workspace/workspace-mode-toggle.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import {
+  useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
@@ -81,17 +82,12 @@ export function WorkspaceModeToggle({
   const chatRef = useRef<HTMLButtonElement>(null)
   const tasksRef = useRef<HTMLButtonElement>(null)
   const knowledgeRef = useRef<HTMLButtonElement>(null)
-  const refByMode: Record<WorkspaceMode, RefObject<HTMLButtonElement | null>> = {
-    chat: chatRef,
-    tasks: tasksRef,
-    knowledge: knowledgeRef,
-  }
 
   const [indicator, setIndicator] = useState<{ left: number; width: number } | null>(null)
   const [hasAnimated, setHasAnimated] = useState(false)
 
-  useIsomorphicLayoutEffect(() => {
-    const button = refByMode[mode].current
+  const updateIndicator = useCallback(() => {
+    const button = (mode === 'chat' ? chatRef : mode === 'tasks' ? tasksRef : knowledgeRef).current
     const container = containerRef.current
     if (!button || !container) return
 
@@ -102,6 +98,21 @@ export function WorkspaceModeToggle({
       width: buttonRect.width,
     })
   }, [mode])
+
+  useIsomorphicLayoutEffect(() => {
+    updateIndicator()
+  }, [hideTasks, knowledgePendingCount, updateIndicator])
+
+  useEffect(() => {
+    const button = (mode === 'chat' ? chatRef : mode === 'tasks' ? tasksRef : knowledgeRef).current
+    const container = containerRef.current
+    if (!button || !container || typeof ResizeObserver === 'undefined') return
+
+    const observer = new ResizeObserver(() => updateIndicator())
+    observer.observe(button)
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [mode, updateIndicator])
 
   useEffect(() => {
     if (!indicator || hasAnimated) return

--- a/apps/web/src/components/workspace/workspace-sessions-rail.tsx
+++ b/apps/web/src/components/workspace/workspace-sessions-rail.tsx
@@ -73,7 +73,7 @@ export function WorkspaceSessionsRail({
   const dotElsRef = useRef<Map<string, HTMLSpanElement>>(new Map())
   const frameRef = useRef<number | null>(null)
   const pointerStrengthRef = useRef(0)
-  const [hoveredIndex, setHoveredIndex] = useState(-1)
+  const [hoveredSessionId, setHoveredSessionId] = useState<string | null>(null)
 
   const visibleSessions = useMemo(
     () =>
@@ -139,10 +139,13 @@ export function WorkspaceSessionsRail({
         const nextHoveredIndex = cursorY !== null && pointerStrength > 0.2
           ? Math.max(0, Math.min(visibleSessions.length - 1, Math.floor(cursorY / ROW_HEIGHT)))
           : -1
+        const nextHoveredSessionId = nextHoveredIndex >= 0
+          ? visibleSessions[nextHoveredIndex]?.id ?? null
+          : null
 
         pointerStrengthRef.current = pointerStrength
         applyRailStyles(anchorY, pointerStrength)
-        setHoveredIndex((current) => (current === nextHoveredIndex ? current : nextHoveredIndex))
+        setHoveredSessionId((current) => (current === nextHoveredSessionId ? current : nextHoveredSessionId))
 
         if (pointerStrength !== targetStrength) {
           frameRef.current = requestAnimationFrame(updateFrame)
@@ -151,7 +154,7 @@ export function WorkspaceSessionsRail({
 
       frameRef.current = requestAnimationFrame(updateFrame)
     },
-    [activeIndex, applyRailStyles, visibleSessions.length]
+    [activeIndex, applyRailStyles, visibleSessions]
   )
 
   const handleMouseMove = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
@@ -166,8 +169,14 @@ export function WorkspaceSessionsRail({
   }, [scheduleRailUpdate])
 
   useLayoutEffect(() => {
-    applyRailStyles(getRailAnchorY(activeIndex), 0)
-  }, [activeIndex, applyRailStyles])
+    const cursorY = cursorYRef.current
+    const pointerStrength = cursorY === null ? 0 : pointerStrengthRef.current
+    const restAnchorY = getRailAnchorY(activeIndex)
+    const anchorY = cursorY === null
+      ? restAnchorY
+      : restAnchorY + (cursorY - restAnchorY) * pointerStrength
+    applyRailStyles(anchorY, pointerStrength)
+  }, [activeIndex, applyRailStyles, visibleSessions.length])
 
   useLayoutEffect(() => {
     return () => {
@@ -187,13 +196,14 @@ export function WorkspaceSessionsRail({
         style={{ paddingBottom: RAIL_EDGE_PADDING_PX, paddingTop: RAIL_EDGE_PADDING_PX }}
         aria-label={kind === 'tasks' ? 'Tasks' : 'Chats'}
       >
-        {visibleSessions.map((session, index) => {
+        {visibleSessions.map((session) => {
           const isActive = session.id === activeSessionId
-          const isHovered = index === hoveredIndex
+          const isHovered = session.id === hoveredSessionId
+          const statusColorCls = dotColorClass(session, unseenCompletedSessions)
 
-          const colorCls = isHovered || isActive
+          const colorCls = (isHovered || isActive) && statusColorCls === 'bg-muted-foreground'
             ? 'bg-primary'
-            : dotColorClass(session, unseenCompletedSessions)
+            : statusColorCls
           const title =
             kind === 'tasks' && session.autopilot ? session.autopilot.taskName : session.title
 
@@ -219,7 +229,7 @@ export function WorkspaceSessionsRail({
                     }}
                     className={cn(
                       'block rounded-full transform-gpu transition-colors duration-150 ease-out will-change-transform',
-                      hoveredIndex < 0 && 'transition-transform duration-200 ease-out',
+                      hoveredSessionId === null && 'transition-transform duration-200 ease-out',
                       colorCls
                     )}
                     style={{

--- a/apps/web/src/components/workspace/workspace-sessions-rail.tsx
+++ b/apps/web/src/components/workspace/workspace-sessions-rail.tsx
@@ -27,12 +27,18 @@ type WorkspaceSessionsRailProps = {
   onMarkAutopilotRunSeen?: (runId: string) => Promise<void> | void
 }
 
+function isIdleSession(session: WorkspaceSession, unseen: ReadonlySet<string>): boolean {
+  return session.status !== 'busy'
+    && session.status !== 'error'
+    && !session.autopilot?.hasUnseenResult
+    && !unseen.has(session.id)
+}
+
 function dotColorClass(session: WorkspaceSession, unseen: ReadonlySet<string>): string {
+  if (isIdleSession(session, unseen)) return 'bg-muted-foreground'
   if (session.status === 'busy') return 'bg-amber-400'
   if (session.status === 'error') return 'bg-red-400'
-  if (session.autopilot?.hasUnseenResult) return 'bg-green-400'
-  if (unseen.has(session.id)) return 'bg-green-400'
-  return 'bg-muted-foreground'
+  return 'bg-green-400'
 }
 
 function focusFactor(distancePx: number): number {
@@ -139,9 +145,7 @@ export function WorkspaceSessionsRail({
         const nextHoveredIndex = cursorY !== null && pointerStrength > 0.2
           ? Math.max(0, Math.min(visibleSessions.length - 1, Math.floor(cursorY / ROW_HEIGHT)))
           : -1
-        const nextHoveredSessionId = nextHoveredIndex >= 0
-          ? visibleSessions[nextHoveredIndex]?.id ?? null
-          : null
+        const nextHoveredSessionId = visibleSessions[nextHoveredIndex]?.id ?? null
 
         pointerStrengthRef.current = pointerStrength
         applyRailStyles(anchorY, pointerStrength)
@@ -199,9 +203,10 @@ export function WorkspaceSessionsRail({
         {visibleSessions.map((session) => {
           const isActive = session.id === activeSessionId
           const isHovered = session.id === hoveredSessionId
+          const isIdle = isIdleSession(session, unseenCompletedSessions)
           const statusColorCls = dotColorClass(session, unseenCompletedSessions)
 
-          const colorCls = (isHovered || isActive) && statusColorCls === 'bg-muted-foreground'
+          const colorCls = (isHovered || isActive) && isIdle
             ? 'bg-primary'
             : statusColorCls
           const title =


### PR DESCRIPTION
## Summary

- **Rail colors:** Hovering over non-idle session dots now preserves their status colors (busy=amber, error=red, completed/unseen=green); only idle dots turn primary on hover/active. Previously, all hovered dots used bg-primary regardless of status.
- **Rail magnification:** Fixed magnification reset that occurred after 1-2 seconds when the cursor was still hovering. The layout effect now re-applies styles from the current cursor anchor instead of forcing rest-state, preventing visual jumps during polling/refresh.
- **Knowledge toggle indicator:** Added remeasurement when the badge appears/disappears (knowledgePendingCount changes) and added ResizeObserver support to track button/container size changes, fixing a visual glitch where the indicator width didn't update after the badge disappeared.
- **Knowledge editor layout:** Moved Properties panel into the `.workspace-tiptap` scrollable area below the toolbar. Only the toolbar remains fixed, maximizing usable space for content.
- **Markdown preview layout:** Aligned preview so Properties and body scroll together while the preview header/actions stay fixed, matching the editor pattern.

## Tests / Checks Run

```bash
# From apps/web/
pnpm test
# Result: 4136 passed | 15 skipped (4151 total) ✓
pnpm lint
# Result: 0 errors, 16 warnings (pre-existing unused-var warnings in unrelated tests)

# From repo root
bash scripts/check-podman-images.sh
# Result: Podman image validation passed ✓
```

## Review Notes / Risks

- **Rail state tracking:** Changed `hoveredIndex` (number) to `hoveredSessionId` (string | null) to survive session list refreshes without losing hover state. The layout effect now respects the current cursor position and re-applies magnification instead of resetting.
- **Toggle ResizeObserver:** Added ResizeObserver on the active button and container for robust indicator resizing. Gracefully handles environments where ResizeObserver is unavailable.
- **Editor layout:** Properties moved inside `.workspace-tiptap`; padding adjusted to avoid double padding (Properties has px-4, body wrapper has px-6). Toolbar remains fixed outside the scroller. Internal link logic still queries `.workspace-tiptap` as the scroller, which remains correct.
- **Preview layout:** `MarkdownPreview` now owns its content padding (px-6 pt-1 pb-6) so Properties and body scroll together within the preview panel's scroll area. Only the Quickview header remains fixed.

## Checklist

- [x] All new/modified tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Podman images build locally (`bash scripts/check-podman-images.sh`)
- [x] No secrets committed (reviewed changed files)
- [x] Self-reviewed: changes match the stated goals only
- [x] No docs or config updates needed (UI bug fixes only)