### PR TITLE
fix(scripts): clear all Next.js desktop artifacts in release

### DIFF
--- a/scripts/create-local-release.sh
+++ b/scripts/create-local-release.sh
@@ -248,7 +248,9 @@ clear_arch_build_artifacts() {
 
   printf '==> Clearing cached build artifacts for %s\n' "$arch"
 
-  rm -rf "$WEB_DIR/.next"
+  shopt -s nullglob
+  rm -rf "$WEB_DIR/.next" "$WEB_DIR"/.next-desktop*
+  shopt -u nullglob
   clear_web_native_artifacts
   rm -f "$DESKTOP_DIR/bin/node" "$DESKTOP_DIR/bin/opencode" "$DESKTOP_DIR/bin/workspace-agent"
 
@@ -333,6 +335,7 @@ build_web_for_arch() {
     cd "$WEB_DIR"
     PATH="$DESKTOP_DIR/bin:$PATH" \
       ARCHE_RUNTIME_MODE='desktop' \
+      ARCHE_DESKTOP_NEXT_DIST_DIR='' \
       ARCHE_DESKTOP_PLATFORM='darwin' \
       ARCHE_DESKTOP_WEB_HOST='127.0.0.1' \
       pnpm build


### PR DESCRIPTION
## Summary
- **Why**: Release builds failed due to stale Next.js desktop artifacts causing TypeScript validation errors after the `autopilot` → `flows` route migration
- **What**: Updated `clear_arch_build_artifacts` to clear all `.next-desktop*` directories and forced release builds to use default `.next` dist directory
- **Impact**: Fixes local release script failures caused by cached validator files referencing removed routes

## Tests/Checks Run
```bash
# Script syntax validation
bash -n scripts/create-local-release.sh
# ✓ Passed

# Desktop tests
cd apps/desktop && pnpm test
# ✓ 50 tests passed

# Web tests
cd apps/web && pnpm test
# ✓ 4422 tests passed (15 skipped)

# Linting
cd apps/web && pnpm lint
# ✓ 0 errors (16 existing warnings in unrelated test files)

# Podman image validation
bash scripts/check-podman-images.sh
# ✓ arche-web and arche-workspace images built successfully

# Desktop-mode build verification
rm -rf apps/web/.next apps/web/.next-desktop*
PATH="apps/desktop/bin:$PATH" \
  ARCHE_RUNTIME_MODE='desktop' \
  ARCHE_DESKTOP_NEXT_DIST_DIR='' \
  ARCHE_DESKTOP_PLATFORM='darwin' \
  ARCHE_DESKTOP_WEB_HOST='127.0.0.1' \
  pnpm build
# ✓ Build passed, no stale validator errors
```

## Review Notes
- Minimal change: 2 lines modified, 4 insertions, 1 deletion
- Uses existing script patterns: `nullglob` for safe glob expansion
- Consistent with repository conventions (no extra comments, SCREAMING_SNAKE_CASE env vars)
- The empty `ARCHE_DESKTOP_NEXT_DIST_DIR=''` ensures `next.config.ts` uses default `.next` output for release builds
- Desktop dev sessions (which set this env var to vault-specific directories like `.next-desktop-vault-*`) are unaffected

## Risks
- Low risk: Script changes are isolated to release build flow
- The glob pattern `.next-desktop*` matches the patterns in `tsconfig.json` lines 42-47 that include desktop dev artifacts
- If no `.next-desktop*` directories exist, `shopt -s nullglob` prevents errors

## Checklist
- [x] Tests pass locally
- [x] Linter passes locally
- [x] Changes follow repository conventions (no extra comments, minimal necessary change)
- [x] No secrets or sensitive data in changes
- [ ] CI checks passing
- [ ] Documentation updates (not required - internal script)
- [ ] Breaking changes considered (none - only internal release script)