### PR TITLE
fix(web): allow GitHub manifest redirect under CSP

### DIFF
--- a/apps/web/src/app/api/u/[slug]/kb-github-remote/manifest/__tests__/route.test.ts
+++ b/apps/web/src/app/api/u/[slug]/kb-github-remote/manifest/__tests__/route.test.ts
@@ -67,11 +67,15 @@ describe('GET /api/u/[slug]/kb-github-remote/manifest', () => {
   it('returns HTML form with organization GitHub App creation URL', async () => {
     const { GET } = await import('../route')
 
-    const response = await GET(request('/api/u/alice/kb-github-remote/manifest?owner=acme-org'), params())
+    const response = await GET(
+      request('/api/u/alice/kb-github-remote/manifest?owner=acme-org', { headers: { 'x-nonce': 'nonce-1' } }),
+      params(),
+    )
 
     expect(response.status).toBe(200)
     const body = await response.text()
     expect(body).toContain('<form method="post" action="https://github.com/organizations/acme-org/settings/apps/new?state=setup-state-1">')
+    expect(body).toContain('<script nonce="nonce-1">document.forms[0].submit()</script>')
     expect(body).toContain('https://example.com/api/u/alice/kb-github-remote/callback?state=setup-state-1')
   })
 

--- a/apps/web/src/app/api/u/[slug]/kb-github-remote/manifest/route.ts
+++ b/apps/web/src/app/api/u/[slug]/kb-github-remote/manifest/route.ts
@@ -10,6 +10,14 @@ import { getSession } from '@/lib/runtime/session'
 
 const GITHUB_OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/
 
+function escapeHtmlAttribute(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ slug: string }> },
@@ -60,6 +68,8 @@ export async function GET(
     : 'https://github.com/settings/apps/new'
 
   const escapedManifest = JSON.stringify(manifest).replace(/</g, '\\u003c')
+  const nonce = request.headers.get('x-nonce')
+  const scriptNonceAttribute = nonce ? ` nonce="${escapeHtmlAttribute(nonce)}"` : ''
   const html = `<!DOCTYPE html>
 <html>
 <head><meta charset="utf-8"><title>Redirecting to GitHub…</title></head>
@@ -67,7 +77,7 @@ export async function GET(
 <form method="post" action="${actionUrl}?state=${encodeURIComponent(state)}">
 <input type="hidden" name="manifest" value='${escapedManifest}'>
 </form>
-<script>document.forms[0].submit()</script>
+<script${scriptNonceAttribute}>document.forms[0].submit()</script>
 </body>
 </html>`
 


### PR DESCRIPTION
## Summary
- Add the middleware CSP nonce to the GitHub App manifest auto-submit script.
- Keeps the organization GitHub App manifest form flow working under the production nonce-based CSP.

## Verification
- `PATH=/opt/homebrew/bin:$PATH npx --yes pnpm@11.1.1 exec vitest run \"src/app/api/u/[slug]/kb-github-remote/manifest/__tests__/route.test.ts\"`
- `PATH=/opt/homebrew/bin:$PATH npx --yes pnpm@11.1.1 build`
- `PATH=/opt/homebrew/bin:$PATH npx --yes pnpm@11.1.1 lint` (passes with existing warnings)
- `PATH=/opt/homebrew/bin:$PATH npx --yes pnpm@11.1.1 test`
- `bash scripts/check-podman-images.sh`