### PR TITLE
fix(ci): build arm64 images on native arm64 runner

### DIFF
--- a/.github/workflows/build-push-workspace.yml
+++ b/.github/workflows/build-push-workspace.yml
@@ -20,11 +20,15 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -35,9 +39,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.client_payload.ref || github.ref }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -109,16 +110,36 @@ jobs:
             ${{ steps.tags.outputs.MODE == 'main' && steps.tags.outputs.DEFAULT_ARCH_TAGS == 'true' && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}
             ${{ steps.tags.outputs.MODE == 'main' && steps.tags.outputs.DEFAULT_ARCH_TAGS == 'true' && format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, steps.tags.outputs.SHA_TAG) || '' }}
 
-      - name: Comment PR with image info
-        if: steps.tags.outputs.MODE == 'pr' && matrix.arch == 'amd64'
+  comment-pr:
+    name: Comment PR with image info
+    needs: build-and-push
+    if: github.event_name == 'repository_dispatch' || github.event.inputs.pr_number != ''
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Resolve PR number
+        id: pr
         run: |
-          IMAGE="$REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.PR_TAG }}"
-          ARM_IMAGE="$REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.PR_TAG }}-arm64"
-          BODY=$(printf '📦 **PR Workspace Image Built Successfully**\n\nDefault (amd64):\n```\n%s\n```\n\nOptional arm64:\n```\n%s\n```' "$IMAGE" "$ARM_IMAGE")
+          PR_NUM="${{ github.event.client_payload.pr_number || github.event.inputs.pr_number }}"
+          if [[ -z "$PR_NUM" ]]; then
+            echo "No PR number resolved" >&2
+            exit 1
+          fi
+          echo "PR_NUMBER=$PR_NUM" >> "$GITHUB_OUTPUT"
+          echo "PR_TAG=pr-$PR_NUM" >> "$GITHUB_OUTPUT"
+
+      - name: Comment PR with image info
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          IMAGE="$REGISTRY/$IMAGE_NAME:${{ steps.pr.outputs.PR_TAG }}"
+          ARM_IMAGE="$REGISTRY/$IMAGE_NAME:${{ steps.pr.outputs.PR_TAG }}-arm64"
+          BODY=$(printf '📦 **PR Workspace Image Built Successfully**\n\namd64 (default):\n```\n%s\n```\n\narm64:\n```\n%s\n```' "$IMAGE" "$ARM_IMAGE")
           PAYLOAD=$(jq -nc --arg body "$BODY" '{body: $body}')
 
           curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.tags.outputs.PR_NUMBER }}/comments" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.pr.outputs.PR_NUMBER }}/comments" \
             -d "$PAYLOAD"

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -20,11 +20,15 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -35,9 +39,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.client_payload.ref || github.ref }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -99,16 +100,36 @@ jobs:
             ${{ steps.tags.outputs.MODE == 'main' && steps.tags.outputs.DEFAULT_ARCH_TAGS == 'true' && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}
             ${{ steps.tags.outputs.MODE == 'main' && steps.tags.outputs.DEFAULT_ARCH_TAGS == 'true' && format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, steps.tags.outputs.SHA_TAG) || '' }}
 
-      - name: Comment PR with image info
-        if: steps.tags.outputs.MODE == 'pr' && matrix.arch == 'amd64'
+  comment-pr:
+    name: Comment PR with image info
+    needs: build-and-push
+    if: github.event_name == 'repository_dispatch' || github.event.inputs.pr_number != ''
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Resolve PR number
+        id: pr
         run: |
-          IMAGE="$REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.PR_TAG }}"
-          ARM_IMAGE="$REGISTRY/$IMAGE_NAME:${{ steps.tags.outputs.PR_TAG }}-arm64"
-          BODY=$(printf '📦 **PR Image Built Successfully**\n\nDefault (amd64):\n```\n%s\n```\n\nOptional arm64:\n```\n%s\n```' "$IMAGE" "$ARM_IMAGE")
+          PR_NUM="${{ github.event.client_payload.pr_number || github.event.inputs.pr_number }}"
+          if [[ -z "$PR_NUM" ]]; then
+            echo "No PR number resolved" >&2
+            exit 1
+          fi
+          echo "PR_NUMBER=$PR_NUM" >> "$GITHUB_OUTPUT"
+          echo "PR_TAG=pr-$PR_NUM" >> "$GITHUB_OUTPUT"
+
+      - name: Comment PR with image info
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          IMAGE="$REGISTRY/$IMAGE_NAME:${{ steps.pr.outputs.PR_TAG }}"
+          ARM_IMAGE="$REGISTRY/$IMAGE_NAME:${{ steps.pr.outputs.PR_TAG }}-arm64"
+          BODY=$(printf '📦 **PR Image Built Successfully**\n\namd64 (default):\n```\n%s\n```\n\narm64:\n```\n%s\n```' "$IMAGE" "$ARM_IMAGE")
           PAYLOAD=$(jq -nc --arg body "$BODY" '{body: $body}')
 
           curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.tags.outputs.PR_NUMBER }}/comments" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.pr.outputs.PR_NUMBER }}/comments" \
             -d "$PAYLOAD"


### PR DESCRIPTION
## Summary

Multi-arch image builds were introduced in #270 (April 2026), but **no `*-arm64` tag has ever been published to GHCR**. Every release since then has shipped without arm64, and the docs/`.env.example` files that tell users to pull `:latest-arm64` are silently broken:

```bash
$ docker pull ghcr.io/peaberry-studio/arche/web:latest-arm64
Error response from daemon: manifest unknown
$ docker pull ghcr.io/peaberry-studio/arche/workspace:latest-arm64
Error response from daemon: manifest unknown
```

Direct registry probe confirms zero `*-arm64` tags exist on either `peaberry-studio/arche/web` or `peaberry-studio/arche/workspace`:

```
latest-arm64 -> HTTP 404
v3.0.0-arm64 -> HTTP 404
v2.4.0-arm64 -> HTTP 404
```

**Root cause:** `.github/workflows/build-push.yml` and `build-push-workspace.yml` build the arm64 leg under QEMU on `ubuntu-latest`. The Next.js + Prisma build is OOM-ing / timing out under emulation, but `fail-fast: false` keeps the amd64 leg green, so release tags get cut and the failure is invisible unless you open the Actions UI.

## Changes

1. **Switch arm64 to a native runner.** Replace the QEMU-on-`ubuntu-latest` arm64 leg with GitHub's free public-repo `ubuntu-24.04-arm` runner. Drop the now-redundant `docker/setup-qemu-action@v3` step. Tag scheme is unchanged — `:latest`/`:vX.Y.Z` stay amd64-default and `-amd64`/`-arm64` suffix tags remain published, so no consumer pins need to change.
2. **Move the PR-image comment to its own job.** The existing comment step ran on the amd64 matrix leg unconditionally, so it always advertised an `-arm64` tag regardless of whether arm64 actually built. Moved it to a `comment-pr` job that `needs:` the full matrix, so the comment only appears when every arch published successfully. Rewrote the body from `"Optional arm64"` to plain `"arm64"` now that both arches are reliably built.

No code, docs, or `.env.example` changes were needed — the docs were already accurate in intent; the CI just wasn't delivering on them.

## Why native runner instead of a multi-arch manifest

Considered (option 1a from the issue): single buildx step pushing `--platform linux/amd64,linux/arm64` into one manifest list, dropping the arch suffixes. Rejected because:
- It would break every pinned `:vX.Y.Z-amd64` consumer that exists on GHCR today.
- Native arm64 builds are roughly 4-10x faster than QEMU emulation for the Next.js + Prisma image, which keeps release latency low.
- It's a strictly smaller diff.

## Why no change to `build-and-deploy.yml`

Re-checked the deploy flow. `deploy: needs: [build-web, build-workspace]` already correctly blocks deploy when any matrix entry fails — `fail-fast: false` only controls *cancellation* of sibling matrix entries, not the overall job result. The "silent release" described in the original issue happens on tag pushes (`v*.*.*`), which trigger `build-push.yml` directly and never involve `build-and-deploy.yml`. The git tag is created manually by a maintainer regardless of CI outcome, so the missing safeguard is really "don't let arm64 fail in the first place" — which this PR achieves.

## Test plan

- [ ] Re-run `Build & Push Web Image` and `Build & Push Workspace Image` workflows on this branch via `workflow_dispatch` and confirm both `amd64` and `arm64` matrix legs succeed.
- [ ] Confirm `actionlint` is clean (verified locally).
- [ ] After merge, cut a dry-run tag (or wait for the next release) and confirm:
  - `ghcr.io/peaberry-studio/arche/web:<tag>-arm64` exists.
  - `ghcr.io/peaberry-studio/arche/workspace:<tag>-arm64` exists.
  - `docker pull --platform linux/arm64 ghcr.io/peaberry-studio/arche/web:<tag>-arm64` works on an arm64 host.
- [ ] Trigger a PR-image build and confirm the comment now posts from the standalone `comment-pr` job with the updated wording, and that it only fires when both arches actually built.