### PR TITLE
feat(deploy): make --ssh-key optional to support ssh-agent/1Password

### DIFF
--- a/infra/deploy/README.md
+++ b/infra/deploy/README.md
@@ -6,8 +6,8 @@ Deploy Arche to a VPS or run the local development stack with hot reload.
 
 ```
 Local Machine
-  ./deploy.sh --ip X --domain Y --ssh-key K --acme-email E
-  ./deploy.sh --ip X --domain Y --ssh-key K --cloudflare-tunnel
+  ./deploy.sh --ip X --domain Y [--ssh-key K] --acme-email E
+  ./deploy.sh --ip X --domain Y [--ssh-key K] --cloudflare-tunnel
               │ SSH (Ansible)
               ▼
 Remote VPS (/opt/arche)
@@ -92,6 +92,16 @@ Deploys to a VPS via SSH using Ansible. The playbook provisions Podman (if missi
 
 Remote deployments support two exposure modes: direct exposure with Traefik and ACME, or Cloudflare Tunnel with the origin ports closed.
 
+If `--ssh-key` is omitted, the deployer lets OpenSSH and Ansible use your normal SSH setup: ssh-agent, 1Password SSH agent, `~/.ssh/config`, and default key discovery. Pass `--ssh-key` only when you want to force a specific local private key file.
+
+```bash
+# Use ssh-agent, 1Password SSH agent, ~/.ssh/config, or default OpenSSH keys
+./deploy.sh --ip 203.0.113.50 --domain arche.example.com --cloudflare-tunnel
+
+# Force a specific key file
+./deploy.sh --ip 203.0.113.50 --domain arche.example.com --ssh-key ~/.ssh/id_ed25519 --cloudflare-tunnel
+```
+
 #### Direct exposure (default)
 
 - Domain: any single hostname (apex or subdomain), with TLS via ACME HTTP challenge
@@ -107,7 +117,6 @@ cp .env.example .env
 ./deploy.sh \
   --ip 203.0.113.50 \
   --domain arche.example.com \
-  --ssh-key ~/.ssh/id_rsa \
   --acme-email admin@example.com \
   --skip-ensure-dns-record
 ```
@@ -130,7 +139,6 @@ cp .env.example .env
 ./deploy.sh \
   --ip 203.0.113.50 \
   --domain arche.example.com \
-  --ssh-key ~/.ssh/id_rsa \
   --cloudflare-tunnel
 ```
 
@@ -144,7 +152,7 @@ Create and configure the tunnel in the Cloudflare dashboard before deploying. Th
 |------|----------|-------------|
 | `--ip` | Yes | VPS IP address |
 | `--domain` | Yes | Production domain |
-| `--ssh-key` | Yes | Path to SSH private key |
+| `--ssh-key` | No | Path to SSH private key. Omit to use ssh-agent, 1Password SSH agent, `~/.ssh/config`, or default OpenSSH keys |
 | `--acme-email` | Direct only | Let's Encrypt ACME email |
 | `--cloudflare-tunnel` | No | Use Cloudflare Tunnel instead of public `80/443` and ACME |
 | `--version` | No | Web image tag to deploy (default: `latest`) |
@@ -273,7 +281,10 @@ HTTP-01 challenge is used in direct remote mode. Make sure your domain resolves 
 ## Maintenance
 
 ```bash
-# SSH into VPS
+# SSH into VPS using ssh-agent/OpenSSH defaults
+ssh root@<IP>
+
+# Or force a specific key file
 ssh -i ~/.ssh/id_rsa root@<IP>
 
 # View logs
@@ -291,15 +302,15 @@ podman ps -a --filter label=arche.role=web
 podman ps -a --filter label=arche.managed=true
 
 # Re-deploy (from local machine)
-./deploy.sh --ip <IP> --domain <DOMAIN> --ssh-key <KEY> --acme-email <EMAIL> [--skip-ensure-dns-record]
+./deploy.sh --ip <IP> --domain <DOMAIN> [--ssh-key <KEY>] --acme-email <EMAIL> [--skip-ensure-dns-record]
 
 # Re-deploy in Cloudflare Tunnel mode (from local machine)
-./deploy.sh --ip <IP> --domain <DOMAIN> --ssh-key <KEY> --cloudflare-tunnel
+./deploy.sh --ip <IP> --domain <DOMAIN> [--ssh-key <KEY>] --cloudflare-tunnel
 ```
 
 ## Troubleshooting
 
-**SSH connection fails**: Ensure the SSH key has access and the user can log in (`ssh -i <key> <user>@<ip>`).
+**SSH connection fails**: Ensure OpenSSH can log in with the same user and host (`ssh <user>@<ip>`), or force a key file with `ssh -i <key> <user>@<ip>` and `--ssh-key <key>`.
 
 **ACME certificate not issued**: Check Traefik logs (`podman compose logs traefik`). Verify domain A/AAAA records point to the VPS and ports `80/443` are reachable.
 

--- a/infra/deploy/deploy.sh
+++ b/infra/deploy/deploy.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 # Arche One-Click Deployer
 # Usage:
-#   Remote:    ./deploy.sh --ip <IP> --domain <DOMAIN> --ssh-key <KEY> --acme-email <EMAIL>
-#   Tunnel:    ./deploy.sh --ip <IP> --domain <DOMAIN> --ssh-key <KEY> --cloudflare-tunnel
+#   Remote:    ./deploy.sh --ip <IP> --domain <DOMAIN> [--ssh-key <KEY>] --acme-email <EMAIL>
+#   Tunnel:    ./deploy.sh --ip <IP> --domain <DOMAIN> [--ssh-key <KEY>] --cloudflare-tunnel
 #   Local dev: ./deploy.sh --local-dev
 #   Local dev down: ./deploy.sh --local-dev-down
 
@@ -84,6 +84,11 @@ prepare_remote_workspace_image() {
 
   local repo_root="$REPO_ROOT"
   local workspace_src="$repo_root/infra/workspace-image"
+  local ssh_opts=(-o BatchMode=yes -o ConnectTimeout=10)
+
+  if [[ -n "$SSH_KEY" ]]; then
+    ssh_opts+=(-i "$SSH_KEY")
+  fi
 
   if [[ ! -f "$workspace_src/Containerfile" ]]; then
     err "Cannot find infra/workspace-image/Containerfile in $repo_root"
@@ -93,11 +98,11 @@ prepare_remote_workspace_image() {
 
   log "Syncing workspace image sources to remote host..."
   tar -C "$repo_root" -czf - infra/workspace-image | \
-    ssh -o BatchMode=yes -o ConnectTimeout=10 -i "$SSH_KEY" "${SSH_USER}@${DEPLOY_IP}" \
+    ssh "${ssh_opts[@]}" "${SSH_USER}@${DEPLOY_IP}" \
       "rm -rf /tmp/arche-workspace-image-src && mkdir -p /tmp/arche-workspace-image-src && tar -xzf - -C /tmp/arche-workspace-image-src --strip-components=2"
 
   log "Building workspace image on remote host: arche-workspace:latest"
-  ssh -o BatchMode=yes -o ConnectTimeout=10 -i "$SSH_KEY" "${SSH_USER}@${DEPLOY_IP}" \
+  ssh "${ssh_opts[@]}" "${SSH_USER}@${DEPLOY_IP}" \
     "cd /tmp/arche-workspace-image-src && podman build --build-arg OPENCODE_VERSION=$RESOLVED_OPENCODE_VERSION -t arche-workspace:latest ."
 }
 
@@ -115,6 +120,11 @@ prepare_remote_web_image() {
   local repo_root="$SCRIPT_DIR/../.."
   repo_root="$(cd "$repo_root" && pwd)"
   local web_src="$repo_root/apps/web"
+  local ssh_opts=(-o BatchMode=yes -o ConnectTimeout=10)
+
+  if [[ -n "$SSH_KEY" ]]; then
+    ssh_opts+=(-i "$SSH_KEY")
+  fi
 
   if [[ ! -f "$web_src/Containerfile" ]]; then
     err "Cannot find apps/web/Containerfile in $repo_root"
@@ -124,11 +134,11 @@ prepare_remote_web_image() {
 
   log "Syncing web image sources to remote host..."
   tar -C "$repo_root" -czf - apps/web | \
-    ssh -o BatchMode=yes -o ConnectTimeout=10 -i "$SSH_KEY" "${SSH_USER}@${DEPLOY_IP}" \
+    ssh "${ssh_opts[@]}" "${SSH_USER}@${DEPLOY_IP}" \
       "rm -rf /tmp/arche-web-src && mkdir -p /tmp/arche-web-src && tar -xzf - -C /tmp/arche-web-src --strip-components=2"
 
   log "Building web image on remote host: arche-web:latest"
-  ssh -o BatchMode=yes -o ConnectTimeout=10 -i "$SSH_KEY" "${SSH_USER}@${DEPLOY_IP}" \
+  ssh "${ssh_opts[@]}" "${SSH_USER}@${DEPLOY_IP}" \
     "cd /tmp/arche-web-src && podman build -t arche-web:latest ."
 }
 
@@ -137,16 +147,16 @@ usage() {
 Arche One-Click Deployer
 
 REMOTE MODE:
-  ./deploy.sh --ip <IP> --domain <DOMAIN> --ssh-key <KEY> --acme-email <EMAIL> [OPTIONS]
-  ./deploy.sh --ip <IP> --domain <DOMAIN> --ssh-key <KEY> --cloudflare-tunnel [OPTIONS]
+  ./deploy.sh --ip <IP> --domain <DOMAIN> [--ssh-key <KEY>] --acme-email <EMAIL> [OPTIONS]
+  ./deploy.sh --ip <IP> --domain <DOMAIN> [--ssh-key <KEY>] --cloudflare-tunnel [OPTIONS]
 
   Required:
     --ip            VPS IP address (IPv4 or IPv6)
     --domain        Production domain (e.g. arche.example.com or app.arche.example.com)
-    --ssh-key       Path to SSH private key
     --acme-email    Email for Let's Encrypt ACME account (direct mode only)
 
   Optional:
+    --ssh-key       Path to SSH private key (omit to use ssh-agent, ~/.ssh/config, or default OpenSSH keys)
     --cloudflare-tunnel  Use Cloudflare Tunnel instead of public 80/443 + ACME
     --version       Web image tag to deploy (default: latest)
     --user          SSH user (default: root)
@@ -302,7 +312,6 @@ validate_remote() {
 
   [[ -z "$DEPLOY_IP" ]]    && ERRORS+=("--ip is required")
   [[ -z "$DEPLOY_DOMAIN" ]] && ERRORS+=("--domain is required")
-  [[ -z "$SSH_KEY" ]]       && ERRORS+=("--ssh-key is required")
 
   if [[ "$EXPOSURE_MODE" == "direct" ]]; then
     [[ -z "$ACME_EMAIL" ]] && ERRORS+=("--acme-email is required")
@@ -523,6 +532,11 @@ ensure_dns_record() {
 # ---------------------------------------------------------------------------
 deploy_remote() {
   log "Deploying to $DEPLOY_IP ($DEPLOY_DOMAIN) via Ansible"
+  local ssh_opts=(-o BatchMode=yes -o ConnectTimeout=10)
+
+  if [[ -n "$SSH_KEY" ]]; then
+    ssh_opts+=(-i "$SSH_KEY")
+  fi
 
   # Check prerequisites
   if ! command -v ansible-playbook &>/dev/null; then
@@ -532,8 +546,8 @@ deploy_remote() {
 
   # Test SSH connectivity
   log "Testing SSH connectivity..."
-  if ! ssh -o BatchMode=yes -o ConnectTimeout=10 -i "$SSH_KEY" "${SSH_USER}@${DEPLOY_IP}" true 2>/dev/null; then
-    err "Cannot connect via SSH to ${SSH_USER}@${DEPLOY_IP} with key $SSH_KEY"
+  if ! ssh "${ssh_opts[@]}" "${SSH_USER}@${DEPLOY_IP}" true 2>/dev/null; then
+    err "Cannot connect via SSH to ${SSH_USER}@${DEPLOY_IP}${SSH_KEY:+ with key $SSH_KEY}"
     exit 1
   fi
   log "SSH connection OK"
@@ -552,10 +566,14 @@ deploy_remote() {
   EXTRA_VARS_FILE=$(mktemp)
   trap 'rm -f "$INVENTORY" "$EXTRA_VARS_FILE"' EXIT
 
-  cat > "$INVENTORY" <<EOF
-[arche]
-${DEPLOY_IP} ansible_user=${SSH_USER} ansible_ssh_private_key_file=${SSH_KEY}
-EOF
+  {
+    printf '[arche]\n'
+    printf '%s ansible_user=%s' "$DEPLOY_IP" "$SSH_USER"
+    if [[ -n "$SSH_KEY" ]]; then
+      printf ' ansible_ssh_private_key_file=%s' "$SSH_KEY"
+    fi
+    printf '\n'
+  } > "$INVENTORY"
 
   # Export variables so python3 subprocess can read them
   export DEPLOY_DOMAIN ACME_EMAIL IMAGE_PREFIX WEB_VERSION WEB_IMAGE OPENCODE_IMAGE EXPOSURE_MODE CLOUDFLARED_TUNNEL_TOKEN CLOUDFLARED_IMAGE


### PR DESCRIPTION
## Summary

- Removed required validation for \`--ssh-key\` flag in remote deployment mode
- SSH commands now conditionally add \`-i\` only when \`--ssh-key\` is provided
- Ansible inventory omits \`ansible_ssh_private_key_file\` when no key is specified
- Updated README with ssh-agent/1Password examples and optional flag documentation
- Enables OpenSSH to use ssh-agent, 1Password SSH agent, \`~/.ssh/config\`, and default key discovery

## Why this change exists

Users with SSH keys managed by 1Password SSH agent or ssh-agent could not deploy without extracting keys to local files. Making \`--ssh-key\` optional allows OpenSSH/Ansible to use the normal SSH stack, while still supporting explicit key files when needed.

## Tests/checks run

- \`bash -n deploy.sh\` - Shell syntax validation: passed
- \`ansible-playbook\` availability check: confirmed installed
- Validation check: confirmed \`--ssh-key is required\` error removed (11 validation errors → 10 validation errors, ssh-key requirement gone)
- Git commit \`fc77b30b\` created and pushed to \`origin/feat/ssh-agent-support\`

## Review notes / risks

- Users must ensure OpenSSH can authenticate to the VPS (ssh-agent, ~/.ssh/config, or default keys) when \`--ssh-key\` is omitted
- SSH commands use \`-o BatchMode=yes\` to prevent interactive password prompts (intentional)
- Backward compatible: \`--ssh-key\` still works exactly as before when provided
- Ansible.cfg already configured to use SSH defaults correctly

## Checklist

- [x] Read and understood surrounding code before editing
- [x] Change does only what was requested (no refactoring)
- [x] Shell syntax validated with \`bash -n\`
- [x] Documentation updated (README.md examples and CLI reference)
- [x] No secrets committed (no .env, tokens, or credentials)
- [x] Conventional commit format used
- [x] Branch pushed successfully to origin
- [x] Ready for review