### PR TITLE
fix(deploy): stabilize daemon startup

### DIFF
--- a/apps/web/tests/dev-scripts.test.ts
+++ b/apps/web/tests/dev-scripts.test.ts
@@ -148,6 +148,10 @@ describe('web dev scripts', () => {
       resolve(repoRoot, 'infra', 'deploy', 'ansible', 'roles', 'app', 'templates', 'arche-autostart.sh.j2'),
       'utf8',
     )
+    const autostartServiceTemplate = readFileSync(
+      resolve(repoRoot, 'infra', 'deploy', 'ansible', 'roles', 'app', 'templates', 'arche-autostart.service.j2'),
+      'utf8',
+    )
     const deployScript = readFileSync(resolve(repoRoot, 'infra', 'deploy', 'deploy.sh'), 'utf8')
 
     const tunnelEntrypointStart = composeTemplate.indexOf(
@@ -172,6 +176,9 @@ describe('web dev scripts', () => {
     expect(composeTemplate).toContain('cloudflared:')
     expect(composeTemplate).toContain('image: {{ cloudflared_image }}')
     expect(composeTemplate).toContain('TUNNEL_TOKEN: "${CLOUDFLARED_TUNNEL_TOKEN}"')
+    expect(composeTemplate).toContain('- ./node_modules/.bin/tsx')
+    expect(composeTemplate).toContain('- src/reaper-daemon.ts')
+    expect(composeTemplate).toContain('- src/flow-daemon.ts')
     expect(composeTemplate).toContain("{% if deploy_mode == 'remote' and exposure_mode == 'direct' %}")
     expect(tunnelEntrypointBlock).not.toContain('letsencrypt')
     expect(tunnelEntrypointBlock).not.toContain('websecure')
@@ -180,5 +187,7 @@ describe('web dev scripts', () => {
     expect(appTasks).toContain("cloudflared{% endif %}")
     expect(commonTasks).toContain("when: exposure_mode == 'direct'")
     expect(autostartTemplate).toContain("cloudflared{% endif %}")
+    expect(autostartServiceTemplate).toContain('KillMode=process')
+    expect(autostartServiceTemplate).toContain('TimeoutStartSec=600s')
   })
 })

--- a/infra/deploy/ansible/roles/app/templates/arche-autostart.service.j2
+++ b/infra/deploy/ansible/roles/app/templates/arche-autostart.service.j2
@@ -11,7 +11,8 @@ RemainAfterExit=yes
 ExecStart=/usr/local/bin/arche-autostart
 Restart=on-failure
 RestartSec=20s
-TimeoutStartSec=180s
+KillMode=process
+TimeoutStartSec=600s
 
 [Install]
 WantedBy=multi-user.target

--- a/infra/deploy/ansible/roles/app/templates/compose.yml.j2
+++ b/infra/deploy/ansible/roles/app/templates/compose.yml.j2
@@ -143,9 +143,8 @@ services:
     image: {{ web_image }}
     restart: "on-failure:5"
     command:
-      - pnpm
-      - run
-      - start:reaper
+      - ./node_modules/.bin/tsx
+      - src/reaper-daemon.ts
     env_file:
       - {{ env_file_name | default('.env') }}
     # Reaper only reconciles database state with container lifecycle via Docker.
@@ -165,9 +164,8 @@ services:
     image: {{ web_image }}
     restart: "unless-stopped"
     command:
-      - pnpm
-      - run
-      - start:flows
+      - ./node_modules/.bin/tsx
+      - src/flow-daemon.ts
     env_file:
       - {{ env_file_name | default('.env') }}
     networks:


### PR DESCRIPTION
Summary:
- Start reaper and flows with direct tsx commands instead of pnpm run in production compose.
- Set arche-autostart KillMode=process and extend startup timeout to 600s.
- Add deploy template regression coverage.

Verification:
- pnpm test
- pnpm lint (0 errors, existing unrelated warnings)
- bash scripts/check-podman-images.sh
- Remote hotfix verified on the VPS