### PR TITLE
fix(web): preserve public URL in GitHub KB redirects

### DIFF
--- a/apps/web/src/app/api/u/[slug]/kb-github-remote/callback/route.ts
+++ b/apps/web/src/app/api/u/[slug]/kb-github-remote/callback/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { auditEvent } from '@/lib/auth'
 import { verifyInstallation } from '@/lib/git/github-app-auth'
+import { getPublicBaseUrl } from '@/lib/http'
 import { requireKbGithubRemoteAdmin } from '@/lib/kb-github-remote/route-auth'
 import {
   clearKbGithubRemoteSetupCookie,
@@ -16,27 +17,27 @@ export async function GET(
 ): Promise<Response> {
   const { slug } = await params
   const setupSession = await getKbGithubRemoteSetupSession(request, slug)
-  if (!setupSession.ok) return redirectToManage(request.url, slug, setupSession.error)
+  if (!setupSession.ok) return redirectToManage(request, slug, setupSession.error)
 
   const admin = requireKbGithubRemoteAdmin(setupSession.user)
-  if (!admin.ok) return redirectToManage(request.url, slug, 'forbidden')
+  if (!admin.ok) return redirectToManage(request, slug, 'forbidden')
 
   const url = new URL(request.url)
   const installationIdRaw = url.searchParams.get('installation_id')
   const installationId = installationIdRaw ? Number(installationIdRaw) : NaN
   if (!Number.isSafeInteger(installationId) || installationId <= 0) {
-    return redirectToManage(request.url, slug, 'invalid_installation_id')
+    return redirectToManage(request, slug, 'invalid_installation_id')
   }
 
   const record = await kbGithubRemoteService.findIntegration()
   const config = kbGithubRemoteService.decryptIntegrationConfig(record)
   if (!config?.appId || !config.privateKey) {
-    return redirectToManage(request.url, slug, 'not_configured')
+    return redirectToManage(request, slug, 'not_configured')
   }
 
   const verification = await verifyInstallation(config.appId, config.privateKey, installationId)
   if (!verification.ok) {
-    return redirectToManage(request.url, slug, 'verification_failed')
+    return redirectToManage(request, slug, 'verification_failed')
   }
 
   await kbGithubRemoteService.saveInstallation({
@@ -50,7 +51,8 @@ export async function GET(
     metadata: { account: verification.account, installationId },
   })
 
-  const manageUrl = new URL(`/u/${slug}/settings/integrations/kb-github-remote`, request.url)
+  const baseUrl = getPublicBaseUrl(request.headers, request.url)
+  const manageUrl = new URL(`/u/${slug}/settings/integrations/kb-github-remote`, baseUrl)
   manageUrl.searchParams.set('installed', 'true')
   const response = NextResponse.redirect(manageUrl)
   setRestoredSessionCookie(response, setupSession.restoredSessionCookie, request.headers)
@@ -58,8 +60,9 @@ export async function GET(
   return response
 }
 
-function redirectToManage(requestUrl: string, slug: string, error: string): NextResponse {
-  const url = new URL(`/u/${slug}/settings/integrations/kb-github-remote`, requestUrl)
+function redirectToManage(request: NextRequest, slug: string, error: string): NextResponse {
+  const baseUrl = getPublicBaseUrl(request.headers, request.url)
+  const url = new URL(`/u/${slug}/settings/integrations/kb-github-remote`, baseUrl)
   url.searchParams.set('error', error)
   return NextResponse.redirect(url)
 }

--- a/apps/web/src/app/api/u/[slug]/kb-github-remote/manifest/__tests__/route.test.ts
+++ b/apps/web/src/app/api/u/[slug]/kb-github-remote/manifest/__tests__/route.test.ts
@@ -85,7 +85,7 @@ describe('GET /api/u/[slug]/kb-github-remote/manifest', () => {
     const response = await GET(request('/api/u/alice/kb-github-remote/manifest?owner=../bad'), params())
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe('http://localhost/u/alice/settings/integrations/kb-github-remote?error=invalid_owner')
+    expect(response.headers.get('location')).toBe('https://example.com/u/alice/settings/integrations/kb-github-remote?error=invalid_owner')
     expect(createKbGithubRemoteSetupStateMock).not.toHaveBeenCalled()
   })
 
@@ -93,10 +93,15 @@ describe('GET /api/u/[slug]/kb-github-remote/manifest', () => {
     getSessionMock.mockResolvedValue(null)
     const { GET } = await import('../route')
 
-    const response = await GET(request('/api/u/alice/kb-github-remote/manifest'), params())
+    const response = await GET(
+      request('/api/u/alice/kb-github-remote/manifest', {
+        headers: { 'x-forwarded-host': 'josemi.peaberry.studio', 'x-forwarded-proto': 'https' },
+      }),
+      params(),
+    )
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe('http://localhost/u/alice/settings/integrations/kb-github-remote?error=unauthorized')
+    expect(response.headers.get('location')).toBe('https://example.com/u/alice/settings/integrations/kb-github-remote?error=unauthorized')
   })
 
   it('redirects with forbidden for non-admin users', async () => {
@@ -106,6 +111,6 @@ describe('GET /api/u/[slug]/kb-github-remote/manifest', () => {
     const response = await GET(request('/api/u/alice/kb-github-remote/manifest'), params())
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe('http://localhost/u/alice/settings/integrations/kb-github-remote?error=forbidden')
+    expect(response.headers.get('location')).toBe('https://example.com/u/alice/settings/integrations/kb-github-remote?error=forbidden')
   })
 })

--- a/apps/web/src/app/api/u/[slug]/kb-github-remote/manifest/route.ts
+++ b/apps/web/src/app/api/u/[slug]/kb-github-remote/manifest/route.ts
@@ -25,24 +25,25 @@ export async function GET(
   const { slug } = await params
   const url = new URL(request.url)
   const owner = url.searchParams.get('owner')
+  const baseUrl = getPublicBaseUrl(request.headers, request.url)
 
   if (owner && !GITHUB_OWNER_PATTERN.test(owner)) {
     return NextResponse.redirect(
-      new URL(`/u/${slug}/settings/integrations/kb-github-remote?error=invalid_owner`, request.url),
+      new URL(`/u/${slug}/settings/integrations/kb-github-remote?error=invalid_owner`, baseUrl),
     )
   }
 
   const session = await getSession()
   if (!session) {
     return NextResponse.redirect(
-      new URL(`/u/${slug}/settings/integrations/kb-github-remote?error=unauthorized`, request.url),
+      new URL(`/u/${slug}/settings/integrations/kb-github-remote?error=unauthorized`, baseUrl),
     )
   }
 
   const admin = requireKbGithubRemoteAdmin(session.user)
   if (!admin.ok) {
     return NextResponse.redirect(
-      new URL(`/u/${slug}/settings/integrations/kb-github-remote?error=forbidden`, request.url),
+      new URL(`/u/${slug}/settings/integrations/kb-github-remote?error=forbidden`, baseUrl),
     )
   }
 
@@ -52,7 +53,6 @@ export async function GET(
     userId: session.user.id,
   })
 
-  const baseUrl = getPublicBaseUrl(request.headers, request.url)
   const manifest = {
     default_events: [],
     default_permissions: { contents: 'write', metadata: 'read' },

--- a/apps/web/src/app/api/u/[slug]/kb-github-remote/route.test.ts
+++ b/apps/web/src/app/api/u/[slug]/kb-github-remote/route.test.ts
@@ -228,10 +228,15 @@ describe('/api/u/[slug]/kb-github-remote/setup', () => {
   it('redirects back to management when the manifest code is missing', async () => {
     const { GET } = await import('./setup/route')
 
-    const response = await GET(request('/api/u/alice/kb-github-remote/setup'), params())
+    const response = await GET(
+      request('/api/u/alice/kb-github-remote/setup', {
+        headers: { 'x-forwarded-host': 'josemi.peaberry.studio', 'x-forwarded-proto': 'https' },
+      }),
+      params(),
+    )
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe('http://localhost/u/alice/settings/integrations/kb-github-remote?error=missing_code')
+    expect(response.headers.get('location')).toBe('https://josemi.peaberry.studio/u/alice/settings/integrations/kb-github-remote?error=missing_code')
   })
 
   it('redirects back to management when GitHub rejects the manifest code', async () => {
@@ -268,10 +273,15 @@ describe('/api/u/[slug]/kb-github-remote/callback', () => {
   it('verifies and stores the installation before redirecting to management', async () => {
     const { GET } = await import('./callback/route')
 
-    const response = await GET(request('/api/u/alice/kb-github-remote/callback?installation_id=123'), params())
+    const response = await GET(
+      request('/api/u/alice/kb-github-remote/callback?installation_id=123', {
+        headers: { 'x-forwarded-host': 'josemi.peaberry.studio', 'x-forwarded-proto': 'https' },
+      }),
+      params(),
+    )
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe('http://localhost/u/alice/settings/integrations/kb-github-remote?installed=true')
+    expect(response.headers.get('location')).toBe('https://josemi.peaberry.studio/u/alice/settings/integrations/kb-github-remote?installed=true')
     expect(verifyInstallationMock).toHaveBeenCalledWith('42', 'private-key', 123)
     expect(saveInstallationMock).toHaveBeenCalledWith({ account: 'acme', installationId: 123 })
   })

--- a/apps/web/src/app/api/u/[slug]/kb-github-remote/setup/route.ts
+++ b/apps/web/src/app/api/u/[slug]/kb-github-remote/setup/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { auditEvent } from '@/lib/auth'
 import { exchangeManifestCode } from '@/lib/git/github-app-auth'
+import { getPublicBaseUrl } from '@/lib/http'
 import { requireKbGithubRemoteAdmin } from '@/lib/kb-github-remote/route-auth'
 import {
   getKbGithubRemoteSetupSession,
@@ -15,20 +16,20 @@ export async function GET(
 ): Promise<Response> {
   const { slug } = await params
   const setupSession = await getKbGithubRemoteSetupSession(request, slug)
-  if (!setupSession.ok) return redirectToManage(request.url, slug, setupSession.error)
+  if (!setupSession.ok) return redirectToManage(request, slug, setupSession.error)
 
   const admin = requireKbGithubRemoteAdmin(setupSession.user)
-  if (!admin.ok) return redirectToManage(request.url, slug, 'forbidden')
+  if (!admin.ok) return redirectToManage(request, slug, 'forbidden')
 
   const url = new URL(request.url)
   const code = url.searchParams.get('code')
   if (!code) {
-    return redirectToManage(request.url, slug, 'missing_code')
+    return redirectToManage(request, slug, 'missing_code')
   }
 
   const result = await exchangeManifestCode(code)
   if (!result.ok) {
-    return redirectToManage(request.url, slug, 'exchange_failed')
+    return redirectToManage(request, slug, 'exchange_failed')
   }
 
   await kbGithubRemoteService.saveAppConfig({
@@ -52,8 +53,9 @@ export async function GET(
   return response
 }
 
-function redirectToManage(requestUrl: string, slug: string, error: string): NextResponse {
-  const url = new URL(`/u/${slug}/settings/integrations/kb-github-remote`, requestUrl)
+function redirectToManage(request: NextRequest, slug: string, error: string): NextResponse {
+  const baseUrl = getPublicBaseUrl(request.headers, request.url)
+  const url = new URL(`/u/${slug}/settings/integrations/kb-github-remote`, baseUrl)
   url.searchParams.set('error', error)
   return NextResponse.redirect(url)
 }


### PR DESCRIPTION
## Summary
- Use the public base URL resolver for GitHub KB remote management redirects instead of `request.url`.
- Prevent GitHub App setup and installation callbacks from redirecting users to internal `localhost:3000` URLs behind proxies.
- Cover proxied setup/callback redirects with `x-forwarded-host` and `x-forwarded-proto` regression tests.

## Verification
- `PATH=/opt/homebrew/bin:$PATH npx --yes pnpm@11.1.1 exec vitest run \"src/app/api/u/[slug]/kb-github-remote/route.test.ts\" \"src/app/api/u/[slug]/kb-github-remote/manifest/__tests__/route.test.ts\"`
- `PATH=/opt/homebrew/bin:$PATH npx --yes pnpm@11.1.1 build`
- `PATH=/opt/homebrew/bin:$PATH npx --yes pnpm@11.1.1 lint` (passes with existing warnings)
- `PATH=/opt/homebrew/bin:$PATH npx --yes pnpm@11.1.1 test`
- `bash scripts/check-podman-images.sh`