### PR TITLE
fix(release): ensure fresh target-arch web native deps per build

### DIFF
--- a/apps/web/tests/native-dependencies.test.ts
+++ b/apps/web/tests/native-dependencies.test.ts
@@ -1,20 +1,59 @@
-import { readdirSync } from 'fs'
+import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
 import { describe, expect, it } from 'vitest'
 
 const requiredDarwinNativePackages = ['lightningcss-darwin-arm64', 'lightningcss-darwin-x64']
+const repoRoot = resolve(process.cwd(), '..', '..')
+const webRoot = process.cwd()
+
+function readRepoFile(path: string) {
+  return readFileSync(resolve(repoRoot, path), 'utf8')
+}
+
+function readWebFile(path: string) {
+  return readFileSync(resolve(webRoot, path), 'utf8')
+}
 
 describe('native dependencies', () => {
-  it('installs lightningcss native packages for both macOS release architectures', () => {
-    const pnpmStorePath = resolve(process.cwd(), 'node_modules', '.pnpm')
-    const installedPackages = readdirSync(pnpmStorePath)
+  it('configures pnpm to resolve optional native packages for both macOS release architectures', () => {
+    const workspaceConfig = readWebFile('pnpm-workspace.yaml')
+
+    expect(workspaceConfig).toMatch(/^supportedArchitectures:/m)
+    expect(workspaceConfig).toMatch(/^  os:\n(?:^    - .*\n)*^    - darwin$/m)
+    expect(workspaceConfig).toMatch(/^  cpu:\n(?:^    - .*\n)*^    - x64$/m)
+    expect(workspaceConfig).toMatch(/^  cpu:\n(?:^    - .*\n)*^    - arm64$/m)
+  })
+
+  it('locks lightningcss native packages for both macOS release architectures', () => {
+    const lockfile = readWebFile('pnpm-lock.yaml')
 
     for (const packageName of requiredDarwinNativePackages) {
-      expect(
-        installedPackages.some((installedPackage) => installedPackage.startsWith(`${packageName}@`)),
-        `${packageName} is installed`,
-      ).toBe(true)
+      expect(lockfile, `${packageName} has a package snapshot`).toMatch(
+        new RegExp(`^  ${packageName}@\\d+\\.\\d+\\.\\d+:$`, 'm'),
+      )
+      expect(lockfile, `${packageName} is linked from lightningcss optionalDependencies`).toMatch(
+        new RegExp(`^      ${packageName}: \\d+\\.\\d+\\.\\d+$`, 'm'),
+      )
     }
+  })
+
+  it('prepares fresh target-architecture web native dependencies before each release build', () => {
+    const releaseScript = readRepoFile('scripts/create-local-release.sh')
+    const clearArchFunctionIndex = releaseScript.indexOf('clear_arch_build_artifacts()')
+    const verifyFunctionIndex = releaseScript.indexOf('verify_web_native_dependencies_for_arch()')
+    const buildArchFunctionIndex = releaseScript.indexOf('build_arch()')
+    const nodeModulesResetIndex = releaseScript.indexOf('rm -rf "$WEB_DIR/node_modules"', clearArchFunctionIndex)
+    const syncCallIndex = releaseScript.indexOf('sync_web_dependencies_for_arch "$arch"', buildArchFunctionIndex)
+    const verifyCallIndex = releaseScript.indexOf('verify_web_native_dependencies_for_arch "$arch"', buildArchFunctionIndex)
+    const buildWebCallIndex = releaseScript.indexOf('build_web_for_arch "$arch"', buildArchFunctionIndex)
+
+    expect(clearArchFunctionIndex).toBeGreaterThan(-1)
+    expect(nodeModulesResetIndex).toBeGreaterThan(clearArchFunctionIndex)
+    expect(nodeModulesResetIndex).toBeLessThan(verifyFunctionIndex)
+    expect(verifyFunctionIndex).toBeGreaterThan(-1)
+    expect(syncCallIndex).toBeGreaterThan(buildArchFunctionIndex)
+    expect(verifyCallIndex).toBeGreaterThan(syncCallIndex)
+    expect(buildWebCallIndex).toBeGreaterThan(verifyCallIndex)
   })
 })

--- a/scripts/create-local-release.sh
+++ b/scripts/create-local-release.sh
@@ -252,6 +252,7 @@ clear_arch_build_artifacts() {
   rm -rf "$WEB_DIR/.next" "$WEB_DIR"/.next-desktop*
   shopt -u nullglob
   clear_web_native_artifacts
+  rm -rf "$WEB_DIR/node_modules"
   rm -f "$DESKTOP_DIR/bin/node" "$DESKTOP_DIR/bin/opencode" "$DESKTOP_DIR/bin/workspace-agent"
 
   case "$arch" in
@@ -327,6 +328,21 @@ sync_web_dependencies_for_arch() {
   )
 }
 
+verify_web_native_dependencies_for_arch() {
+  local arch="$1"
+
+  printf '==> Verifying web native dependencies for %s\n' "$arch"
+  verify_target_node_runtime "$arch"
+
+  (
+    cd "$WEB_DIR"
+    PATH="$DESKTOP_DIR/bin:$PATH" \
+      npm_config_arch="$arch" \
+      npm_config_target_arch="$arch" \
+      node -e 'require("@tailwindcss/postcss")'
+  ) || fail "Failed to load @tailwindcss/postcss with bundled $arch Node.js. Ensure web dependencies were installed after clearing node_modules for the target architecture."
+}
+
 build_web_for_arch() {
   local arch="$1"
 
@@ -382,6 +398,7 @@ build_arch() {
   clear_arch_build_artifacts "$arch"
   prepare_runtime_binaries_for_arch "$arch" "$runtime_platform" "$goarch"
   sync_web_dependencies_for_arch "$arch"
+  verify_web_native_dependencies_for_arch "$arch"
   build_web_for_arch "$arch"
   repair_web_standalone_symlinks
   sync_desktop_dependencies_for_arch "$arch"


### PR DESCRIPTION
## Summary

- **Why**: Local macOS release builds failed for x64 because optional native packages (e.g., `lightningcss-darwin-x64`) were not installed when `pnpm install` saw an existing `node_modules` and reported "Already up to date"
- **What**: Reset `apps/web/node_modules` before each architecture pass in the release script and add a preflight check that loads `@tailwindcss/postcss` with the bundled Node to verify native bindings are present
- **How**: Updated `clear_arch_build_artifacts` to delete `node_modules`, added `verify_web_native_dependencies_for_arch` that verifies `process.arch` and loads Tailwind, and adjusted `native-dependencies.test.ts` to check deterministic config/lockfile/script structure instead of installed state

## Tests and checks run

```bash
# From apps/web/
pnpm test                              # 452 passed | 3 skipped (4440 tests total)
/opt/homebrew/bin/pnpm lint            # 0 errors, 16 warnings (pre-existing)
bash -n scripts/create-local-release.sh
node -e 'require("@tailwindcss/postcss")'
bash scripts/check-podman-images.sh    # web and workspace images built successfully
```

## Review notes and risks

- **Risk**: This adds ~2–3 minutes per architecture build due to fresh `pnpm install` and native dependency rebuild. Trade-off: correct cross-arch builds vs. incremental install savings.
- **Scope**: Only touches release script and its associated test. No runtime behavior changes.
- **Stale branch cleanup**: `origin/fix/cross-arch-native-deps` (without `-dependencies`) is marked stale in `git remote show origin`; this PR uses the corrected name `fix/cross-arch-native-dependencies`.

## Checklist

- [x] All existing tests pass
- [x] New/adjusted tests verify config and script behavior (deterministic, not installed-state inspection)
- [ ] Code follows repo conventions (naming, imports, types, etc.)
- [x] Linter passes with no errors
- [x] Podman images build locally
- [x] Commit follows Conventional Commits format
- [x] No secrets or unrelated files committed