### PR TITLE
fix(web): use NextResponse for GitHub manifest route

### DIFF
--- a/apps/web/src/app/api/u/[slug]/kb-github-remote/manifest/route.ts
+++ b/apps/web/src/app/api/u/[slug]/kb-github-remote/manifest/route.ts
@@ -71,7 +71,7 @@ export async function GET(
 </body>
 </html>`
 
-  const response = new Response(html, {
+  const response = new NextResponse(html, {
     headers: { 'content-type': 'text/html;charset=utf-8' },
   })
   setKbGithubRemoteSetupCookie(response, state, request.headers)


### PR DESCRIPTION
## Summary
- Use `NextResponse` for the GitHub App manifest HTML response so setup cookies can be set during manifest creation.
- Fixes the production build type-check failure in `build-web / build-and-push (amd64)`.

## Verification
- `PATH=/opt/homebrew/bin:$PATH npx --yes pnpm@11.1.1 exec vitest run \"src/app/api/u/[slug]/kb-github-remote/manifest/__tests__/route.test.ts\"`
- `PATH=/opt/homebrew/bin:$PATH npx --yes pnpm@11.1.1 build`
- `PATH=/opt/homebrew/bin:$PATH npx --yes pnpm@11.1.1 test`
- `PATH=/opt/homebrew/bin:$PATH npx --yes pnpm@11.1.1 lint` (passes with existing warnings)
- `bash scripts/check-podman-images.sh`