### PR TITLE
feat(autopilot): implement soft delete for tasks

### DIFF
--- a/apps/web/prisma/migrations/20260514130000_add_autopilot_task_soft_delete/migration.sql
+++ b/apps/web/prisma/migrations/20260514130000_add_autopilot_task_soft_delete/migration.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "autopilot_tasks" ADD COLUMN "deleted_at" TIMESTAMP(3);
+
+CREATE UNIQUE INDEX "autopilot_tasks_user_id_name_active_key"
+  ON "autopilot_tasks"("user_id", "name")
+  WHERE "deleted_at" IS NULL;
+
+DROP INDEX IF EXISTS "autopilot_tasks_user_id_name_key";

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -293,10 +293,10 @@ model AutopilotTask {
 
   createdAt      DateTime       @default(now()) @map("created_at")
   updatedAt      DateTime       @updatedAt @map("updated_at")
+  deletedAt      DateTime?      @map("deleted_at")
 
   runs           AutopilotRun[]
 
-  @@unique([userId, name])
   @@index([userId])
   @@index([enabled, nextRunAt])
   @@index([leaseExpiresAt])

--- a/apps/web/prisma/schema.sqlite.prisma
+++ b/apps/web/prisma/schema.sqlite.prisma
@@ -252,10 +252,10 @@ model AutopilotTask {
 
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")
+  deletedAt      DateTime? @map("deleted_at")
 
   runs           AutopilotRun[]
 
-  @@unique([userId, name])
   @@index([userId])
   @@index([enabled, nextRunAt])
   @@index([leaseExpiresAt])

--- a/apps/web/src/lib/__tests__/prisma-desktop.test.ts
+++ b/apps/web/src/lib/__tests__/prisma-desktop.test.ts
@@ -153,6 +153,71 @@ describe('desktop prisma context isolation', () => {
     expect(createIndexIndex).toBeGreaterThan(addColumnIndex)
   })
 
+  it('adds the autopilot soft-delete column before creating the active-name index', async () => {
+    const executeRawUnsafe = vi.fn()
+    const queryRawUnsafe = vi.fn().mockResolvedValue([{ name: 'id' }])
+
+    mockGeneratedPrismaClient.mockImplementationOnce(({ adapter }: { adapter: { url: string } }) => ({
+      adapterUrl: adapter.url,
+      $executeRaw: vi.fn(),
+      $executeRawUnsafe: executeRawUnsafe,
+      $queryRawUnsafe: queryRawUnsafe,
+      $queryRaw: vi.fn().mockResolvedValue([{ value: '7' }]),
+    }))
+
+    const { initDesktopDatabase } = await import('../prisma-desktop')
+    await initDesktopDatabase()
+
+    const ddl = executeRawUnsafe.mock.calls.map((call) => String(call[0]))
+    const addColumnIndex = ddl.findIndex((statement) =>
+      statement === 'ALTER TABLE "autopilot_tasks" ADD COLUMN "deleted_at" DATETIME',
+    )
+    const createIndexIndex = ddl.findIndex((statement) =>
+      statement.includes('CREATE UNIQUE INDEX IF NOT EXISTS "autopilot_tasks_user_id_name_active_key"'),
+    )
+
+    expect(addColumnIndex).toBeGreaterThanOrEqual(0)
+    expect(createIndexIndex).toBeGreaterThan(addColumnIndex)
+  })
+
+  it('replaces the legacy autopilot task name index with active-only uniqueness', async () => {
+    const executeRawUnsafe = vi.fn()
+    const queryRawUnsafe = vi.fn().mockResolvedValue([
+      { name: 'kind' },
+      { name: 'provider_sync_hash' },
+      { name: 'provider_synced_at' },
+      { name: 'slack_notification_config' },
+      { name: 'retry_attempt' },
+      { name: 'retry_scheduled_for' },
+      { name: 'deleted_at' },
+      { name: 'result_seen_at' },
+      { name: 'attempt' },
+    ])
+
+    mockGeneratedPrismaClient.mockImplementationOnce(({ adapter }: { adapter: { url: string } }) => ({
+      adapterUrl: adapter.url,
+      $executeRaw: vi.fn(),
+      $executeRawUnsafe: executeRawUnsafe,
+      $queryRawUnsafe: queryRawUnsafe,
+      $queryRaw: vi.fn().mockResolvedValue([{ value: '7' }]),
+    }))
+
+    const { initDesktopDatabase } = await import('../prisma-desktop')
+    await initDesktopDatabase()
+
+    const ddl = executeRawUnsafe.mock.calls.map((call) => String(call[0]))
+    const dropLegacyIndex = ddl.findIndex((statement) =>
+      statement === 'DROP INDEX IF EXISTS "autopilot_tasks_user_id_name_key"',
+    )
+    const createActiveIndex = ddl.findIndex((statement) =>
+      statement === 'CREATE UNIQUE INDEX IF NOT EXISTS "autopilot_tasks_user_id_name_active_key" ON "autopilot_tasks"("user_id", "name") WHERE "deleted_at" IS NULL',
+    )
+
+    expect(dropLegacyIndex).toBeGreaterThanOrEqual(0)
+    expect(createActiveIndex).toBeGreaterThan(dropLegacyIndex)
+    expect(ddl).not.toContain('CREATE UNIQUE INDEX IF NOT EXISTS "autopilot_tasks_user_id_name_key" ON "autopilot_tasks"("user_id", "name")')
+  })
+
   it('executes the current desktop schema DDL including durable runs and Slack DM tables', async () => {
     const executeRawUnsafe = vi.fn()
     const queryRawUnsafe = vi.fn().mockResolvedValue([
@@ -162,6 +227,7 @@ describe('desktop prisma context isolation', () => {
       { name: 'slack_notification_config' },
       { name: 'retry_attempt' },
       { name: 'retry_scheduled_for' },
+      { name: 'deleted_at' },
       { name: 'result_seen_at' },
       { name: 'attempt' },
     ])
@@ -185,6 +251,7 @@ describe('desktop prisma context isolation', () => {
     expect(ddl.some((statement) => statement.includes('CREATE TABLE IF NOT EXISTS "external_integrations"'))).toBe(true)
     expect(ddl.some((statement) => statement.includes('CREATE TABLE IF NOT EXISTS "slack_dm_session_bindings"'))).toBe(true)
     expect(ddl.some((statement) => statement.includes('"slack_notification_config" TEXT'))).toBe(true)
+    expect(ddl.some((statement) => statement.includes('"deleted_at" DATETIME'))).toBe(true)
     expect(ddl.some((statement) => statement.includes('"attempt" INTEGER NOT NULL DEFAULT 1'))).toBe(true)
   })
 })

--- a/apps/web/src/lib/prisma-desktop.ts
+++ b/apps/web/src/lib/prisma-desktop.ts
@@ -177,6 +177,7 @@ const SCHEMA_DDL = [
     "retry_scheduled_for" DATETIME,
     "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" DATETIME NOT NULL,
+    "deleted_at" DATETIME,
     CONSTRAINT "autopilot_tasks_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE
   )`,
   `CREATE TABLE IF NOT EXISTS "autopilot_runs" (
@@ -254,7 +255,8 @@ const SCHEMA_DDL = [
   `CREATE UNIQUE INDEX IF NOT EXISTS "slack_pending_dm_decisions_source_event_id_key" ON "slack_pending_dm_decisions"("source_event_id")`,
   `CREATE INDEX IF NOT EXISTS "slack_pending_dm_decisions_expires_at_idx" ON "slack_pending_dm_decisions"("expires_at")`,
   `CREATE UNIQUE INDEX IF NOT EXISTS "slack_notification_channels_slack_team_id_channel_id_key" ON "slack_notification_channels"("slack_team_id", "channel_id")`,
-  `CREATE UNIQUE INDEX IF NOT EXISTS "autopilot_tasks_user_id_name_key" ON "autopilot_tasks"("user_id", "name")`,
+  `DROP INDEX IF EXISTS "autopilot_tasks_user_id_name_key"`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "autopilot_tasks_user_id_name_active_key" ON "autopilot_tasks"("user_id", "name") WHERE "deleted_at" IS NULL`,
   `CREATE INDEX IF NOT EXISTS "autopilot_tasks_user_id_idx" ON "autopilot_tasks"("user_id")`,
   `CREATE INDEX IF NOT EXISTS "autopilot_tasks_enabled_next_run_at_idx" ON "autopilot_tasks"("enabled", "next_run_at")`,
   `CREATE INDEX IF NOT EXISTS "autopilot_tasks_lease_expires_at_idx" ON "autopilot_tasks"("lease_expires_at")`,
@@ -270,7 +272,7 @@ const SCHEMA_DDL = [
   `CREATE INDEX IF NOT EXISTS "two_factor_recovery_user_id_idx" ON "two_factor_recovery"("user_id")`,
 ]
 
-const SCHEMA_VERSION = '7'
+const SCHEMA_VERSION = '8'
 
 function isCreateIndexStatement(ddl: string): boolean {
   return /^CREATE (UNIQUE )?INDEX\b/.test(ddl.trim())
@@ -300,6 +302,7 @@ async function ensureDesktopSchemaColumns(client: DesktopPrismaClient): Promise<
   await ensureColumn(client, 'autopilot_tasks', 'slack_notification_config', 'ALTER TABLE "autopilot_tasks" ADD COLUMN "slack_notification_config" TEXT')
   await ensureColumn(client, 'autopilot_tasks', 'retry_attempt', 'ALTER TABLE "autopilot_tasks" ADD COLUMN "retry_attempt" INTEGER NOT NULL DEFAULT 0')
   await ensureColumn(client, 'autopilot_tasks', 'retry_scheduled_for', 'ALTER TABLE "autopilot_tasks" ADD COLUMN "retry_scheduled_for" DATETIME')
+  await ensureColumn(client, 'autopilot_tasks', 'deleted_at', 'ALTER TABLE "autopilot_tasks" ADD COLUMN "deleted_at" DATETIME')
   await ensureColumn(client, 'autopilot_runs', 'result_seen_at', 'ALTER TABLE "autopilot_runs" ADD COLUMN "result_seen_at" DATETIME')
   await ensureColumn(client, 'autopilot_runs', 'attempt', 'ALTER TABLE "autopilot_runs" ADD COLUMN "attempt" INTEGER NOT NULL DEFAULT 1')
 }

--- a/apps/web/src/lib/services/__tests__/autopilot.test.ts
+++ b/apps/web/src/lib/services/__tests__/autopilot.test.ts
@@ -29,7 +29,7 @@ describe('autopilotService', () => {
   // listTasksByUserId
   // -----------------------------------------------------------------------
   describe('listTasksByUserId', () => {
-    it('queries tasks scoped to user with run include and ordering', async () => {
+    it('queries active tasks scoped to user with run include and ordering', async () => {
       mockPrisma.autopilotTask.findMany.mockResolvedValue([])
       const { listTasksByUserId } = await import('../autopilot')
       const result = await listTasksByUserId('user-1')
@@ -37,7 +37,7 @@ describe('autopilotService', () => {
       expect(result).toEqual([])
       expect(mockPrisma.autopilotTask.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { userId: 'user-1' },
+          where: { deletedAt: null, userId: 'user-1' },
           include: expect.objectContaining({
             runs: expect.objectContaining({ take: 1 }),
           }),
@@ -64,7 +64,7 @@ describe('autopilotService', () => {
 
       expect(result).toEqual(task)
       expect(mockPrisma.autopilotTask.findFirst).toHaveBeenCalledWith({
-        where: { id: 'task-1', userId: 'user-1' },
+        where: { deletedAt: null, id: 'task-1', userId: 'user-1' },
         include: expect.objectContaining({
           runs: expect.objectContaining({ take: 50 }),
         }),
@@ -151,11 +151,11 @@ describe('autopilotService', () => {
 
       expect(result).toEqual(updated)
       expect(mockPrisma.autopilotTask.updateMany).toHaveBeenCalledWith({
-        where: { id: 'task-1', userId: 'user-1' },
+        where: { deletedAt: null, id: 'task-1', userId: 'user-1' },
         data: { name: 'New Name' },
       })
       expect(mockPrisma.autopilotTask.findFirst).toHaveBeenCalledWith({
-        where: { id: 'task-1', userId: 'user-1' },
+        where: { deletedAt: null, id: 'task-1', userId: 'user-1' },
       })
     })
 
@@ -181,7 +181,7 @@ describe('autopilotService', () => {
 
       expect(result).toEqual(updated)
       expect(mockPrisma.autopilotTask.updateMany).toHaveBeenCalledWith({
-        where: { id: 'task-1', userId: 'user-1' },
+        where: { deletedAt: null, id: 'task-1', userId: 'user-1' },
         data: { slackNotificationConfig: expect.anything() },
       })
     })
@@ -191,15 +191,25 @@ describe('autopilotService', () => {
   // deleteTaskByIdAndUserId
   // -----------------------------------------------------------------------
   describe('deleteTaskByIdAndUserId', () => {
-    it('deletes tasks scoped to id and user', async () => {
-      mockPrisma.autopilotTask.deleteMany.mockResolvedValue({ count: 1 })
+    it('archives active tasks scoped to id and user without deleting run rows', async () => {
+      const deletedAt = new Date('2026-04-20T12:00:00Z')
+      mockPrisma.autopilotTask.updateMany.mockResolvedValue({ count: 1 })
 
       const { deleteTaskByIdAndUserId } = await import('../autopilot')
-      await deleteTaskByIdAndUserId('task-1', 'user-1')
+      await deleteTaskByIdAndUserId('task-1', 'user-1', deletedAt)
 
-      expect(mockPrisma.autopilotTask.deleteMany).toHaveBeenCalledWith({
-        where: { id: 'task-1', userId: 'user-1' },
+      expect(mockPrisma.autopilotTask.updateMany).toHaveBeenCalledWith({
+        where: { deletedAt: null, id: 'task-1', userId: 'user-1' },
+        data: {
+          deletedAt,
+          enabled: false,
+          leaseExpiresAt: null,
+          leaseOwner: null,
+          retryAttempt: 0,
+          retryScheduledFor: null,
+        },
       })
+      expect(mockPrisma.autopilotTask.deleteMany).not.toHaveBeenCalled()
     })
   })
 
@@ -241,6 +251,8 @@ describe('autopilotService', () => {
       expect(mockPrisma.autopilotTask.findFirst).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
+            deletedAt: null,
+            enabled: true,
             user: {
               autopilotTasks: {
                 none: {
@@ -248,6 +260,14 @@ describe('autopilotService', () => {
                 },
               },
             },
+          }),
+        }),
+      )
+      expect(mockPrisma.autopilotTask.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            deletedAt: null,
+            enabled: true,
           }),
         }),
       )
@@ -388,9 +408,10 @@ describe('autopilotService', () => {
 
       expect(mockPrisma.autopilotTask.findFirst).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: expect.objectContaining({ userId: 'user-1' }),
+          where: expect.objectContaining({ deletedAt: null, userId: 'user-1' }),
         }),
       )
+      expect(mockPrisma.autopilotTask.updateMany).not.toHaveBeenCalled()
     })
 
     it('returns null when task not found', async () => {
@@ -438,6 +459,7 @@ describe('autopilotService', () => {
 
       const findCall = mockPrisma.autopilotTask.findFirst.mock.calls[0][0]
       expect(findCall.where).not.toHaveProperty('userId')
+      expect(findCall.where).toEqual(expect.objectContaining({ deletedAt: null }))
     })
 
     it('can explicitly use the per-user concurrency policy for immediate claims', async () => {
@@ -457,6 +479,7 @@ describe('autopilotService', () => {
       expect(mockPrisma.autopilotTask.findFirst).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
+            deletedAt: null,
             user: {
               autopilotTasks: {
                 none: {
@@ -464,6 +487,31 @@ describe('autopilotService', () => {
                 },
               },
             },
+          }),
+        }),
+      )
+    })
+
+    it('requires active tasks when racing to claim an immediate run', async () => {
+      const task = { id: 'task-1', leaseOwner: null, leaseExpiresAt: null }
+      mockPrisma.autopilotTask.findFirst.mockResolvedValue(task)
+      mockPrisma.autopilotTask.updateMany.mockResolvedValue({ count: 1 })
+
+      const { claimTaskForImmediateRun } = await import('../autopilot')
+      await claimTaskForImmediateRun({
+        id: 'task-1',
+        leaseMs: 60_000,
+        leaseOwner: 'worker-1',
+        now,
+        userId: 'user-1',
+      })
+
+      expect(mockPrisma.autopilotTask.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            deletedAt: null,
+            id: 'task-1',
+            userId: 'user-1',
           }),
         }),
       )
@@ -828,6 +876,23 @@ describe('autopilotService', () => {
           hasUnseenResult: true,
         },
       ])
+      expect(mockPrisma.autopilotRun.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            task: { userId: 'user-1' },
+          }),
+        }),
+      )
+    })
+
+    it('does not require active tasks so archived task sessions remain classified', async () => {
+      mockPrisma.autopilotRun.findMany.mockResolvedValue([])
+
+      const { findSessionMetadataByUserId } = await import('../autopilot')
+      await findSessionMetadataByUserId('user-1', ['oc-session-1'])
+
+      const query = mockPrisma.autopilotRun.findMany.mock.calls[0][0]
+      expect(query.where.task).toEqual({ userId: 'user-1' })
     })
 
     it('filters out runs without openCodeSessionId', async () => {

--- a/apps/web/src/lib/services/__tests__/services.test.ts
+++ b/apps/web/src/lib/services/__tests__/services.test.ts
@@ -301,7 +301,7 @@ describe('service layer', () => {
   })
 
   describe('autopilotService', () => {
-    it('listTasksByUserId scopes tasks to the user and includes latest runs', async () => {
+    it('listTasksByUserId scopes active tasks to the user and includes latest runs', async () => {
       mockPrisma.autopilotTask.findMany.mockResolvedValue([])
 
       const { autopilotService } = await import('../index')
@@ -309,7 +309,7 @@ describe('service layer', () => {
 
       expect(mockPrisma.autopilotTask.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { userId: 'user-1' },
+          where: { deletedAt: null, userId: 'user-1' },
           include: expect.objectContaining({
             runs: expect.objectContaining({ take: 1 }),
           }),

--- a/apps/web/src/lib/services/autopilot.ts
+++ b/apps/web/src/lib/services/autopilot.ts
@@ -22,6 +22,7 @@ export type AutopilotTaskRecord = {
   slackNotificationConfig?: Prisma.JsonValue | null
   createdAt: Date
   updatedAt: Date
+  deletedAt: Date | null
 }
 
 export type AutopilotRunRecord = {
@@ -141,7 +142,7 @@ function claimAvailabilityWhere(
 
 export async function listTasksByUserId(userId: string): Promise<AutopilotTaskListRecord[]> {
   return prisma.autopilotTask.findMany({
-    where: { userId },
+    where: { deletedAt: null, userId },
     include: TASK_RUN_INCLUDE,
     orderBy: [
       { enabled: 'desc' },
@@ -153,7 +154,7 @@ export async function listTasksByUserId(userId: string): Promise<AutopilotTaskLi
 
 export async function findTaskByIdAndUserId(id: string, userId: string): Promise<AutopilotTaskDetailRecord | null> {
   return prisma.autopilotTask.findFirst({
-    where: { id, userId },
+    where: { deletedAt: null, id, userId },
     include: TASK_DETAIL_INCLUDE,
   })
 }
@@ -209,15 +210,25 @@ export async function updateTaskByIdAndUserId(
   }
 
   const result = await prisma.autopilotTask.updateMany({
-    where: { id, userId },
+    where: { deletedAt: null, id, userId },
     data: updateData,
   })
   if (result.count === 0) return null
-  return prisma.autopilotTask.findFirst({ where: { id, userId } })
+  return prisma.autopilotTask.findFirst({ where: { deletedAt: null, id, userId } })
 }
 
-export function deleteTaskByIdAndUserId(id: string, userId: string) {
-  return prisma.autopilotTask.deleteMany({ where: { id, userId } })
+export function deleteTaskByIdAndUserId(id: string, userId: string, deletedAt = new Date()) {
+  return prisma.autopilotTask.updateMany({
+    where: { deletedAt: null, id, userId },
+    data: {
+      deletedAt,
+      enabled: false,
+      leaseOwner: null,
+      leaseExpiresAt: null,
+      retryAttempt: 0,
+      retryScheduledFor: null,
+    },
+  })
 }
 
 export async function claimNextDueTask(params: {
@@ -229,6 +240,7 @@ export async function claimNextDueTask(params: {
   for (let attempt = 0; attempt < 3; attempt += 1) {
     const task = await prisma.autopilotTask.findFirst({
       where: {
+        deletedAt: null,
         enabled: true,
         nextRunAt: { lte: params.now },
         ...claimAvailabilityWhere(params.now, 'per_user'),
@@ -251,6 +263,7 @@ export async function claimNextDueTask(params: {
     const leaseExpiresAt = new Date(params.now.getTime() + params.leaseMs)
     const claimed = await prisma.autopilotTask.updateMany({
       where: {
+        deletedAt: null,
         id: task.id,
         enabled: true,
         nextRunAt: task.nextRunAt,
@@ -295,6 +308,7 @@ export async function claimTaskForImmediateRun(params: {
   const concurrencyPolicy = params.concurrencyPolicy ?? 'task_only'
   const task = await prisma.autopilotTask.findFirst({
     where: {
+      deletedAt: null,
       id: params.id,
       ...(params.userId ? { userId: params.userId } : {}),
       ...claimAvailabilityWhere(params.now, concurrencyPolicy),
@@ -308,6 +322,7 @@ export async function claimTaskForImmediateRun(params: {
   const leaseExpiresAt = new Date(params.now.getTime() + params.leaseMs)
   const claimed = await prisma.autopilotTask.updateMany({
     where: {
+      deletedAt: null,
       id: task.id,
       ...(params.userId ? { userId: params.userId } : {}),
       ...claimAvailabilityWhere(params.now, concurrencyPolicy),


### PR DESCRIPTION
## Summary
- Implement future-facing soft delete for Autopilot tasks to preserve `autopilot_runs` rows
- Maintain session classification in workspace sidebar for archived tasks
- Add partial unique index on `(user_id, name)` that only applies to active tasks

## Changes
### Database
- Add `deleted_at` column to `autopilot_tasks` table (nullable)
- Remove legacy unique constraint on `(user_id, name)`
- Add partial unique index on `(user_id, name) WHERE deleted_at IS NULL`
- Manual migration SQL since Prisma cannot represent partial indexes
- Desktop SQLite schema updated to version 8 with equivalent DDL

### Service Layer (`src/lib/services/autopilot.ts`)
- Add `deletedAt: Date | null` to `AutopilotTaskRecord` type
- Update all task access methods to filter `deletedAt: null`:
  - `listTasksByUserId`
  - `findTaskByIdAndUserId`
  - `updateTaskByIdAndUserId`
  - `claimNextDueTask`
  - `claimTaskForImmediateRun`
- Change `deleteTaskByIdAndUserId` to soft delete:
  - Sets `deletedAt: new Date()`
  - Disables task (`enabled: false`)
  - Clears lease fields (`leaseOwner: null`, `leaseExpiresAt: null`)
  - Resets retry fields (`retryAttempt: 0`, `retryScheduledFor: null`)
- **Preserve** `findSessionMetadataByUserId` behavior (archived tasks still provide metadata)

### Tests
- Add comprehensive test coverage for soft delete behavior
- Test active filtering in all access methods
- Test soft delete sets archive fields correctly
- Test claim operations exclude deleted tasks
- Test metadata preservation for archived tasks
- Test desktop schema migration DDL

## Notes
- Does not backfill already-deleted tasks (explicit requirement)
- Partial unique index cannot be represented in Prisma schema, so it's only in migration SQL and desktop DDL
- `findSessionMetadataByUserId` intentionally not filtered to preserve session classification for archived tasks

## Migration Safety
- Forward-compatible (additive) migration: new nullable column, new index
- Does not require expand-contract pattern
- Legacy index is dropped first, then new partial index is created