### PR TITLE
fix(web): add cross-architecture native dependencies support

### DIFF
--- a/apps/web/pnpm-workspace.yaml
+++ b/apps/web/pnpm-workspace.yaml
@@ -19,6 +19,14 @@ allowBuilds:
   ssh2: false
   # ESLint's TypeScript import resolver uses this native resolver.
   unrs-resolver: true
+supportedArchitectures:
+  os:
+    - current
+    - darwin
+  cpu:
+    - current
+    - x64
+    - arm64
 overrides:
   tar: 7.5.7
   lodash: 4.17.23

--- a/apps/web/tests/native-dependencies.test.ts
+++ b/apps/web/tests/native-dependencies.test.ts
@@ -1,0 +1,20 @@
+import { readdirSync } from 'fs'
+import { resolve } from 'path'
+
+import { describe, expect, it } from 'vitest'
+
+const requiredDarwinNativePackages = ['lightningcss-darwin-arm64', 'lightningcss-darwin-x64']
+
+describe('native dependencies', () => {
+  it('installs lightningcss native packages for both macOS release architectures', () => {
+    const pnpmStorePath = resolve(process.cwd(), 'node_modules', '.pnpm')
+    const installedPackages = readdirSync(pnpmStorePath)
+
+    for (const packageName of requiredDarwinNativePackages) {
+      expect(
+        installedPackages.some((installedPackage) => installedPackage.startsWith(`${packageName}@`)),
+        `${packageName} is installed`,
+      ).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
- Adds `supportedArchitectures` to `apps/web/pnpm-workspace.yaml` to install optional native packages for both macOS x64 and arm64 architectures.
- Adds `apps/web/tests/native-dependencies.test.ts` to verify both lightningcss darwin architectures are installed.
- Fresh `pnpm install` now installs all required native packages for cross-architecture macOS releases.

**Tests/checks run:**
- `cd apps/web && pnpm test` - 452 test files passed, 3 skipped
- `cd apps/web && pnpm build` - Build succeeded
- `cd apps/web && pnpm lint` - Passed with existing warnings only, no errors
- `cd apps/web && pnpm exec vitest run tests/native-dependencies.test.ts` - Test passed

**Verified packages installed:**
- `lightningcss-darwin-arm64`
- `lightningcss-darwin-x64`
- `@next/swc-darwin-arm64`
- `@next/swc-darwin-x64`
- `@tailwindcss/oxide-darwin-arm64`
- `@tailwindcss/oxide-darwin-x64`
- `@img/sharp-darwin-arm64`
- `@img/sharp-darwin-x64`

**Review notes/risks:**
- Existing `node_modules` require fresh install to pick up new architecture configuration.
- Configuration increases disk usage by installing both architecture packages.
- No impact on development workflow for single-architecture builds.

**Checklist:**
- [x] Tests pass locally
- [x] Self-reviewed changes
- [x] No secrets committed
- [x] Follows AGENTS.md conventions
- [x] Conventional commit format used