### PR TITLE
fix(web): move prompt lifecycle to /chat/stream to prevent event race

### DIFF
--- a/apps/web/src/app/api/w/[slug]/chat/runs/__tests__/route.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/runs/__tests__/route.test.ts
@@ -144,132 +144,17 @@ describe('/api/w/[slug]/chat/runs', () => {
     }
   }
 
-  it('starts an OpenCode prompt under a durable run lock', async () => {
-    const fetchMock = vi.fn((url: string | URL) => {
-      const href = String(url)
-      if (href === 'http://test-slug:3000/session/s1/prompt_async') {
-        return Promise.resolve(new Response('', { status: 200 }))
-      }
-      return Promise.reject(new Error(`unexpected fetch ${href}`))
-    })
-    vi.stubGlobal('fetch', fetchMock)
-
-    const { POST } = await import('../route')
-    const res = await POST(postRequest({
-      sessionId: 's1',
-      text: 'Hi',
-      model: { providerId: 'openai', modelId: 'gpt-5.2' },
-    }), params())
-
-    expect(res.status).toBe(200)
-    await expect(res.json()).resolves.toEqual({
-      runId: 'run-1',
-      sessionId: 's1',
-      status: 'running',
-    })
-    expect(mocks.messageRunService.createActiveRunAfterRuntimeStateCheck).toHaveBeenCalledWith({
-      readRuntimeSessionState: expect.any(Function),
-      slug: 'alice',
-      sessionId: 's1',
-      source: 'web',
-    })
-    const promptCall = fetchMock.mock.calls.find(([url]) => String(url).endsWith('/session/s1/prompt_async'))
-    expect(promptCall).toBeDefined()
-    expect(JSON.parse(String(promptCall?.[1]?.body))).toEqual({
-      parts: [{ type: 'text', text: 'Hi' }],
-      model: { providerID: 'openai', modelID: 'gpt-5.2' },
-    })
-  })
-
-  it('sends built PDF and image attachment parts to prompt_async', async () => {
-    mocks.isPdfMime.mockImplementation((mime: string) => mime === 'application/pdf')
-    mocks.workspaceAgentFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        data: {
-          ok: true,
-          content: Buffer.from('pdf bytes').toString('base64'),
-          encoding: 'base64',
-        },
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        data: {
-          ok: true,
-          content: 'image bytes',
-          encoding: 'utf-8',
-        },
-      })
-    const fetchMock = vi.fn((url: string | URL) => {
-      const href = String(url)
-      if (href === 'http://test-slug:3000/session/s1/prompt_async') {
-        return Promise.resolve(new Response('', { status: 200 }))
-      }
-      return Promise.reject(new Error(`unexpected fetch ${href}`))
-    })
-    vi.stubGlobal('fetch', fetchMock)
-
-    const { POST } = await import('../route')
-    const res = await POST(postRequest({
-      sessionId: 's1',
-      text: 'Summarize these files',
-      attachments: [
-        { path: '.arche/attachments/report.pdf', filename: 'report.pdf', mime: 'application/pdf' },
-        { path: '.arche/attachments/screenshot.png', filename: 'screenshot.png', mime: 'image/png' },
-      ],
-    }), params())
-
-    expect(res.status).toBe(200)
-    const promptCall = fetchMock.mock.calls.find(([url]) => String(url).endsWith('/session/s1/prompt_async'))
-    const promptBody = JSON.parse(String(promptCall?.[1]?.body))
-
-    expect(promptBody.parts).toContainEqual({ type: 'text', text: 'Summarize these files' })
-    expect(promptBody.parts).toContainEqual({
-      type: 'file',
-      mime: 'image/png',
-      filename: 'screenshot.png',
-      url: `data:image/png;base64,${Buffer.from('image bytes').toString('base64')}`,
-    })
-    expect(promptBody.parts.some((part: { text?: string }) =>
-      part.text?.includes('Extracted text from attached PDF') && part.text.includes('PDF body'),
-    )).toBe(true)
-    expect(promptBody.parts.some((part: { text?: string }) =>
-      part.text?.includes('Attached workspace files:') && part.text.includes('/workspace/.arche/attachments/report.pdf'),
-    )).toBe(true)
-  })
-
-  it('rejects concurrent prompts without calling prompt_async', async () => {
-    mocks.messageRunService.createActiveRunAfterRuntimeStateCheck.mockImplementationOnce(async (params: {
-      readRuntimeSessionState: () => Promise<unknown>
-    }) => {
-      await params.readRuntimeSessionState()
-      return {
-        ok: false,
-        error: 'session_busy',
-        activeRun: {
-          id: 'run-active',
-          slug: 'alice',
-          sessionId: 's1',
-          source: 'web',
-          status: 'running',
-          error: null,
-          startedAt: new Date('2026-05-13T12:00:00.000Z'),
-          finishedAt: null,
-        },
-      }
-    })
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ s1: { type: 'busy' } }), { status: 200 }),
-    )
+  it('does not start prompts through POST because stream owns the lifecycle', async () => {
+    const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
 
     const { POST } = await import('../route')
     const res = await POST(postRequest({ sessionId: 's1', text: 'Hi' }), params())
 
-    expect(res.status).toBe(409)
-    const body = await res.json()
-    expect(body.error).toBe('session_busy')
-    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('http://test-slug:3000/session/status')
+    expect(res.status).toBe(410)
+    await expect(res.json()).resolves.toEqual({ error: 'prompt_start_moved_to_stream' })
+    expect(mocks.messageRunService.createActiveRunAfterRuntimeStateCheck).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('returns and clears no active run when OpenCode is already idle', async () => {
@@ -331,66 +216,13 @@ describe('/api/w/[slug]/chat/runs', () => {
     expect((await res.json()).activeRun.runId).toBe('run-1')
   })
 
-  it('returns 503 for active run checks and prompt starts without a running instance', async () => {
+  it('returns 503 for active run checks without a running instance', async () => {
     mocks.instanceService.findCredentialsBySlug.mockResolvedValue({ status: 'stopped', serverPassword: null })
     mocks.messageRunService.findActiveRun.mockResolvedValue(activeRun())
 
-    const { GET, POST } = await import('../route')
+    const { GET } = await import('../route')
     const getRes = await GET(getRequest('s1'), params())
-    const postRes = await POST(postRequest({ sessionId: 's1', text: 'Hi' }), params())
 
     expect(getRes.status).toBe(503)
-    expect(postRes.status).toBe(503)
-  })
-
-  it('validates POST bodies before starting runs', async () => {
-    const { POST } = await import('../route')
-
-    const invalidJson = await POST(new NextRequest('http://localhost/api/w/alice/chat/runs', {
-      method: 'POST',
-      body: 'not json{',
-      headers: { 'Content-Type': 'application/json' },
-    }), params())
-    expect(invalidJson.status).toBe(400)
-
-    const missing = await POST(postRequest({ sessionId: 's1' }), params())
-    expect(missing.status).toBe(400)
-
-    const tooManyAttachments = await POST(postRequest({
-      sessionId: 's1',
-      attachments: Array.from({ length: 11 }, (_, index) => ({ path: `.arche/attachments/${index}.txt` })),
-    }), params())
-    expect(tooManyAttachments.status).toBe(400)
-
-    mocks.isWorkspaceAttachmentPath.mockReturnValue(false)
-    const invalidAttachment = await POST(postRequest({
-      sessionId: 's1',
-      text: 'Hi',
-      attachments: [{ path: '/tmp/nope.txt' }],
-    }), params())
-    expect(invalidAttachment.status).toBe(400)
-    await expect(invalidAttachment.json()).resolves.toEqual({ error: 'invalid_attachment_path' })
-  })
-
-  it('marks runs failed when prompt startup fails', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
-
-    const { POST } = await import('../route')
-    const res = await POST(postRequest({ sessionId: 's1', text: 'Hi' }), params())
-
-    expect(res.status).toBe(502)
-    await expect(res.json()).resolves.toEqual({ error: 'network down' })
-    expect(mocks.messageRunService.markRunFailed).toHaveBeenCalledWith('run-1', 'network down')
-  })
-
-  it('marks runs failed when OpenCode rejects prompt startup', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('bad prompt', { status: 500 })))
-
-    const { POST } = await import('../route')
-    const res = await POST(postRequest({ sessionId: 's1', text: 'Hi' }), params())
-
-    expect(res.status).toBe(502)
-    await expect(res.json()).resolves.toEqual({ error: 'Failed to start message: bad prompt' })
-    expect(mocks.messageRunService.markRunFailed).toHaveBeenCalledWith('run-1', 'Failed to start message: bad prompt')
   })
 })

--- a/apps/web/src/app/api/w/[slug]/chat/runs/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/runs/route.ts
@@ -1,31 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { getInstanceUrl } from '@/lib/opencode/client'
-import {
-  buildWorkspacePromptParts,
-  normalizeContextPaths,
-  normalizeMessageAttachments,
-} from '@/lib/opencode/workspace-prompt'
-import { resolveRuntimeProviderId } from '@/lib/providers/catalog'
 import { withAuth } from '@/lib/runtime/with-auth'
 import { instanceService, messageRunService } from '@/lib/services'
 import type { ActiveRunRuntimeState, MessageRunRecord } from '@/lib/services/message-run'
 import { decryptPassword } from '@/lib/spawner/crypto'
-import { getWorkspaceAgentUrl } from '@/lib/workspace-agent/client'
-import { MAX_ATTACHMENTS_PER_MESSAGE } from '@/lib/workspace-attachments'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
-
-const PROMPT_START_TIMEOUT_MS = 60_000
-
-type StartPromptBody = {
-  sessionId?: string
-  text?: string
-  model?: { providerId: string; modelId: string }
-  attachments?: unknown
-  contextPaths?: unknown
-}
 
 function jsonErrorResponse(status: number, error: string) {
   return NextResponse.json({ error }, { status })
@@ -33,37 +15,6 @@ function jsonErrorResponse(status: number, error: string) {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
-}
-
-function getString(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined
-}
-
-function parseStartPromptBody(body: unknown): StartPromptBody {
-  if (!isRecord(body)) return {}
-
-  const model = isRecord(body.model)
-    ? {
-        providerId: getString(body.model.providerId) ?? '',
-        modelId: getString(body.model.modelId) ?? '',
-      }
-    : undefined
-
-  return {
-    sessionId: getString(body.sessionId),
-    text: getString(body.text),
-    model: model?.providerId && model.modelId ? model : undefined,
-    attachments: body.attachments,
-    contextPaths: body.contextPaths,
-  }
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === 'AbortError'
-}
-
-function isTimeoutError(error: unknown): boolean {
-  return error instanceof Error && error.name === 'TimeoutError'
 }
 
 function serializeRun(run: MessageRunRecord) {
@@ -119,7 +70,6 @@ async function getInstanceConnection(slug: string) {
   return {
     authHeader,
     baseUrl: getInstanceUrl(slug),
-    workspaceAgentUrl: getWorkspaceAgentUrl(slug),
   }
 }
 
@@ -162,103 +112,5 @@ export const GET = withAuth(
 
 export const POST = withAuth(
   { csrf: true },
-  async (request: NextRequest, { slug }) => {
-    const connection = await getInstanceConnection(slug)
-    if (!connection) {
-      return jsonErrorResponse(503, 'instance_unavailable')
-    }
-
-    let body: unknown
-    try {
-      body = await request.json()
-    } catch {
-      return jsonErrorResponse(400, 'invalid_json')
-    }
-
-    const input = parseStartPromptBody(body)
-    const sessionId = input.sessionId?.trim()
-    const attachments = normalizeMessageAttachments(input.attachments)
-    const contextPaths = normalizeContextPaths(input.contextPaths)
-
-    if (!sessionId || (!input.text && attachments.length === 0)) {
-      return jsonErrorResponse(400, 'missing_fields')
-    }
-
-    if (attachments.length > MAX_ATTACHMENTS_PER_MESSAGE) {
-      return jsonErrorResponse(400, 'too_many_attachments')
-    }
-
-    const prompt = await buildWorkspacePromptParts({
-      agent: { baseUrl: connection.workspaceAgentUrl, authHeader: connection.authHeader },
-      attachments,
-      contextPaths,
-      text: input.text,
-    })
-    if (!prompt.ok) {
-      return jsonErrorResponse(400, prompt.error)
-    }
-
-    const runResult = await messageRunService.createActiveRunAfterRuntimeStateCheck({
-      readRuntimeSessionState: () => readRuntimeSessionState({
-        authHeader: connection.authHeader,
-        baseUrl: connection.baseUrl,
-        sessionId,
-      }),
-      sessionId,
-      slug,
-      source: 'web',
-    })
-    if (!runResult.ok) {
-      return NextResponse.json(
-        {
-          error: 'session_busy',
-          activeRun: runResult.activeRun ? serializeRun(runResult.activeRun) : null,
-        },
-        { status: 409 },
-      )
-    }
-
-    const runId = runResult.run.id
-    const promptBody = {
-      parts: prompt.parts,
-      ...(input.model && {
-        model: {
-          providerID: resolveRuntimeProviderId(input.model.providerId),
-          modelID: input.model.modelId,
-        },
-      }),
-    }
-
-    const promptStartSignal = AbortSignal.timeout(PROMPT_START_TIMEOUT_MS)
-    let promptResponse: Response
-    try {
-      promptResponse = await fetch(`${connection.baseUrl}/session/${sessionId}/prompt_async`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: connection.authHeader,
-        },
-        body: JSON.stringify(promptBody),
-        signal: promptStartSignal,
-      })
-    } catch (error) {
-      const detail =
-        isTimeoutError(error) || (promptStartSignal.aborted && isAbortError(error))
-          ? 'prompt_start_timeout'
-          : error instanceof Error
-            ? error.message
-            : 'prompt_start_failed'
-      await messageRunService.markRunFailed(runId, detail)
-      return jsonErrorResponse(502, detail)
-    }
-
-    if (!promptResponse.ok) {
-      const errorText = await promptResponse.text()
-      const detail = `Failed to start message: ${errorText}`
-      await messageRunService.markRunFailed(runId, detail)
-      return jsonErrorResponse(502, detail)
-    }
-
-    return NextResponse.json({ runId, sessionId, status: 'running' })
-  },
+  async () => jsonErrorResponse(410, 'prompt_start_moved_to_stream'),
 )

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/route.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/route.test.ts
@@ -10,7 +10,9 @@ const mocks = vi.hoisted(() => ({
 
   instanceService: { findCredentialsBySlug: vi.fn() },
   messageRunService: {
+    createActiveRunAfterRuntimeStateCheck: vi.fn(),
     findRunById: vi.fn(),
+    markRunAborted: vi.fn(),
     markRunFailed: vi.fn(),
     markRunSucceeded: vi.fn(),
   },
@@ -153,6 +155,20 @@ describe('POST /api/w/[slug]/chat/stream', () => {
       startedAt: new Date(),
       finishedAt: null,
     })
+    mocks.messageRunService.createActiveRunAfterRuntimeStateCheck.mockResolvedValue({
+      ok: true,
+      run: {
+        id: 'run-started',
+        slug: 'alice',
+        sessionId: 's1',
+        source: 'web',
+        status: 'running',
+        error: null,
+        startedAt: new Date('2026-05-13T12:00:00.000Z'),
+        finishedAt: null,
+      },
+    })
+    mocks.messageRunService.markRunAborted.mockResolvedValue(undefined)
     mocks.messageRunService.markRunFailed.mockResolvedValue(undefined)
     mocks.messageRunService.markRunSucceeded.mockResolvedValue(undefined)
   })
@@ -170,6 +186,15 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     return new NextRequest(`http://localhost/api/w/${slug}/chat/stream`, {
       method: 'POST',
       body: JSON.stringify(requestBody),
+      headers: { 'Content-Type': 'application/json' },
+      signal,
+    })
+  }
+
+  function makeStartPostRequest(body: unknown, slug = 'alice', signal?: AbortSignal) {
+    return new NextRequest(`http://localhost/api/w/${slug}/chat/stream`, {
+      method: 'POST',
+      body: JSON.stringify(body),
       headers: { 'Content-Type': 'application/json' },
       signal,
     })
@@ -239,6 +264,34 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     expect(json.error).toBe('missing_fields')
   })
 
+  it('rejects too many attachments before creating a new run', async () => {
+    const { POST } = await import('../route')
+    const res = await POST(makeStartPostRequest({
+      sessionId: 's1',
+      attachments: Array.from({ length: 11 }, (_, index) => ({ path: `.arche/attachments/${index}.txt` })),
+    }), params())
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: 'too_many_attachments' })
+    expect(mocks.messageRunService.createActiveRunAfterRuntimeStateCheck).not.toHaveBeenCalled()
+  })
+
+  it('marks a new run failed when prompt building rejects an attachment', async () => {
+    mocks.isWorkspaceAttachmentPath.mockReturnValue(false)
+    vi.stubGlobal('fetch', vi.fn())
+
+    const { POST } = await import('../route')
+    const res = await POST(makeStartPostRequest({
+      sessionId: 's1',
+      text: 'Hi',
+      attachments: [{ path: '/tmp/nope.txt' }],
+    }), params())
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: 'invalid_attachment_path' })
+    expect(mocks.messageRunService.markRunFailed).toHaveBeenCalledWith('run-started', 'invalid_attachment_path')
+  })
+
   it('returns 404 when run is not found', async () => {
     mocks.messageRunService.findRunById.mockResolvedValue(null)
     const { POST } = await import('../route')
@@ -296,6 +349,226 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     const { POST } = await import('../route')
     const res = await POST(makePostRequest({ sessionId: 's1', text: 'hi' }), params())
     expect(res.status).toBe(401)
+  })
+
+  it('subscribes to events before starting a new prompt', async () => {
+    const calls: string[] = []
+    const fetchMock = vi.fn((url: string | URL, init?: RequestInit) => {
+      const href = String(url)
+      calls.push(`${init?.method ?? 'GET'} ${href}`)
+
+      if (href === 'http://test-slug:3000/event') {
+        return Promise.resolve(new Response(eventStream([
+          {
+            type: 'message.updated',
+            properties: { info: { id: 'm1', role: 'assistant', sessionID: 's1' } },
+          },
+          {
+            type: 'message.part.updated',
+            properties: { part: { id: 'p1', messageID: 'm1', sessionID: 's1', type: 'text' } },
+          },
+          { type: 'session.idle', properties: { info: { sessionID: 's1' } } },
+        ]), { status: 200 }))
+      }
+
+      if (href === 'http://test-slug:3000/session/s1/prompt_async') {
+        return Promise.resolve(new Response('', { status: 200 }))
+      }
+
+      return Promise.reject(new Error(`unexpected fetch ${init?.method ?? 'GET'} ${href}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    mocks.resolveRuntimeProviderId.mockImplementation((id: string) => `runtime:${id}`)
+
+    const { POST } = await import('../route')
+    const res = await POST(makeStartPostRequest({
+      sessionId: 's1',
+      text: 'Hi',
+      model: { providerId: 'openai', modelId: 'gpt-5.2' },
+    }), params())
+
+    await expect(res.text()).resolves.toContain('event: done')
+    expect(calls[0]).toBe('GET http://test-slug:3000/event')
+    expect(calls).toContain('POST http://test-slug:3000/session/s1/prompt_async')
+    expect(calls.indexOf('GET http://test-slug:3000/event')).toBeLessThan(
+      calls.indexOf('POST http://test-slug:3000/session/s1/prompt_async'),
+    )
+    expect(mocks.messageRunService.createActiveRunAfterRuntimeStateCheck).toHaveBeenCalledWith({
+      readRuntimeSessionState: expect.any(Function),
+      slug: 'alice',
+      sessionId: 's1',
+      source: 'web',
+    })
+    const promptCall = fetchMock.mock.calls.find(([url]) => String(url).endsWith('/session/s1/prompt_async'))
+    expect(JSON.parse(String(promptCall?.[1]?.body))).toEqual({
+      parts: [{ type: 'text', text: 'Hi' }],
+      model: { providerID: 'runtime:openai', modelID: 'gpt-5.2' },
+    })
+    expect(mocks.messageRunService.markRunSucceeded).toHaveBeenCalledWith('run-started')
+  })
+
+  it('sends built PDF and image attachment parts to prompt_async after subscribing', async () => {
+    mocks.isPdfMime.mockImplementation((mime: string) => mime === 'application/pdf')
+    mocks.extractPdfText.mockResolvedValue({ ok: true, text: 'PDF body', truncated: false })
+    mocks.workspaceAgentFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          ok: true,
+          content: Buffer.from('pdf bytes').toString('base64'),
+          encoding: 'base64',
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          ok: true,
+          content: 'image bytes',
+          encoding: 'utf-8',
+        },
+      })
+    const calls: string[] = []
+    const fetchMock = vi.fn((url: string | URL, init?: RequestInit) => {
+      const href = String(url)
+      calls.push(`${init?.method ?? 'GET'} ${href}`)
+
+      if (href === 'http://test-slug:3000/event') {
+        return Promise.resolve(new Response(eventStream([
+          {
+            type: 'message.updated',
+            properties: { info: { id: 'm1', role: 'assistant', sessionID: 's1' } },
+          },
+          {
+            type: 'message.part.updated',
+            properties: { part: { id: 'p1', messageID: 'm1', sessionID: 's1', type: 'text' } },
+          },
+          { type: 'session.idle', properties: { info: { sessionID: 's1' } } },
+        ]), { status: 200 }))
+      }
+
+      if (href === 'http://test-slug:3000/session/s1/prompt_async') {
+        return Promise.resolve(new Response('', { status: 200 }))
+      }
+
+      return Promise.reject(new Error(`unexpected fetch ${init?.method ?? 'GET'} ${href}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('../route')
+    const res = await POST(makeStartPostRequest({
+      sessionId: 's1',
+      text: 'Summarize these files',
+      attachments: [
+        { path: '.arche/attachments/report.pdf', filename: 'report.pdf', mime: 'application/pdf' },
+        { path: '.arche/attachments/screenshot.png', filename: 'screenshot.png', mime: 'image/png' },
+      ],
+    }), params())
+
+    await expect(res.text()).resolves.toContain('event: done')
+    expect(calls.indexOf('GET http://test-slug:3000/event')).toBeLessThan(
+      calls.indexOf('POST http://test-slug:3000/session/s1/prompt_async'),
+    )
+    const promptCall = fetchMock.mock.calls.find(([url]) => String(url).endsWith('/session/s1/prompt_async'))
+    const promptBody = JSON.parse(String(promptCall?.[1]?.body))
+
+    expect(promptBody.parts).toContainEqual({ type: 'text', text: 'Summarize these files' })
+    expect(promptBody.parts).toContainEqual({
+      type: 'file',
+      mime: 'image/png',
+      filename: 'screenshot.png',
+      url: `data:image/png;base64,${Buffer.from('image bytes').toString('base64')}`,
+    })
+    expect(promptBody.parts.some((part: { text?: string }) =>
+      part.text?.includes('Extracted text from attached PDF') && part.text.includes('PDF body'),
+    )).toBe(true)
+    expect(promptBody.parts.some((part: { text?: string }) =>
+      part.text?.includes('Attached workspace files:') && part.text.includes('/workspace/.arche/attachments/report.pdf'),
+    )).toBe(true)
+  })
+
+  it('rejects concurrent prompt starts without subscribing or calling prompt_async', async () => {
+    mocks.messageRunService.createActiveRunAfterRuntimeStateCheck.mockResolvedValueOnce({
+      ok: false,
+      error: 'session_busy',
+      activeRun: {
+        id: 'run-active',
+        slug: 'alice',
+        sessionId: 's1',
+        source: 'web',
+        status: 'running',
+        error: null,
+        startedAt: new Date('2026-05-13T12:00:00.000Z'),
+        finishedAt: null,
+      },
+    })
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('../route')
+    const res = await POST(makeStartPostRequest({ sessionId: 's1', text: 'Hi' }), params())
+
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toEqual({
+      error: 'session_busy',
+      activeRun: {
+        runId: 'run-active',
+        sessionId: 's1',
+        source: 'web',
+        status: 'running',
+        startedAt: '2026-05-13T12:00:00.000Z',
+      },
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('marks a new run failed when prompt startup fails after subscription', async () => {
+    const calls: string[] = []
+    const fetchMock = vi.fn((url: string | URL, init?: RequestInit) => {
+      const href = String(url)
+      calls.push(`${init?.method ?? 'GET'} ${href}`)
+
+      if (href === 'http://test-slug:3000/event') {
+        return Promise.resolve(new Response(new ReadableStream<Uint8Array>(), { status: 200 }))
+      }
+
+      if (href === 'http://test-slug:3000/session/s1/prompt_async') {
+        return Promise.resolve(new Response('bad prompt', { status: 500 }))
+      }
+
+      return Promise.reject(new Error(`unexpected fetch ${init?.method ?? 'GET'} ${href}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('../route')
+    const res = await POST(makeStartPostRequest({ sessionId: 's1', text: 'Hi' }), params())
+
+    await expect(res.text()).resolves.toContain('Failed to start message: bad prompt')
+    expect(calls.indexOf('GET http://test-slug:3000/event')).toBeLessThan(
+      calls.indexOf('POST http://test-slug:3000/session/s1/prompt_async'),
+    )
+    expect(mocks.messageRunService.markRunFailed).toHaveBeenCalledWith(
+      'run-started',
+      'Failed to start message: bad prompt',
+    )
+  })
+
+  it('marks a new run failed when the upstream event subscription fails', async () => {
+    vi.stubGlobal('fetch', vi.fn((url: string | URL) => {
+      if (String(url) === 'http://test-slug:3000/event') {
+        return Promise.resolve(new Response('', { status: 500 }))
+      }
+
+      return Promise.reject(new Error(`unexpected fetch ${String(url)}`))
+    }))
+
+    const { POST } = await import('../route')
+    const res = await POST(makeStartPostRequest({ sessionId: 's1', text: 'Hi' }), params())
+
+    await expect(res.text()).resolves.toContain('Failed to connect to event stream')
+    expect(mocks.messageRunService.markRunFailed).toHaveBeenCalledWith(
+      'run-started',
+      'event_stream_unavailable',
+    )
   })
 
   it('streams assistant status, parts, metadata, workspace updates, and completion', async () => {
@@ -534,6 +807,71 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     const res = await POST(makePostRequest({ sessionId: 's1', text: 'hi' }), params())
 
     await expect(res.text()).resolves.toContain('stream down')
+  })
+
+  it('keeps waiting through delegated silence while upstream is busy and finalizes once idle', async () => {
+    vi.useFakeTimers()
+    try {
+      const readStatus = vi.fn()
+        .mockResolvedValueOnce('busy')
+        .mockResolvedValueOnce('idle')
+      mocks.createUpstreamSessionStatusReader.mockReturnValue(readStatus)
+      mocks.getSilentStreamOutcome.mockImplementation(({ upstreamStatus }: { upstreamStatus: string | null }) => (
+        upstreamStatus === 'idle' ? 'finalize_idle' : 'keep_waiting'
+      ))
+      vi.stubGlobal('fetch', vi.fn((url: string | URL) => {
+        if (String(url) === 'http://test-slug:3000/event') {
+          return Promise.resolve(new Response(new ReadableStream<Uint8Array>(), { status: 200 }))
+        }
+
+        return Promise.reject(new Error(`unexpected fetch ${String(url)}`))
+      }))
+
+      const { POST } = await import('../route')
+      const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
+      const textPromise = res.text()
+
+      await vi.advanceTimersByTimeAsync(21_000)
+      expect(mocks.messageRunService.markRunFailed).not.toHaveBeenCalledWith('run-1', 'stream_timeout')
+
+      await vi.advanceTimersByTimeAsync(21_000)
+      const text = await textPromise
+
+      expect(text).toContain('event: done')
+      expect(text).not.toContain('stream_timeout')
+      expect(readStatus).toHaveBeenCalledTimes(2)
+      expect(mocks.messageRunService.markRunSucceeded).toHaveBeenCalledWith('run-1')
+      expect(mocks.messageRunService.markRunFailed).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('marks the run failed when the watchdog reports a real stream timeout', async () => {
+    vi.useFakeTimers()
+    try {
+      mocks.createUpstreamSessionStatusReader.mockReturnValue(vi.fn().mockResolvedValue(null))
+      mocks.getSilentStreamOutcome.mockReturnValue('stream_timeout')
+      vi.stubGlobal('fetch', vi.fn((url: string | URL) => {
+        if (String(url) === 'http://test-slug:3000/event') {
+          return Promise.resolve(new Response(new ReadableStream<Uint8Array>(), { status: 200 }))
+        }
+
+        return Promise.reject(new Error(`unexpected fetch ${String(url)}`))
+      }))
+
+      const { POST } = await import('../route')
+      const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
+      const textPromise = res.text()
+
+      await vi.advanceTimersByTimeAsync(21_000)
+      const text = await textPromise
+
+      expect(text).toContain('stream_timeout')
+      expect(mocks.messageRunService.markRunFailed).toHaveBeenCalledWith('run-1', 'stream_timeout')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('filters unrelated events and marks run failures from session errors', async () => {

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/route.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/route.test.ts
@@ -264,6 +264,17 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     expect(json.error).toBe('missing_fields')
   })
 
+  it('rejects prompt input when observing an existing run', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+
+    const { POST } = await import('../route')
+    const res = await POST(makeStartPostRequest({ sessionId: 's1', runId: 'run-1', text: 'ignored' }), params())
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: 'invalid_stream_payload' })
+    expect(mocks.messageRunService.findRunById).not.toHaveBeenCalled()
+  })
+
   it('rejects too many attachments before creating a new run', async () => {
     const { POST } = await import('../route')
     const res = await POST(makeStartPostRequest({
@@ -649,9 +660,7 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     const { POST } = await import('../route')
     const res = await POST(makePostRequest({
       sessionId: 's1',
-      text: 'Hi',
-      model: { providerId: 'openai', modelId: 'gpt-5.2' },
-      contextPaths: [' notes/a.md ', 'notes/a.md', 'invalid/../path'],
+      runId: 'run-1',
     }), params())
 
     const text = await res.text()
@@ -695,7 +704,7 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const { POST } = await import('../route')
-    const res = await POST(makePostRequest({ sessionId: 's1', text: 'Hi' }), params())
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
 
     const text = await res.text()
 
@@ -740,7 +749,7 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const { POST } = await import('../route')
-    const res = await POST(makePostRequest({ sessionId: 's1', text: 'Hi' }), params())
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
 
     const text = await res.text()
 
@@ -782,7 +791,7 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const { POST } = await import('../route')
-    const res = await POST(makePostRequest({ sessionId: 's1', text: 'Hi' }), params())
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
 
     const text = await res.text()
 
@@ -795,7 +804,7 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 500 })))
 
     const { POST } = await import('../route')
-    const res = await POST(makePostRequest({ sessionId: 's1', text: 'hi' }), params())
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
 
     await expect(res.text()).resolves.toContain('Failed to connect to event stream')
   })
@@ -804,7 +813,7 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('stream down')))
 
     const { POST } = await import('../route')
-    const res = await POST(makePostRequest({ sessionId: 's1', text: 'hi' }), params())
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
 
     await expect(res.text()).resolves.toContain('stream down')
   })
@@ -912,7 +921,7 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const { POST } = await import('../route')
-    const res = await POST(makePostRequest({ sessionId: 's1', text: 'Hi' }), params())
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
 
     const text = await res.text()
     expect(text).toContain('provider missing')

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/watchdog.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/watchdog.test.ts
@@ -69,16 +69,30 @@ describe('chat stream watchdog helpers', () => {
       })).toBe('keep_waiting')
     })
 
-    it('times out after extended silence even when upstream stays busy', () => {
+    it('keeps waiting through extended silence while upstream stays busy', () => {
       expect(getSilentStreamOutcome({
         upstreamStatus: 'busy',
         silentForMs: 60_000,
         relevantEventTimeoutMs: 20_000,
-      })).toBe('stream_timeout')
+        runtimeMs: 60_000,
+        maxRuntimeMs: 35 * 60 * 1000,
+      })).toBe('keep_waiting')
       expect(getSilentStreamOutcome({
         upstreamStatus: 'retry',
         silentForMs: 36_000,
         relevantEventTimeoutMs: 12_000,
+        runtimeMs: 36_000,
+        maxRuntimeMs: 35 * 60 * 1000,
+      })).toBe('keep_waiting')
+    })
+
+    it('times out only when the explicit max runtime is reached', () => {
+      expect(getSilentStreamOutcome({
+        upstreamStatus: 'busy',
+        silentForMs: 60_000,
+        relevantEventTimeoutMs: 20_000,
+        runtimeMs: 35 * 60 * 1000,
+        maxRuntimeMs: 35 * 60 * 1000,
       })).toBe('stream_timeout')
     })
 
@@ -87,6 +101,8 @@ describe('chat stream watchdog helpers', () => {
         upstreamStatus: 'idle',
         silentForMs: 20_000,
         relevantEventTimeoutMs: 20_000,
+        runtimeMs: 20_000,
+        maxRuntimeMs: 35 * 60 * 1000,
       })).toBe('finalize_idle')
     })
 
@@ -95,11 +111,15 @@ describe('chat stream watchdog helpers', () => {
         upstreamStatus: null,
         silentForMs: 20_000,
         relevantEventTimeoutMs: 20_000,
+        runtimeMs: 20_000,
+        maxRuntimeMs: 35 * 60 * 1000,
       })).toBe('stream_timeout')
       expect(getSilentStreamOutcome({
         upstreamStatus: 'complete',
         silentForMs: 20_000,
         relevantEventTimeoutMs: 20_000,
+        runtimeMs: 20_000,
+        maxRuntimeMs: 35 * 60 * 1000,
       })).toBe('stream_timeout')
     })
   })

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -205,6 +205,11 @@ export const POST = withAuth(
       text,
     } = streamBody
     const startsPrompt = !resume && !runId
+    const hasPromptInput = Boolean(text) || attachments.length > 0 || contextPaths.length > 0 || Boolean(model)
+
+    if (!startsPrompt && hasPromptInput) {
+      return jsonErrorResponse(400, 'invalid_stream_payload')
+    }
 
     if (attachments.length > MAX_ATTACHMENTS_PER_MESSAGE) {
       return jsonErrorResponse(400, 'too_many_attachments')
@@ -397,16 +402,11 @@ export const POST = withAuth(
         }
 
         if (startsPrompt) {
-          if (!promptBody) {
-            markRunFailed('missing_fields')
-            sendEvent('error', { error: 'missing_fields' })
-            await cancelReader()
-            return
-          }
-
           const promptStartSignal = AbortSignal.timeout(PROMPT_START_TIMEOUT_MS)
           let promptResponse: Response
           try {
+            // Once OpenCode receives the prompt it may keep running after navigation;
+            // keep the run resumable instead of marking it aborted on disconnect.
             promptStarted = true
             promptResponse = await fetch(`${baseUrl}/session/${sessionId}/prompt_async`, {
               method: 'POST',

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -3,11 +3,21 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getIdleFinalizationOutcome, getSilentStreamOutcome } from '@/app/api/w/[slug]/chat/stream/watchdog'
 import { createUpstreamSessionStatusReader } from '@/app/api/w/[slug]/chat/stream/status-reader'
 import { getInstanceUrl } from '@/lib/opencode/client'
-import { normalizeProviderId } from '@/lib/providers/catalog'
+import {
+  buildWorkspacePromptParts,
+  normalizeContextPaths,
+  normalizeMessageAttachments,
+  type MessageAttachmentInput,
+  type OpenCodePromptPart,
+} from '@/lib/opencode/workspace-prompt'
+import { normalizeProviderId, resolveRuntimeProviderId } from '@/lib/providers/catalog'
 import { withAuth } from '@/lib/runtime/with-auth'
 import { instanceService, messageRunService } from '@/lib/services'
+import { MESSAGE_RUN_TIMEOUT_MS, type ActiveRunRuntimeState } from '@/lib/services/message-run'
 import { INITIAL_SSE_PARSE_STATE, parseSseChunk } from '@/lib/sse-parser'
 import { decryptPassword } from '@/lib/spawner/crypto'
+import { getWorkspaceAgentUrl } from '@/lib/workspace-agent/client'
+import { MAX_ATTACHMENTS_PER_MESSAGE } from '@/lib/workspace-attachments'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -15,6 +25,23 @@ export const dynamic = 'force-dynamic'
 const STREAM_RELEVANT_EVENT_TICK_MS = 1000
 const SEND_STREAM_RELEVANT_EVENT_TIMEOUT_MS = 20_000
 const RESUME_STREAM_RELEVANT_EVENT_TIMEOUT_MS = 12_000
+const PROMPT_START_TIMEOUT_MS = 60_000
+
+type StreamRequestBody = {
+  attachments: MessageAttachmentInput[]
+  contextPaths: string[]
+  messageId?: string
+  model?: { providerId: string; modelId: string }
+  resume: boolean
+  runId?: string
+  sessionId: string
+  text?: string
+}
+
+type PromptBody = {
+  parts: OpenCodePromptPart[]
+  model?: { providerID: string; modelID: string }
+}
 
 function jsonErrorResponse(status: number, error: string) {
   return NextResponse.json({ error }, { status })
@@ -30,6 +57,10 @@ function getString(value: unknown): string | undefined {
 
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError'
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'TimeoutError'
 }
 
 function createSseResponse(events: Array<{ event: string; data: unknown }>): Response {
@@ -69,22 +100,63 @@ function createTerminalRunResponse(status: string, error: string | null): Respon
   ])
 }
 
-function parseObserveBody(body: unknown): {
-  sessionId: string
-  runId?: string
-  resume: boolean
-  messageId?: string
-} | null {
+function parseStreamRequestBody(body: unknown): StreamRequestBody | null {
   if (!isRecord(body)) return null
 
   const sessionId = getString(body.sessionId)
   if (!sessionId) return null
 
+  const model = isRecord(body.model)
+    ? {
+        providerId: getString(body.model.providerId) ?? '',
+        modelId: getString(body.model.modelId) ?? '',
+      }
+    : undefined
+
+  const text = typeof body.text === 'string' && body.text.trim().length > 0
+    ? body.text
+    : undefined
+
   return {
-    sessionId,
-    runId: getString(body.runId),
-    resume: body.resume === true,
+    attachments: normalizeMessageAttachments(body.attachments),
+    contextPaths: normalizeContextPaths(body.contextPaths),
     messageId: getString(body.messageId),
+    model: model?.providerId && model.modelId ? model : undefined,
+    resume: body.resume === true,
+    runId: getString(body.runId),
+    sessionId,
+    text,
+  }
+}
+
+async function readRuntimeSessionState(params: {
+  authHeader: string
+  baseUrl: string
+  sessionId: string
+}): Promise<ActiveRunRuntimeState> {
+  try {
+    const response = await fetch(`${params.baseUrl}/session/status`, {
+      headers: {
+        Authorization: params.authHeader,
+        Accept: 'application/json',
+      },
+      cache: 'no-store',
+    })
+    if (!response.ok) return 'unknown'
+
+    const data: unknown = await response.json()
+    if (!isRecord(data)) return 'unknown'
+
+    const statusRecord = data[params.sessionId]
+    if (!isRecord(statusRecord)) return 'idle'
+
+    const statusType = statusRecord.type
+    if (statusType === 'busy' || statusType === 'retry') return 'busy'
+    if (statusType === 'idle') return 'idle'
+
+    return 'unknown'
+  } catch {
+    return 'unknown'
   }
 }
 
@@ -117,12 +189,40 @@ export const POST = withAuth(
       return jsonErrorResponse(400, 'invalid_json')
     }
 
-    const observeBody = parseObserveBody(body)
-    if (!observeBody || (!observeBody.resume && !observeBody.runId)) {
+    const streamBody = parseStreamRequestBody(body)
+    if (!streamBody) {
       return jsonErrorResponse(400, 'missing_fields')
     }
 
-    const { sessionId, resume, messageId, runId } = observeBody
+    const {
+      attachments,
+      contextPaths,
+      messageId,
+      model,
+      resume,
+      runId,
+      sessionId,
+      text,
+    } = streamBody
+    const startsPrompt = !resume && !runId
+
+    if (attachments.length > MAX_ATTACHMENTS_PER_MESSAGE) {
+      return jsonErrorResponse(400, 'too_many_attachments')
+    }
+
+    if (startsPrompt && !text && attachments.length === 0) {
+      return jsonErrorResponse(400, 'missing_fields')
+    }
+
+    const password = decryptPassword(instance.serverPassword)
+    const authHeader = `Basic ${Buffer.from(`opencode:${password}`).toString('base64')}`
+    const baseUrl = getInstanceUrl(slug)
+    const workspaceAgentUrl = getWorkspaceAgentUrl(slug)
+
+    let activeRunId = runId ?? null
+    let runStartedAt = Date.now()
+    let promptBody: PromptBody | null = null
+
     if (runId) {
       const run = await messageRunService.findRunById(runId)
       if (!run || run.slug !== slug || run.sessionId !== sessionId) {
@@ -131,11 +231,63 @@ export const POST = withAuth(
       if (run.status !== 'running') {
         return createTerminalRunResponse(run.status, run.error)
       }
+      runStartedAt = run.startedAt.getTime()
     }
 
-    const password = decryptPassword(instance.serverPassword)
-    const authHeader = `Basic ${Buffer.from(`opencode:${password}`).toString('base64')}`
-    const baseUrl = getInstanceUrl(slug)
+    if (startsPrompt) {
+      const runResult = await messageRunService.createActiveRunAfterRuntimeStateCheck({
+        readRuntimeSessionState: () => readRuntimeSessionState({
+          authHeader,
+          baseUrl,
+          sessionId,
+        }),
+        sessionId,
+        slug,
+        source: 'web',
+      })
+
+      if (!runResult.ok) {
+        return NextResponse.json(
+          {
+            error: 'session_busy',
+            activeRun: runResult.activeRun
+              ? {
+                  runId: runResult.activeRun.id,
+                  sessionId: runResult.activeRun.sessionId,
+                  source: runResult.activeRun.source,
+                  status: runResult.activeRun.status,
+                  startedAt: runResult.activeRun.startedAt.toISOString(),
+                }
+              : null,
+          },
+          { status: 409 },
+        )
+      }
+
+      activeRunId = runResult.run.id
+      runStartedAt = runResult.run.startedAt.getTime()
+
+      const prompt = await buildWorkspacePromptParts({
+        agent: { baseUrl: workspaceAgentUrl, authHeader },
+        attachments,
+        contextPaths,
+        text,
+      })
+      if (!prompt.ok) {
+        await messageRunService.markRunFailed(activeRunId, prompt.error).catch(() => undefined)
+        return jsonErrorResponse(400, prompt.error)
+      }
+
+      promptBody = {
+        parts: prompt.parts,
+        ...(model && {
+          model: {
+            providerID: resolveRuntimeProviderId(model.providerId),
+            modelID: model.modelId,
+          },
+        }),
+      }
+    }
 
     // Create SSE stream
     const encoder = new TextEncoder()
@@ -150,12 +302,16 @@ export const POST = withAuth(
         // Shared reference so the abort path and finally block can always
         // clean up the active reader when it exists.
         let eventReader: ReadableStreamDefaultReader<Uint8Array> | null = null
+        let promptStarted = !startsPrompt
 
         const handleAbort = () => {
           clientGone = true
           aborted = true
           upstreamEventsController.abort()
           void eventReader?.cancel().catch(() => undefined)
+          if (startsPrompt && activeRunId && !promptStarted) {
+            void messageRunService.markRunAborted(activeRunId).catch(() => undefined)
+          }
           try { controller.close() } catch { /* already closed/errored */ }
         }
 
@@ -175,13 +331,13 @@ export const POST = withAuth(
         }
 
         const markRunSucceeded = () => {
-          if (!runId) return
-          void messageRunService.markRunSucceeded(runId).catch(() => undefined)
+          if (!activeRunId) return
+          void messageRunService.markRunSucceeded(activeRunId).catch(() => undefined)
         }
 
         const markRunFailed = (detail: string) => {
-          if (!runId) return
-          void messageRunService.markRunFailed(runId, detail).catch(() => undefined)
+          if (!activeRunId) return
+          void messageRunService.markRunFailed(activeRunId, detail).catch(() => undefined)
         }
 
         try {
@@ -209,6 +365,7 @@ export const POST = withAuth(
               })
 
               if (!eventsResponse.ok || !eventsResponse.body) {
+                markRunFailed('event_stream_unavailable')
                 sendEvent('error', { error: 'Failed to connect to event stream' })
                 return
               }
@@ -217,6 +374,7 @@ export const POST = withAuth(
               eventReader = reader
             } catch (error) {
               if (!clientGone && !isAbortError(error)) {
+                markRunFailed(error instanceof Error ? error.message : 'event_stream_unavailable')
                 sendEvent('error', {
                   error: error instanceof Error ? error.message : 'Unknown error'
                 })
@@ -232,6 +390,54 @@ export const POST = withAuth(
 
         if (!reader || clientGone || aborted) {
           return
+        }
+
+        const cancelReader = async () => {
+          await reader.cancel().catch(() => undefined)
+        }
+
+        if (startsPrompt) {
+          if (!promptBody) {
+            markRunFailed('missing_fields')
+            sendEvent('error', { error: 'missing_fields' })
+            await cancelReader()
+            return
+          }
+
+          const promptStartSignal = AbortSignal.timeout(PROMPT_START_TIMEOUT_MS)
+          let promptResponse: Response
+          try {
+            promptStarted = true
+            promptResponse = await fetch(`${baseUrl}/session/${sessionId}/prompt_async`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: authHeader,
+              },
+              body: JSON.stringify(promptBody),
+              signal: promptStartSignal,
+            })
+          } catch (error) {
+            const detail =
+              isTimeoutError(error) || (promptStartSignal.aborted && isAbortError(error))
+                ? 'prompt_start_timeout'
+                : error instanceof Error
+                  ? error.message
+                  : 'prompt_start_failed'
+            markRunFailed(detail)
+            sendEvent('error', { error: detail })
+            await cancelReader()
+            return
+          }
+
+          if (!promptResponse.ok) {
+            const errorText = await promptResponse.text()
+            const detail = `Failed to start message: ${errorText}`
+            markRunFailed(detail)
+            sendEvent('error', { error: detail })
+            await cancelReader()
+            return
+          }
         }
 
         // Track state for the assistant response
@@ -323,6 +529,8 @@ export const POST = withAuth(
 
                 const watchdogOutcome = getSilentStreamOutcome(
                   {
+                    maxRuntimeMs: MESSAGE_RUN_TIMEOUT_MS,
+                    runtimeMs: Date.now() - runStartedAt,
                     upstreamStatus: await readUpstreamSessionStatus(),
                     silentForMs: Date.now() - lastStreamActivityAt,
                     relevantEventTimeoutMs,
@@ -342,6 +550,7 @@ export const POST = withAuth(
 
                 emitStatus('error', undefined, 'stream_timeout')
                 sendEvent('error', { error: 'stream_timeout' })
+                markRunFailed('stream_timeout')
                 aborted = true
               }
               continue
@@ -745,6 +954,7 @@ export const POST = withAuth(
 
       } catch (error) {
         if (!aborted && !request.signal.aborted && !isAbortError(error)) {
+          markRunFailed(error instanceof Error ? error.message : 'stream_error')
           sendEvent('error', {
             error: error instanceof Error ? error.message : 'Unknown error'
           })

--- a/apps/web/src/app/api/w/[slug]/chat/stream/watchdog.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/watchdog.ts
@@ -6,8 +6,6 @@ export type IdleFinalizationOutcome =
 
 export type SilentStreamOutcome = 'finalize_idle' | 'keep_waiting' | 'stream_timeout'
 
-const SILENT_STREAM_TIMEOUT_MULTIPLIER = 3
-
 type IdleFinalizationInput = {
   resume: boolean
   assistantMessageSeen: boolean
@@ -15,6 +13,8 @@ type IdleFinalizationInput = {
 }
 
 type SilentStreamInput = {
+  maxRuntimeMs: number
+  runtimeMs: number
   upstreamStatus: string | null
   silentForMs: number
   relevantEventTimeoutMs: number
@@ -40,18 +40,16 @@ export function getIdleFinalizationOutcome({
   return 'complete'
 }
 
-export function getSilentStreamOutcome({
-  upstreamStatus,
-  silentForMs,
-  relevantEventTimeoutMs,
-}: SilentStreamInput): SilentStreamOutcome {
-  if (upstreamStatus === 'busy' || upstreamStatus === 'retry') {
-    return silentForMs < relevantEventTimeoutMs * SILENT_STREAM_TIMEOUT_MULTIPLIER
-      ? 'keep_waiting'
-      : 'stream_timeout'
+export function getSilentStreamOutcome(input: SilentStreamInput): SilentStreamOutcome {
+  if (input.runtimeMs >= input.maxRuntimeMs) {
+    return 'stream_timeout'
   }
 
-  if (upstreamStatus === 'idle') {
+  if (input.upstreamStatus === 'busy' || input.upstreamStatus === 'retry') {
+    return 'keep_waiting'
+  }
+
+  if (input.upstreamStatus === 'idle') {
     return 'finalize_idle'
   }
 

--- a/apps/web/src/hooks/__tests__/use-workspace-streaming.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-workspace-streaming.test.tsx
@@ -399,6 +399,62 @@ describe("useWorkspace streaming", () => {
 
       act(() => { sse.close(); });
     });
+
+    it("posts new prompt payloads directly to the stream endpoint", async () => {
+      const sse = createSSEStream();
+      let runsPostCount = 0;
+      let streamBody: Record<string, unknown> | null = null;
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          if (String(input) === "/api/u/alice/agents") {
+            return { ok: true, json: async () => ({ agents: DEFAULT_AGENTS }) };
+          }
+          if (String(input) === "/api/w/alice/chat/runs") {
+            runsPostCount += 1;
+            return { ok: true, json: async () => ({ runId: "run-1" }) };
+          }
+          if (String(input).startsWith("/api/w/alice/chat/runs?")) {
+            return { ok: true, json: async () => ({ activeRun: null }) };
+          }
+          if (String(input) === "/api/w/alice/chat/stream") {
+            streamBody = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+            return { ok: true, body: sse };
+          }
+          throw new Error(`Unexpected fetch: ${String(input)}`);
+        })
+      );
+
+      const result = await renderConnectedHook();
+
+      await act(async () => {
+        await result.current.sendMessage(
+          "hello",
+          { providerId: "openai", modelId: "gpt-5.2" },
+          {
+            attachments: [{ path: "docs/a.md", filename: "a.md", mime: "text/markdown" }],
+            contextPaths: ["docs/a.md"],
+          }
+        );
+      });
+
+      await waitFor(() => {
+        expect(streamBody).not.toBeNull();
+      });
+
+      expect(runsPostCount).toBe(0);
+      expect(streamBody).toEqual({
+        sessionId: "s1",
+        resume: false,
+        text: "hello",
+        model: { providerId: "openai", modelId: "gpt-5.2" },
+        attachments: [{ path: "docs/a.md", filename: "a.md", mime: "text/markdown" }],
+        contextPaths: ["docs/a.md"],
+      });
+
+      act(() => { sse.close(); });
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/apps/web/src/hooks/__tests__/use-workspace.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-workspace.test.tsx
@@ -483,14 +483,13 @@ describe("useWorkspace", () => {
         }
 
         if (String(input) === "/api/w/alice/chat/runs") {
-          requestBody = JSON.parse(String(init?.body ?? "{}")) as {
-            model?: { providerId: string; modelId: string };
-          };
           return { ok: true, json: async () => ({ runId: "run-1" }) };
         }
 
         if (String(input) === "/api/w/alice/chat/stream") {
-
+          requestBody = JSON.parse(String(init?.body ?? "{}")) as {
+            model?: { providerId: string; modelId: string };
+          };
           return {
             ok: true,
             body: {
@@ -579,15 +578,14 @@ describe("useWorkspace", () => {
         }
 
         if (String(input) === "/api/w/alice/chat/runs") {
-          requestBody = JSON.parse(String(init?.body ?? "{}")) as {
-            attachments?: Array<{ path: string; filename?: string; mime?: string }>;
-            contextPaths?: string[];
-          };
           return { ok: true, json: async () => ({ runId: "run-1" }) };
         }
 
         if (String(input) === "/api/w/alice/chat/stream") {
-
+          requestBody = JSON.parse(String(init?.body ?? "{}")) as {
+            attachments?: Array<{ path: string; filename?: string; mime?: string }>;
+            contextPaths?: string[];
+          };
           return {
             ok: true,
             body: {
@@ -677,14 +675,13 @@ describe("useWorkspace", () => {
         }
 
         if (String(input) === "/api/w/alice/chat/runs") {
-          requestBody = JSON.parse(String(init?.body ?? "{}")) as {
-            model?: { providerId: string; modelId: string };
-          };
           return { ok: true, json: async () => ({ runId: "run-1" }) };
         }
 
         if (String(input) === "/api/w/alice/chat/stream") {
-
+          requestBody = JSON.parse(String(init?.body ?? "{}")) as {
+            model?: { providerId: string; modelId: string };
+          };
           return {
             ok: true,
             body: {
@@ -788,14 +785,13 @@ describe("useWorkspace", () => {
         }
 
         if (String(input) === "/api/w/alice/chat/runs") {
-          requestBodies.push(JSON.parse(String(init?.body ?? "{}")) as {
-            model?: { providerId: string; modelId: string };
-          });
-          return { ok: true, json: async () => ({ runId: `run-${requestBodies.length}` }) };
+          return { ok: true, json: async () => ({ runId: `run-${requestBodies.length + 1}` }) };
         }
 
         if (String(input) === "/api/w/alice/chat/stream") {
-
+          requestBodies.push(JSON.parse(String(init?.body ?? "{}")) as {
+            model?: { providerId: string; modelId: string };
+          });
           return {
             ok: true,
             body: {

--- a/apps/web/src/hooks/workspace/use-workspace-streaming.ts
+++ b/apps/web/src/hooks/workspace/use-workspace-streaming.ts
@@ -453,7 +453,7 @@ export function useWorkspaceStreaming({
 
       let assistantMessageId: string | null =
         mode === "resume" ? targetMessageId : null;
-      let runId = existingRunId ?? null;
+      const runId = existingRunId ?? null;
       const bufferedParts = new Map<string, MessagePart[]>();
       const textAccumulatorByPart = new Map<string, string>();
       let streamCompleted = false;
@@ -563,41 +563,17 @@ export function useWorkspaceStreaming({
       };
 
       try {
-        if (mode === "send" && !runId) {
-          const startResponse = await fetch(`/api/w/${slug}/chat/runs`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              sessionId,
-              text,
-              model,
-              attachments,
-              contextPaths,
-            }),
-          });
-
-          if (!startResponse.ok) {
-            const error = await startResponse
-              .json()
-              .catch(() => ({ error: "Failed to start message" }));
-            throw new Error(error.error || "Failed to start message");
-          }
-
-          const started = await startResponse.json();
-          if (typeof started.runId !== "string" || started.runId.length === 0) {
-            throw new Error("missing_run_id");
-          }
-          runId = started.runId;
-        }
-
         const response = await fetch(`/api/w/${slug}/chat/stream`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             sessionId,
-            runId,
+            ...(runId ? { runId } : {}),
             resume: mode === "resume",
             messageId: mode === "resume" ? targetMessageId : undefined,
+            ...(mode === "send" && !runId
+              ? { text, model, attachments, contextPaths }
+              : {}),
           }),
           signal: abortController.signal,
         });

--- a/scripts/e2e/fake-runtime-server.mjs
+++ b/scripts/e2e/fake-runtime-server.mjs
@@ -428,8 +428,12 @@ function flushPendingEventBatches() {
 }
 
 function queuePromptEvents(session, userMessage, assistantMessage, assistantPartId, reply) {
+  const minEventClientGeneration = state.eventClients.size === 0
+    ? state.nextEventClientGeneration
+    : state.nextEventClientGeneration - 1
+
   state.pendingEventBatches.push({
-    minEventClientGeneration: state.nextEventClientGeneration,
+    minEventClientGeneration,
     session,
     events: [
       {


### PR DESCRIPTION
## Summary
- Fixed production bug where `POST /chat/runs` started `prompt_async` before `POST /chat/stream` subscribed to `/event`, causing missed early events
- Made `POST /chat/stream` the single owner of web prompt lifecycle to eliminate race conditions
- Fixed watchdog to properly handle long-running delegated tasks (no longer times out on `busy`/`retry` status)
- Removed competing prompt-start path from `POST /chat/runs` (now returns 410 `prompt_start_moved_to_stream`)
- Added comprehensive tests for subscribe-then-start flow, failures, delegated silence, timeout, validation, and concurrent runs

## Tests / Checks Run
- **Full test suite:** `pnpm test` from `apps/web/` — all tests pass
- **Linting:** `pnpm lint` from `apps/web/` — zero errors (16 existing warnings in unrelated test files)
- **Podman images:** `bash scripts/check-podman-images.sh` from repo root — web and workspace images build successfully

## Review Notes / Risks
- **Breaking change:** `POST /api/w/[slug]/chat/runs` no longer starts prompts; returns 410. Callers must use `POST /api/w/[slug]/chat/stream` instead.
- **Backward compatibility:** `GET /api/w/[slug]/chat/runs` remains unchanged for active-run lookup.
- **Concurrency:** New 409 `session_busy` rejection when another run is active on the session.
- **Watchdog behavior:** Max-runtime timeout (35 minutes) now enforced separately from silence detection, allowing legitimate long-running delegated tasks.

## Checklist
- [x] All tests pass locally (`pnpm test`)
- [x] Linter passes (`pnpm lint`)
- [x] Podman images build locally (`bash scripts/check-podman-images.sh`)
- [x] Commit follows Conventional Commits
- [x] No secrets committed (`.env`, credentials, keys)
- [x] Changes limited to requested scope (no unrelated refactors)
- [x] Imports use `@/` alias and follow ordering
- [ ] CI checks pass (to be verified after PR creation)