### PR TITLE
fix(web): provider-org-credentials

### DIFF
--- a/apps/web/src/actions/__tests__/opencode-models.test.ts
+++ b/apps/web/src/actions/__tests__/opencode-models.test.ts
@@ -8,26 +8,33 @@ vi.mock('@/lib/opencode/client', () => ({
   createInstanceClient: vi.fn(),
 }))
 
-vi.mock('@/lib/prisma', () => ({
-  prisma: {
-    user: {
-      findUnique: vi.fn(),
-    },
+vi.mock('@/lib/services', () => ({
+  flowService: {},
+  instanceService: {},
+  messageRunService: {},
+  slackService: {},
+  userService: {
+    findIdBySlug: vi.fn(),
   },
 }))
 
 vi.mock('@/lib/providers/store', () => ({
-  getEffectiveCredentialForUser: vi.fn(),
+  getEnabledProviderIdsForUser: vi.fn(),
 }))
 
 import { getSession } from '@/lib/runtime/session'
 import { createInstanceClient } from '@/lib/opencode/client'
-import { getEffectiveCredentialForUser } from '@/lib/providers/store'
+import { getEnabledProviderIdsForUser } from '@/lib/providers/store'
+import type { ProviderId } from '@/lib/providers/types'
 import { listModelsAction } from '../opencode'
 
 const mockGetSession = vi.mocked(getSession)
 const mockCreateInstanceClient = vi.mocked(createInstanceClient)
-const mockGetEffectiveCredentialForUser = vi.mocked(getEffectiveCredentialForUser)
+const mockGetEnabledProviderIdsForUser = vi.mocked(getEnabledProviderIdsForUser)
+
+function enabledProviders(...providerIds: ProviderId[]): Set<ProviderId> {
+  return new Set(providerIds)
+}
 
 const providersResponse = {
   data: {
@@ -77,7 +84,7 @@ beforeEach(() => {
 
 describe('listModelsAction', () => {
   it('keeps OpenCode Zen models visible without stored credentials', async () => {
-    mockGetEffectiveCredentialForUser.mockResolvedValue(null)
+    mockGetEnabledProviderIdsForUser.mockResolvedValue(enabledProviders())
 
     const result = await listModelsAction('alice')
 
@@ -96,21 +103,7 @@ describe('listModelsAction', () => {
   })
 
   it('keeps paid providers gated behind active credentials', async () => {
-    mockGetEffectiveCredentialForUser.mockImplementation(async ({ providerId }) => {
-      if (providerId === 'openai') {
-        return {
-          source: 'user',
-          credential: {
-            id: 'cred-openai',
-            type: 'api',
-            secret: 'encrypted',
-            version: 1,
-          },
-        }
-      }
-
-      return null
-    })
+    mockGetEnabledProviderIdsForUser.mockResolvedValue(enabledProviders('openai'))
 
     const result = await listModelsAction('alice')
 
@@ -130,21 +123,7 @@ describe('listModelsAction', () => {
   })
 
   it('keeps paid OpenCode Zen models when an OpenCode credential is configured', async () => {
-    mockGetEffectiveCredentialForUser.mockImplementation(async ({ providerId }) => {
-      if (providerId === 'opencode') {
-        return {
-          source: 'user',
-          credential: {
-            id: 'cred-opencode',
-            type: 'api',
-            secret: 'encrypted',
-            version: 1,
-          },
-        }
-      }
-
-      return null
-    })
+    mockGetEnabledProviderIdsForUser.mockResolvedValue(enabledProviders('opencode'))
 
     const result = await listModelsAction('alice')
 
@@ -177,21 +156,7 @@ describe('listModelsAction', () => {
       },
     } as never)
 
-    mockGetEffectiveCredentialForUser.mockImplementation(async ({ providerId }) => {
-      if (providerId === 'openrouter') {
-        return {
-          source: 'organization',
-          credential: {
-            id: 'org-cred-openrouter',
-            type: 'api',
-            secret: 'encrypted',
-            version: 1,
-          },
-        }
-      }
-
-      return null
-    })
+    mockGetEnabledProviderIdsForUser.mockResolvedValue(enabledProviders('openrouter'))
 
     const result = await listModelsAction('alice')
 
@@ -225,21 +190,7 @@ describe('listModelsAction', () => {
       },
     } as never)
 
-    mockGetEffectiveCredentialForUser.mockImplementation(async ({ providerId }) => {
-      if (providerId === 'fireworks') {
-        return {
-          source: 'user',
-          credential: {
-            id: 'cred-fireworks',
-            type: 'api',
-            secret: 'encrypted',
-            version: 1,
-          },
-        }
-      }
-
-      return null
-    })
+    mockGetEnabledProviderIdsForUser.mockResolvedValue(enabledProviders('fireworks'))
 
     const result = await listModelsAction('alice')
 

--- a/apps/web/src/actions/__tests__/opencode-models.test.ts
+++ b/apps/web/src/actions/__tests__/opencode-models.test.ts
@@ -17,17 +17,17 @@ vi.mock('@/lib/prisma', () => ({
 }))
 
 vi.mock('@/lib/providers/store', () => ({
-  getActiveCredentialForUser: vi.fn(),
+  getEffectiveCredentialForUser: vi.fn(),
 }))
 
 import { getSession } from '@/lib/runtime/session'
 import { createInstanceClient } from '@/lib/opencode/client'
-import { getActiveCredentialForUser } from '@/lib/providers/store'
+import { getEffectiveCredentialForUser } from '@/lib/providers/store'
 import { listModelsAction } from '../opencode'
 
 const mockGetSession = vi.mocked(getSession)
 const mockCreateInstanceClient = vi.mocked(createInstanceClient)
-const mockGetActiveCredentialForUser = vi.mocked(getActiveCredentialForUser)
+const mockGetEffectiveCredentialForUser = vi.mocked(getEffectiveCredentialForUser)
 
 const providersResponse = {
   data: {
@@ -77,7 +77,7 @@ beforeEach(() => {
 
 describe('listModelsAction', () => {
   it('keeps OpenCode Zen models visible without stored credentials', async () => {
-    mockGetActiveCredentialForUser.mockResolvedValue(null)
+    mockGetEffectiveCredentialForUser.mockResolvedValue(null)
 
     const result = await listModelsAction('alice')
 
@@ -96,13 +96,16 @@ describe('listModelsAction', () => {
   })
 
   it('keeps paid providers gated behind active credentials', async () => {
-    mockGetActiveCredentialForUser.mockImplementation(async ({ providerId }) => {
+    mockGetEffectiveCredentialForUser.mockImplementation(async ({ providerId }) => {
       if (providerId === 'openai') {
         return {
-          id: 'cred-openai',
-          type: 'api',
-          secret: 'encrypted',
-          version: 1,
+          source: 'user',
+          credential: {
+            id: 'cred-openai',
+            type: 'api',
+            secret: 'encrypted',
+            version: 1,
+          },
         }
       }
 
@@ -127,13 +130,16 @@ describe('listModelsAction', () => {
   })
 
   it('keeps paid OpenCode Zen models when an OpenCode credential is configured', async () => {
-    mockGetActiveCredentialForUser.mockImplementation(async ({ providerId }) => {
+    mockGetEffectiveCredentialForUser.mockImplementation(async ({ providerId }) => {
       if (providerId === 'opencode') {
         return {
-          id: 'cred-opencode',
-          type: 'api',
-          secret: 'encrypted',
-          version: 1,
+          source: 'user',
+          credential: {
+            id: 'cred-opencode',
+            type: 'api',
+            secret: 'encrypted',
+            version: 1,
+          },
         }
       }
 
@@ -147,6 +153,52 @@ describe('listModelsAction', () => {
       expect.arrayContaining([
         expect.objectContaining({ providerId: 'opencode', modelId: 'scene-free' }),
         expect.objectContaining({ providerId: 'opencode', modelId: 'scene-paid' }),
+      ]),
+    )
+  })
+
+  it('includes models from organization credentials when user has no override', async () => {
+    mockCreateInstanceClient.mockResolvedValue({
+      config: {
+        providers: vi.fn().mockResolvedValue({
+          data: {
+            providers: [
+              {
+                id: 'openrouter',
+                name: 'OpenRouter',
+                models: {
+                  'openrouter/auto': { name: 'OpenRouter Auto' },
+                },
+              },
+            ],
+            default: {},
+          },
+        }),
+      },
+    } as never)
+
+    mockGetEffectiveCredentialForUser.mockImplementation(async ({ providerId }) => {
+      if (providerId === 'openrouter') {
+        return {
+          source: 'organization',
+          credential: {
+            id: 'org-cred-openrouter',
+            type: 'api',
+            secret: 'encrypted',
+            version: 1,
+          },
+        }
+      }
+
+      return null
+    })
+
+    const result = await listModelsAction('alice')
+
+    expect(result.ok).toBe(true)
+    expect(result.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ providerId: 'openrouter', modelId: 'openrouter/auto' }),
       ]),
     )
   })
@@ -173,13 +225,16 @@ describe('listModelsAction', () => {
       },
     } as never)
 
-    mockGetActiveCredentialForUser.mockImplementation(async ({ providerId }) => {
+    mockGetEffectiveCredentialForUser.mockImplementation(async ({ providerId }) => {
       if (providerId === 'fireworks') {
         return {
-          id: 'cred-fireworks',
-          type: 'api',
-          secret: 'encrypted',
-          version: 1,
+          source: 'user',
+          credential: {
+            id: 'cred-fireworks',
+            type: 'api',
+            secret: 'encrypted',
+            version: 1,
+          },
         }
       }
 

--- a/apps/web/src/actions/__tests__/opencode.test.ts
+++ b/apps/web/src/actions/__tests__/opencode.test.ts
@@ -37,6 +37,7 @@ vi.mock('@/lib/providers/catalog', () => ({
 
 vi.mock('@/lib/providers/store', () => ({
   getActiveCredentialForUser: vi.fn(),
+  getEffectiveCredentialForUser: vi.fn(),
 }))
 
 vi.mock('@/lib/services', () => ({

--- a/apps/web/src/actions/__tests__/opencode.test.ts
+++ b/apps/web/src/actions/__tests__/opencode.test.ts
@@ -36,8 +36,7 @@ vi.mock('@/lib/providers/catalog', () => ({
 }))
 
 vi.mock('@/lib/providers/store', () => ({
-  getActiveCredentialForUser: vi.fn(),
-  getEffectiveCredentialForUser: vi.fn(),
+  getEnabledProviderIdsForUser: vi.fn(),
 }))
 
 vi.mock('@/lib/services', () => ({

--- a/apps/web/src/actions/opencode.ts
+++ b/apps/web/src/actions/opencode.ts
@@ -17,7 +17,7 @@ import {
   normalizeProviderId,
   resolveRuntimeProviderId,
 } from "@/lib/providers/catalog";
-import { getActiveCredentialForUser } from "@/lib/providers/store";
+import { getEffectiveCredentialForUser } from "@/lib/providers/store";
 import { PROVIDERS, type ProviderId } from "@/lib/providers/types";
 import { getSession } from "@/lib/runtime/session";
 import { flowService, instanceService, messageRunService, slackService, userService } from "@/lib/services";
@@ -1161,11 +1161,11 @@ export async function listModelsAction(slug: string): Promise<{
 
   const enabledProviderIds = new Set<ProviderId>();
   for (const providerId of PROVIDERS) {
-    const credential = await getActiveCredentialForUser({
+    const effectiveCredential = await getEffectiveCredentialForUser({
       userId: ownerUserId,
       providerId,
     });
-    if (credential) enabledProviderIds.add(providerId);
+    if (effectiveCredential) enabledProviderIds.add(providerId);
   }
 
   try {

--- a/apps/web/src/actions/opencode.ts
+++ b/apps/web/src/actions/opencode.ts
@@ -17,8 +17,8 @@ import {
   normalizeProviderId,
   resolveRuntimeProviderId,
 } from "@/lib/providers/catalog";
-import { getEffectiveCredentialForUser } from "@/lib/providers/store";
-import { PROVIDERS, type ProviderId } from "@/lib/providers/types";
+import { getEnabledProviderIdsForUser } from "@/lib/providers/store";
+import type { ProviderId } from "@/lib/providers/types";
 import { getSession } from "@/lib/runtime/session";
 import { flowService, instanceService, messageRunService, slackService, userService } from "@/lib/services";
 import { decryptPassword } from "@/lib/spawner/crypto";
@@ -1159,14 +1159,7 @@ export async function listModelsAction(slug: string): Promise<{
   const client = await createInstanceClient(slug);
   if (!client) return { ok: false, error: "instance_unavailable" };
 
-  const enabledProviderIds = new Set<ProviderId>();
-  for (const providerId of PROVIDERS) {
-    const effectiveCredential = await getEffectiveCredentialForUser({
-      userId: ownerUserId,
-      providerId,
-    });
-    if (effectiveCredential) enabledProviderIds.add(providerId);
-  }
+  const enabledProviderIds = await getEnabledProviderIdsForUser(ownerUserId);
 
   try {
     const result = await client.config.providers();

--- a/apps/web/src/lib/opencode/__tests__/providers.test.ts
+++ b/apps/web/src/lib/opencode/__tests__/providers.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // Mock provider store
 vi.mock('@/lib/providers/store', () => ({
-  getEffectiveCredentialForUser: vi.fn(),
+  getEnabledProviderCredentialsForUser: vi.fn(),
 }))
 
 vi.mock('@/lib/opencode/client', () => ({
@@ -27,16 +27,29 @@ vi.mock('@/lib/providers/tokens', () => ({
 
 import { getInstanceBasicAuth } from '@/lib/opencode/client'
 import { getGatewayTokenTtlSeconds } from '@/lib/providers/config'
-import { getEffectiveCredentialForUser } from '@/lib/providers/store'
+import { getEnabledProviderCredentialsForUser, type EnabledProviderCredentials } from '@/lib/providers/store'
+import type { ProviderId } from '@/lib/providers/types'
 import { instanceService } from '@/lib/services'
 import { issueGatewayToken } from '@/lib/providers/tokens'
 import { ensureProviderAccessFreshForExecution, getProviderSyncHashForUser, syncProviderAccessForInstance } from '../providers'
 
 const mockGetInstanceBasicAuth = vi.mocked(getInstanceBasicAuth)
 const mockGetGatewayTokenTtlSeconds = vi.mocked(getGatewayTokenTtlSeconds)
-const mockGetCredential = vi.mocked(getEffectiveCredentialForUser)
+const mockGetEnabledCredentials = vi.mocked(getEnabledProviderCredentialsForUser)
 const mockInstanceService = vi.mocked(instanceService)
 const mockIssueToken = vi.mocked(issueGatewayToken)
+
+type TestEnabledProviderCredential = {
+  credentialId: string
+  source: 'user' | 'organization'
+  version: number
+}
+
+function enabledCredentials(
+  entries: Array<[ProviderId, TestEnabledProviderCredential]> = [],
+): EnabledProviderCredentials {
+  return new Map(entries)
+}
 
 const fakeInstance = {
   baseUrl: 'http://opencode-alice:4096',
@@ -62,11 +75,10 @@ describe('syncProviderAccessForInstance', () => {
 
     // openai enabled, anthropic enabled, fireworks/openrouter disabled,
     // opencode gets a gateway token even without a stored credential.
-    mockGetCredential.mockImplementation(async ({ providerId }) => {
-      if (providerId === 'openai') return { source: 'user', credential: { id: '1', version: 1 } } as never
-      if (providerId === 'anthropic') return { source: 'organization', credential: { id: '2', version: 2 } } as never
-      return null
-    })
+    mockGetEnabledCredentials.mockResolvedValue(enabledCredentials([
+      ['openai', { credentialId: '1', source: 'user', version: 1 }],
+      ['anthropic', { credentialId: '2', source: 'organization', version: 2 }],
+    ]))
 
     const result = await syncProviderAccessForInstance({
       instance: fakeInstance,
@@ -123,7 +135,7 @@ describe('syncProviderAccessForInstance', () => {
 
   it('disposes instance by default', async () => {
     const mockFetch = vi.mocked(globalThis.fetch)
-    mockGetCredential.mockResolvedValue(null)
+    mockGetEnabledCredentials.mockResolvedValue(enabledCredentials())
 
     await syncProviderAccessForInstance({
       instance: fakeInstance,
@@ -142,7 +154,7 @@ describe('syncProviderAccessForInstance', () => {
 
   it('skips dispose when disposeInstance is false', async () => {
     const mockFetch = vi.mocked(globalThis.fetch)
-    mockGetCredential.mockResolvedValue(null)
+    mockGetEnabledCredentials.mockResolvedValue(enabledCredentials())
 
     await syncProviderAccessForInstance({
       instance: fakeInstance,
@@ -163,7 +175,9 @@ describe('syncProviderAccessForInstance', () => {
   it('returns sync_failed on network error', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')))
 
-    mockGetCredential.mockResolvedValue({ source: 'user', credential: { id: '1', version: 1 } } as never)
+    mockGetEnabledCredentials.mockResolvedValue(enabledCredentials([
+      ['openai', { credentialId: '1', source: 'user', version: 1 }],
+    ]))
 
     const result = await syncProviderAccessForInstance({
       instance: fakeInstance,
@@ -180,7 +194,9 @@ describe('syncProviderAccessForInstance', () => {
       vi.fn().mockResolvedValueOnce(new Response('boom', { status: 500 }))
     )
 
-    mockGetCredential.mockResolvedValue({ source: 'user', credential: { id: '1', version: 1 } } as never)
+    mockGetEnabledCredentials.mockResolvedValue(enabledCredentials([
+      ['openai', { credentialId: '1', source: 'user', version: 1 }],
+    ]))
 
     const result = await syncProviderAccessForInstance({
       instance: fakeInstance,
@@ -192,7 +208,7 @@ describe('syncProviderAccessForInstance', () => {
   })
 
   it('uses the provided instance auth, not a DB lookup', async () => {
-    mockGetCredential.mockResolvedValue(null)
+    mockGetEnabledCredentials.mockResolvedValue(enabledCredentials())
     const mockFetch = vi.mocked(globalThis.fetch)
 
     await syncProviderAccessForInstance({
@@ -212,7 +228,7 @@ describe('syncProviderAccessForInstance', () => {
 
   it('returns success when provider sync state persistence fails after auth succeeds', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-    mockGetCredential.mockResolvedValue(null)
+    mockGetEnabledCredentials.mockResolvedValue(enabledCredentials())
     mockInstanceService.setProviderSyncState.mockRejectedValue(new Error('db unavailable'))
 
     const result = await syncProviderAccessForInstance({
@@ -231,10 +247,9 @@ describe('syncProviderAccessForInstance', () => {
   })
 
   it('skips provider sync refresh when the running instance already matches the expected hash', async () => {
-    mockGetCredential.mockImplementation(async ({ providerId }) => {
-      if (providerId === 'openai') return { source: 'organization', credential: { id: 'org-1', version: 3 } } as never
-      return null
-    })
+    mockGetEnabledCredentials.mockResolvedValue(enabledCredentials([
+      ['openai', { credentialId: 'org-1', source: 'organization', version: 3 }],
+    ]))
 
     mockInstanceService.findProviderSyncBySlug.mockResolvedValue({
       providerSyncHash: await getProviderSyncHashForUser('user-1'),
@@ -248,10 +263,9 @@ describe('syncProviderAccessForInstance', () => {
   })
 
   it('refreshes provider access when the sync record is stale by age', async () => {
-    mockGetCredential.mockImplementation(async ({ providerId }) => {
-      if (providerId === 'openai') return { source: 'organization', credential: { id: 'org-1', version: 3 } } as never
-      return null
-    })
+    mockGetEnabledCredentials.mockResolvedValue(enabledCredentials([
+      ['openai', { credentialId: 'org-1', source: 'organization', version: 3 }],
+    ]))
     mockGetGatewayTokenTtlSeconds.mockReturnValue(120)
     mockInstanceService.findProviderSyncBySlug.mockResolvedValue({
       providerSyncHash: await getProviderSyncHashForUser('user-1'),

--- a/apps/web/src/lib/opencode/providers.ts
+++ b/apps/web/src/lib/opencode/providers.ts
@@ -1,11 +1,11 @@
 import crypto from 'node:crypto'
 
 import { getInstanceBasicAuth } from '@/lib/opencode/client'
-import { getGatewayTokenTtlSeconds } from '@/lib/providers/config'
 import { toRuntimeProviderId } from '@/lib/providers/catalog'
-import { getEffectiveCredentialForUser, type ProviderCredentialSource } from '@/lib/providers/store'
+import { getGatewayTokenTtlSeconds } from '@/lib/providers/config'
+import { getEnabledProviderCredentialsForUser, type EnabledProviderCredentials } from '@/lib/providers/store'
 import { issueGatewayToken } from '@/lib/providers/tokens'
-import { PROVIDERS, type ProviderId } from '@/lib/providers/types'
+import { PROVIDERS } from '@/lib/providers/types'
 import { instanceService } from '@/lib/services'
 
 export type SyncProviderAccessResult =
@@ -24,12 +24,6 @@ type SyncProviderAccessInput = {
 const PROVIDER_SYNC_REFRESH_SKEW_MS = 60_000
 const providerSyncLocks = new Map<string, Promise<void>>()
 
-type EnabledProviderCredentials = Map<ProviderId, {
-  credentialId: string
-  source: ProviderCredentialSource
-  version: number
-}>
-
 function buildProviderSyncHash(enabledByProvider: EnabledProviderCredentials): string {
   // Only configured providers affect runtime auth. Missing credentials and
   // providers that require no managed sync intentionally hash to the same state.
@@ -43,32 +37,6 @@ function buildProviderSyncHash(enabledByProvider: EnabledProviderCredentials): s
     .sort((left, right) => left.providerId.localeCompare(right.providerId))
 
   return crypto.createHash('sha256').update(JSON.stringify(payload)).digest('hex')
-}
-
-async function loadEnabledProviderCredentials(userId: string): Promise<EnabledProviderCredentials> {
-  const enabledByProvider = new Map<ProviderId, {
-    credentialId: string
-    source: ProviderCredentialSource
-    version: number
-  }>()
-
-  for (const providerId of PROVIDERS) {
-    const effectiveCredential = await getEffectiveCredentialForUser({
-      userId,
-      providerId,
-    })
-    if (!effectiveCredential) {
-      continue
-    }
-
-    enabledByProvider.set(providerId, {
-      credentialId: effectiveCredential.credential.id,
-      source: effectiveCredential.source,
-      version: Number(effectiveCredential.credential.version),
-    })
-  }
-
-  return enabledByProvider
 }
 
 function shouldRefreshProviderAccess(args: {
@@ -111,7 +79,7 @@ async function withProviderSyncLock<T>(slug: string, work: () => Promise<T>): Pr
 }
 
 export async function getProviderSyncHashForUser(userId: string): Promise<string> {
-  return buildProviderSyncHash(await loadEnabledProviderCredentials(userId))
+  return buildProviderSyncHash(await getEnabledProviderCredentialsForUser(userId))
 }
 
 export async function ensureProviderAccessFreshForExecution(args: {
@@ -169,7 +137,7 @@ export async function syncProviderAccessForInstance(
   const instance = input.instance
 
   try {
-    const enabledByProvider = await loadEnabledProviderCredentials(input.userId)
+    const enabledByProvider = await getEnabledProviderCredentialsForUser(input.userId)
     const providerSyncHash = buildProviderSyncHash(enabledByProvider)
 
     for (const providerId of PROVIDERS) {

--- a/apps/web/src/lib/providers/__tests__/store.test.ts
+++ b/apps/web/src/lib/providers/__tests__/store.test.ts
@@ -21,6 +21,8 @@ vi.mock('@/lib/providers/crypto', () => ({
 
 import {
   getActiveCredentialForUser,
+  getEnabledProviderCredentialsForUser,
+  getEnabledProviderIdsForUser,
   getEffectiveCredentialForUser,
   replaceApiCredential,
   replaceOrganizationApiCredential,
@@ -155,6 +157,69 @@ describe('store', () => {
           version: 3,
         },
       })
+    })
+  })
+
+  describe('getEnabledProviderCredentialsForUser', () => {
+    it('returns enabled credentials keyed by provider id', async () => {
+      mockGetEffectiveCredentialForUser.mockImplementation(async ({ providerId }) => {
+        if (providerId === 'openai') {
+          return {
+            source: 'user',
+            credential: {
+              id: 'user-cred-1',
+              type: 'api',
+              secret: 'encrypted-secret',
+              version: 2,
+            },
+          }
+        }
+
+        if (providerId === 'openrouter') {
+          return {
+            source: 'organization',
+            credential: {
+              id: 'org-cred-1',
+              type: 'api',
+              secret: 'encrypted-secret',
+              version: 4,
+            },
+          }
+        }
+
+        return null
+      })
+
+      const result = await getEnabledProviderCredentialsForUser('u1')
+
+      expect(result).toEqual(new Map([
+        ['openai', { credentialId: 'user-cred-1', source: 'user', version: 2 }],
+        ['openrouter', { credentialId: 'org-cred-1', source: 'organization', version: 4 }],
+      ]))
+    })
+  })
+
+  describe('getEnabledProviderIdsForUser', () => {
+    it('returns enabled provider ids from effective credentials', async () => {
+      mockGetEffectiveCredentialForUser.mockImplementation(async ({ providerId }) => {
+        if (providerId === 'anthropic') {
+          return {
+            source: 'organization',
+            credential: {
+              id: 'org-cred-2',
+              type: 'api',
+              secret: 'encrypted-secret',
+              version: 1,
+            },
+          }
+        }
+
+        return null
+      })
+
+      const result = await getEnabledProviderIdsForUser('u1')
+
+      expect(result).toEqual(new Set(['anthropic']))
     })
   })
 })

--- a/apps/web/src/lib/providers/store.ts
+++ b/apps/web/src/lib/providers/store.ts
@@ -4,10 +4,19 @@ import { encryptProviderSecret } from './crypto'
 import type {
   EffectiveProviderCredential,
   ProviderCredentialRecord,
+  ProviderCredentialSource,
 } from './credentials'
-import type { ProviderId } from './types'
+import { PROVIDERS, type ProviderId } from './types'
 
 export type { EffectiveProviderCredential, ProviderCredentialRecord, ProviderCredentialSource } from './credentials'
+
+export type EnabledProviderCredential = {
+  credentialId: string
+  source: ProviderCredentialSource
+  version: number
+}
+
+export type EnabledProviderCredentials = Map<ProviderId, EnabledProviderCredential>
 
 export type ReplaceApiCredentialInput = {
   userId: string
@@ -56,4 +65,30 @@ export async function getEffectiveCredentialForUser(
   input: ActiveCredentialInput,
 ): Promise<EffectiveProviderCredential> {
   return providerService.getEffectiveCredentialForUser(input)
+}
+
+export async function getEnabledProviderCredentialsForUser(userId: string): Promise<EnabledProviderCredentials> {
+  const enabledByProvider: EnabledProviderCredentials = new Map()
+
+  for (const providerId of PROVIDERS) {
+    const effectiveCredential = await getEffectiveCredentialForUser({
+      userId,
+      providerId,
+    })
+    if (!effectiveCredential) {
+      continue
+    }
+
+    enabledByProvider.set(providerId, {
+      credentialId: effectiveCredential.credential.id,
+      source: effectiveCredential.source,
+      version: Number(effectiveCredential.credential.version),
+    })
+  }
+
+  return enabledByProvider
+}
+
+export async function getEnabledProviderIdsForUser(userId: string): Promise<Set<ProviderId>> {
+  return new Set((await getEnabledProviderCredentialsForUser(userId)).keys())
 }

--- a/apps/web/src/lib/services/__tests__/provider.test.ts
+++ b/apps/web/src/lib/services/__tests__/provider.test.ts
@@ -95,6 +95,21 @@ describe('providerService', () => {
       expect(result).toEqual({ source: 'organization', credential: cred })
     })
 
+    it('does not let disabled user credentials block organization credentials', async () => {
+      const cred = { id: 'org-p1', type: 'api', secret: 'org-enc', version: 3 }
+      mockPrisma.providerCredential.findFirst.mockResolvedValue(null)
+      mockPrisma.organizationProviderCredential.findFirst.mockResolvedValue(cred)
+
+      const result = await getEffectiveCredentialForUser({ userId: 'u1', providerId: 'openrouter' })
+
+      expect(mockPrisma.providerCredential.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: 'u1', providerId: 'openrouter', status: 'enabled' },
+        }),
+      )
+      expect(result).toEqual({ source: 'organization', credential: cred })
+    })
+
     it('returns null when neither user nor organization credential exists', async () => {
       mockPrisma.providerCredential.findFirst.mockResolvedValue(null)
       mockPrisma.organizationProviderCredential.findFirst.mockResolvedValue(null)

--- a/apps/web/tests/opencode-providers.test.ts
+++ b/apps/web/tests/opencode-providers.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/providers/store', () => ({
-  getEffectiveCredentialForUser: vi.fn(),
+  getEnabledProviderCredentialsForUser: vi.fn(),
 }))
 
 vi.mock('@/lib/services', () => ({
@@ -15,11 +15,24 @@ vi.mock('@/lib/providers/tokens', () => ({
 }))
 
 import { syncProviderAccessForInstance } from '@/lib/opencode/providers'
-import { getEffectiveCredentialForUser } from '@/lib/providers/store'
+import { getEnabledProviderCredentialsForUser, type EnabledProviderCredentials } from '@/lib/providers/store'
 import { issueGatewayToken } from '@/lib/providers/tokens'
+import type { ProviderId } from '@/lib/providers/types'
 
-const mockGetEffectiveCredentialForUser = vi.mocked(getEffectiveCredentialForUser)
+const mockGetEnabledProviderCredentialsForUser = vi.mocked(getEnabledProviderCredentialsForUser)
 const mockIssueGatewayToken = vi.mocked(issueGatewayToken)
+
+type TestEnabledProviderCredential = {
+  credentialId: string
+  source: 'user' | 'organization'
+  version: number
+}
+
+function enabledCredentials(
+  entries: Array<[ProviderId, TestEnabledProviderCredential]> = [],
+): EnabledProviderCredentials {
+  return new Map(entries)
+}
 
 const fakeInstance = {
   baseUrl: 'http://opencode-alice:4096',
@@ -32,7 +45,7 @@ describe('syncProviderAccessForInstance', () => {
   })
 
   it('returns sync_failed when credential lookup throws', async () => {
-    mockGetEffectiveCredentialForUser.mockRejectedValue(new Error('db error'))
+    mockGetEnabledProviderCredentialsForUser.mockRejectedValue(new Error('db error'))
 
     const result = await syncProviderAccessForInstance({
       instance: fakeInstance,
@@ -46,12 +59,9 @@ describe('syncProviderAccessForInstance', () => {
   it('sets auth for active credentials and keeps OpenCode gateway auth', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('true', { status: 200 })))
 
-    mockGetEffectiveCredentialForUser.mockImplementation(async ({ providerId }) => {
-      if (providerId === 'openai') {
-        return { source: 'user', credential: { id: 'cred-1', type: 'api', secret: 'secret', version: 2 } }
-      }
-      return null
-    })
+    mockGetEnabledProviderCredentialsForUser.mockResolvedValue(enabledCredentials([
+      ['openai', { credentialId: 'cred-1', source: 'user', version: 2 }],
+    ]))
 
     mockIssueGatewayToken.mockImplementation(
       ({ providerId }) => `token-${providerId}`


### PR DESCRIPTION
## Summary

- Fixes bug where organization-wide provider credentials were not considered in workspace model selector
- Changed listModelsAction() to use getEffectiveCredentialForUser() instead of getActiveCredentialForUser()
- This allows organization credentials to be used when users have no personal credential override
- Behavior now aligns with /api/u/[slug]/providers endpoint and syncProviderAccessForInstance

## Tests/checks run

From apps/web/:
- pnpm test: 4443 passed, 15 skipped
- pnpm test src/actions/__tests__/opencode-models.test.ts: 5 passed
- pnpm test src/actions/__tests__/opencode.test.ts: 89 passed  
- pnpm lint: passed (existing warnings only)
- bash scripts/check-podman-images.sh: passed

## Review notes/risks

- No database migrations required (code-only fix)
- Confirmed behavior: a disabled user credential does NOT block organization credentials
- New test added for organization credential case
- All existing tests continue to pass

## Checklist

- [x] Tests added for new functionality
- [x] All existing tests pass
- [x] Linting passes
- [x] No secrets committed
- [x] No database changes required
- [x] Commits follow conventional format