### PR TITLE
fix(chat-panel): suppress Mermaid built-in error rendering

### DIFF
--- a/apps/web/src/components/workspace/chat-panel/__tests__/visualization-cards.test.tsx
+++ b/apps/web/src/components/workspace/chat-panel/__tests__/visualization-cards.test.tsx
@@ -95,6 +95,7 @@ describe('visualization cards', () => {
     await waitFor(() => expect(mermaidInitializeMock).toHaveBeenCalledTimes(1))
     expect(mermaidInitializeMock).toHaveBeenCalledWith(expect.objectContaining({
       securityLevel: 'strict',
+      suppressErrorRendering: true,
       htmlLabels: false,
       flowchart: expect.objectContaining({ useMaxWidth: true }),
       theme: 'base',

--- a/apps/web/src/components/workspace/chat-panel/diagram-card.tsx
+++ b/apps/web/src/components/workspace/chat-panel/diagram-card.tsx
@@ -37,6 +37,7 @@ function loadMermaid(): Promise<MermaidApi> {
         mermaid.initialize({
           startOnLoad: false,
           securityLevel: 'strict',
+          suppressErrorRendering: true,
           // Root-level htmlLabels (v11+). The deprecated flowchart.htmlLabels is
           // ignored, so labels would otherwise render as HTML in <foreignObject>
           // and get stripped by DOMPurify's SVG profile, leaving empty nodes.


### PR DESCRIPTION
## Summary

- Prevents Mermaid from injecting its own syntax-error SVG into the document body when diagram rendering fails
- Fixes a visual bug where Mermaid's error graphic could remain detached in the workspace chat UI after failed diagram rendering
- Existing React-controlled error messaging in `DiagramCard` remains unchanged

## Changes

- Added `suppressErrorRendering: true` to Mermaid initialization in `DiagramCard.loadMermaid()`
- Updated visualization cards test to assert Mermaid is initialized with this option

## Tests/Checks Run

- **Git whitespace check**: `git diff --check` - passed
- **Commit verification**: `git rev-parse --short HEAD` - `d4066715`
- **Focused test run**: `pnpm test src/components/workspace/chat-panel/__tests__/visualization-cards.test.tsx` - blocked (node_modules missing, vitest not installed)
- **Broader checks**: `pnpm test`, `pnpm lint`, `bash scripts/check-podman-images.sh` - not run (blocked by missing dependencies)

## Review Notes

- Minimal change: only adds one Mermaid initialization option and one test assertion
- No changes to UI components, markdown parsing, or other visualization code
- Existing error handling/fallback copy remains fully functional
- Mermaid 11.14.0 supports `suppressErrorRendering` to disable internal error SVG injection

## Risks

- Low risk: change is isolated to Mermaid initialization and test assertion
- If `suppressErrorRendering` were unsupported in older Mermaid versions, diagrams would fail silently instead of showing React error message (unlikely given package.json pinning to 11.14.0)

## Checklist

- [x] Code follows existing patterns and conventions
- [x] Change is minimal and focused
- [x] No secrets or sensitive files committed
- [x] Tests cover the new initialization option (assertion added)
- [x] Git whitespace check passed
- [ ] Full test suite run (blocked by missing dependencies)
- [ ] Linter run (blocked by missing dependencies)
- [ ] Podman images build (blocked by missing dependencies)