### PR TITLE
fix(slack): allow thread replies outside notification allowlist

### DIFF
--- a/apps/web/src/app/api/u/[slug]/slack-integration/channels/__tests__/route.test.ts
+++ b/apps/web/src/app/api/u/[slug]/slack-integration/channels/__tests__/route.test.ts
@@ -144,6 +144,7 @@ describe('/api/u/[slug]/slack-integration/channels', () => {
           channels: [
             { id: 'G1', is_member: true, name: 'private-team' },
             { id: 'G2', is_member: false, name: 'outside-private' },
+            { id: 'G3', name: 'incident-room' },
           ],
         })
 
@@ -174,12 +175,13 @@ describe('/api/u/[slug]/slack-integration/channels', () => {
         { channelId: 'C2', isPrivate: true, name: 'ops' },
         { channelId: 'C3', isPrivate: false, name: 'random' },
         { channelId: 'G1', isPrivate: true, name: 'private-team' },
+        { channelId: 'G3', isPrivate: true, name: 'incident-room' },
       ])
       expect(mocks.auditEvent).toHaveBeenCalledWith({
         actorUserId: 'u-admin',
         action: 'slack.notification_channels_refreshed',
         metadata: {
-          channelCount: 4,
+          channelCount: 5,
           slackTeamId: 'T123',
         },
       })

--- a/apps/web/src/app/api/u/[slug]/slack-integration/channels/route.ts
+++ b/apps/web/src/app/api/u/[slug]/slack-integration/channels/route.ts
@@ -52,7 +52,7 @@ async function listSlackChannelsByType(botToken: string, type: 'public_channel' 
       }
 
       const isPrivate = type === 'private_channel' || channel.is_private === true
-      if (isPrivate && channel.is_member !== true) {
+      if (isPrivate && channel.is_member === false) {
         continue
       }
 

--- a/apps/web/src/components/settings/slack-integration-panel.tsx
+++ b/apps/web/src/components/settings/slack-integration-panel.tsx
@@ -542,7 +542,7 @@ export function SlackIntegrationPanel({
                 <div className="space-y-1">
                   <h3 className="text-sm font-medium text-foreground">Notification channels</h3>
                   <p className="text-xs text-muted-foreground">
-                    Channels where Autopilot can send notifications. Private channels only appear if the bot has been invited.
+                    Channels where Autopilot can proactively send notifications. Thread replies work separately whenever Arche is mentioned in a channel where the bot is present.
                   </p>
                 </div>
                 <Button
@@ -558,7 +558,7 @@ export function SlackIntegrationPanel({
 
               {notificationChannels.length === 0 ? (
                 <p className="rounded-lg border border-border/60 bg-card/40 px-3 py-2 text-sm text-muted-foreground">
-                  No channels found. Click refresh to load channels from Slack.
+                  No channels found. Invite the bot to Slack channels, then click refresh to load them from Slack.
                 </p>
               ) : (
                 <div className="space-y-2">

--- a/apps/web/src/lib/slack/__tests__/socket-mode.test.ts
+++ b/apps/web/src/lib/slack/__tests__/socket-mode.test.ts
@@ -1069,7 +1069,7 @@ describe('slack socket manager', () => {
     })
 
     expect(findThreadBindingMock).toHaveBeenCalledTimes(2)
-    expect(isNotificationChannelAllowedMock).toHaveBeenCalledWith('T123', 'C123')
+    expect(isNotificationChannelAllowedMock).not.toHaveBeenCalled()
     expect(promptAsyncMock).toHaveBeenCalledWith(
       expect.objectContaining({ sessionID: 'thread-session-1' }),
       { throwOnError: true },
@@ -1309,11 +1309,18 @@ describe('slack socket manager', () => {
     stopSlackSocketManager()
   })
 
-  it('does not execute channel prompts outside enabled Slack channels', async () => {
+  it('executes mentioned channel prompts without checking notification allowlist', async () => {
     isNotificationChannelAllowedMock.mockResolvedValue(false)
+    const promptAsyncMock = vi.fn().mockResolvedValue({})
+    createInstanceClientMock.mockResolvedValue({
+      session: {
+        create: vi.fn().mockResolvedValue({ data: { id: 'session-allowlist-free' } }),
+        promptAsync: promptAsyncMock,
+      },
+    })
     const client = {
       chat: {
-        postMessage: vi.fn().mockResolvedValue({ ts: 'auth-reply' }),
+        postMessage: vi.fn().mockResolvedValue({ ts: 'reply-1' }),
         update: vi.fn().mockResolvedValue({}),
       },
       conversations: {
@@ -1342,13 +1349,22 @@ describe('slack socket manager', () => {
       },
     })
 
-    expect(client.chat.postMessage).toHaveBeenCalledWith({
-      channel: 'C999',
-      text: 'This Slack channel is not enabled for Arche replies. Ask an admin to allow it in Slack settings.',
-      thread_ts: '100.1',
+    expect(isNotificationChannelAllowedMock).not.toHaveBeenCalled()
+    expect(upsertThreadBindingMock).toHaveBeenCalledWith({
+      channelId: 'C999',
+      executionUserId: 'service-1',
+      openCodeSessionId: 'session-allowlist-free',
+      threadTs: '100.1',
     })
-    expect(ensureSlackServiceUserMock).not.toHaveBeenCalled()
-    expect(createInstanceClientMock).not.toHaveBeenCalled()
+    expect(promptAsyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionID: 'session-allowlist-free' }),
+      { throwOnError: true },
+    )
+    expect(client.chat.update).toHaveBeenCalledWith({
+      channel: 'C999',
+      text: 'Final reply',
+      ts: 'reply-1',
+    })
     expect(recordEventReceiptMock).toHaveBeenCalledWith({
       eventId: 'evt-channel-not-allowed',
       receivedAt: expect.any(Date),

--- a/apps/web/src/lib/slack/socket-mode.ts
+++ b/apps/web/src/lib/slack/socket-mode.ts
@@ -331,14 +331,6 @@ async function authorizeSlackThreadEvent(args: {
     }
   }
 
-  const channelAllowed = await slackService.isNotificationChannelAllowed(slackTeamId, args.channel)
-  if (!channelAllowed) {
-    return {
-      ok: false,
-      message: 'This Slack channel is not enabled for Arche replies. Ask an admin to allow it in Slack settings.',
-    }
-  }
-
   const profile = await loadSlackUserProfile(args.client, args.event.user)
   const resolution = await slackService.resolveArcheUserFromSlackUser(
     slackTeamId,


### PR DESCRIPTION
## Summary
- Allow Slack thread replies whenever Arche is mentioned or a bound thread continues, without requiring the notification-channel allowlist.
- Keep the Slack notification-channel allowlist scoped to proactive Autopilot notifications and clarify that in settings copy.
- Preserve private notification channel refresh when Slack omits `is_member`, only excluding explicit non-members.

## Validation
- `pnpm exec vitest run "src/app/api/u/[slug]/slack-integration/channels/__tests__/route.test.ts" "src/components/settings/__tests__/slack-integration-panel.test.tsx" "src/lib/slack/__tests__/socket-mode.test.ts" "src/lib/slack/__tests__/notifications.test.ts"`
- `pnpm test`
- `pnpm lint` (0 errors, existing warnings)
- `bash scripts/check-podman-images.sh`