### PR TITLE
feat(providers): add Hugging Face as supported provider

### DIFF
--- a/apps/web/src/actions/__tests__/opencode-models.test.ts
+++ b/apps/web/src/actions/__tests__/opencode-models.test.ts
@@ -47,6 +47,13 @@ const providersResponse = {
         },
       },
       {
+        id: 'huggingface',
+        name: 'Hugging Face',
+        models: {
+          'openai/gpt-oss-120b': { name: 'GPT OSS 120B' },
+        },
+      },
+      {
         id: 'opencode',
         name: 'OpenCode Zen',
         models: {
@@ -109,6 +116,7 @@ describe('listModelsAction', () => {
       ]),
     )
     expect(result.models).not.toEqual(expect.arrayContaining([expect.objectContaining({ providerId: 'openai', modelId: 'gpt-5.2' })]))
+    expect(result.models).not.toEqual(expect.arrayContaining([expect.objectContaining({ providerId: 'huggingface', modelId: 'openai/gpt-oss-120b' })]))
     expect(result.models).not.toEqual(expect.arrayContaining([expect.objectContaining({ providerId: 'opencode-go', modelId: 'go-model' })]))
     expect(result.models).not.toEqual(expect.arrayContaining([expect.objectContaining({ providerId: 'ollama', modelId: 'llama3.2' })]))
     expect(result.models).not.toEqual(expect.arrayContaining([expect.objectContaining({ providerId: 'opencode', modelId: 'scene-paid' })]))
@@ -148,8 +156,8 @@ describe('listModelsAction', () => {
     )
   })
 
-  it('includes OpenCode Go and Ollama only when credentials are configured', async () => {
-    mockGetEnabledProviderIdsForUser.mockResolvedValue(enabledProviders('opencode-go', 'ollama'))
+  it('includes Hugging Face, OpenCode Go, and Ollama only when credentials are configured', async () => {
+    mockGetEnabledProviderIdsForUser.mockResolvedValue(enabledProviders('huggingface', 'opencode-go', 'ollama'))
 
     const result = await listModelsAction('alice')
 
@@ -157,6 +165,7 @@ describe('listModelsAction', () => {
     expect(result.models).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ providerId: 'opencode-go', modelId: 'go-model' }),
+        expect.objectContaining({ providerId: 'huggingface', modelId: 'openai/gpt-oss-120b' }),
         expect.objectContaining({ providerId: 'ollama', modelId: 'llama3.2' }),
         expect.objectContaining({ providerId: 'opencode', modelId: 'scene-free' }),
       ]),

--- a/apps/web/src/app/api/internal/providers/[provider]/[...path]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/internal/providers/[provider]/[...path]/__tests__/route.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   getE2eFakeProviderUrl: vi.fn(),
   getCanonicalProviderId: vi.fn((id: string) =>
-    ['openai', 'anthropic', 'fireworks', 'openrouter', 'opencode', 'ollama'].includes(id) ? id : null,
+    ['openai', 'anthropic', 'fireworks', 'huggingface', 'openrouter', 'opencode', 'ollama'].includes(id) ? id : null,
   ),
   getEffectiveCredentialForUser: vi.fn(),
   verifyGatewayToken: vi.fn(),
@@ -49,7 +49,7 @@ describe('/api/internal/providers/[provider]/[...path]', () => {
     mocks.checkRateLimit.mockReturnValue({ allowed: true, remaining: 99, resetAt: Date.now() + 60_000 })
     mocks.getRuntimeCapabilities.mockReturnValue({ auth: true })
     mocks.getCanonicalProviderId.mockImplementation((id: string) =>
-      ['openai', 'anthropic', 'fireworks', 'openrouter', 'opencode', 'ollama'].includes(id) ? id : null,
+      ['openai', 'anthropic', 'fireworks', 'huggingface', 'openrouter', 'opencode', 'ollama'].includes(id) ? id : null,
     )
     fetchMock = vi.fn()
     global.fetch = fetchMock
@@ -428,6 +428,29 @@ describe('/api/internal/providers/[provider]/[...path]', () => {
     const sentHeaders = fetchMock.mock.calls[0][1].headers as Headers
     expect(sentHeaders.get('x-api-key')).toBe('anthropic-key')
     expect(sentHeaders.get('anthropic-version')).toBe('2023-06-01')
+  })
+
+  it('successfully proxies a Hugging Face models request with bearer auth', async () => {
+    mocks.verifyGatewayToken.mockReturnValue({ ...GATEWAY_PAYLOAD, providerId: 'huggingface' })
+    mocks.decryptProviderSecret.mockReturnValue({ apiKey: 'hf-token' })
+    fetchMock.mockResolvedValue(
+      new Response('{"data":[]}', { status: 200, headers: { 'content-type': 'application/json' } }),
+    )
+
+    const res = await GET(
+      makeRequest('GET', 'http://localhost/api/internal/providers/huggingface/v1/models', {
+        headers: { authorization: 'Bearer valid-token' },
+      }),
+      { params: Promise.resolve({ provider: 'huggingface', path: ['v1', 'models'] }) },
+    )
+
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://router.huggingface.co/v1/models',
+      expect.objectContaining({ method: 'GET' }),
+    )
+    const sentHeaders = fetchMock.mock.calls[0][1].headers as Headers
+    expect(sentHeaders.get('authorization')).toBe('Bearer hf-token')
   })
 
   it('allows anonymous opencode when auth capability is off', async () => {

--- a/apps/web/src/app/api/u/[slug]/organization-providers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/u/[slug]/organization-providers/__tests__/route.test.ts
@@ -86,12 +86,13 @@ describe('GET /api/u/[slug]/organization-providers', () => {
       'openai',
       'anthropic',
       'fireworks',
+      'huggingface',
       'openrouter',
       'opencode',
       'opencode-go',
       'ollama',
     ])
-    expect(body.providers).toHaveLength(7)
+    expect(body.providers).toHaveLength(8)
     expect(body.providers.find((provider: { providerId: string }) => provider.providerId === 'openai')).toEqual({
       id: 'cred-openai-current',
       lastUsedAt: '2026-05-01T12:00:00.000Z',
@@ -110,6 +111,10 @@ describe('GET /api/u/[slug]/organization-providers', () => {
     })
     expect(body.providers.find((provider: { providerId: string }) => provider.providerId === 'fireworks')).toEqual({
       providerId: 'fireworks',
+      status: 'missing',
+    })
+    expect(body.providers.find((provider: { providerId: string }) => provider.providerId === 'huggingface')).toEqual({
+      providerId: 'huggingface',
       status: 'missing',
     })
   })

--- a/apps/web/src/lib/opencode/__tests__/providers.test.ts
+++ b/apps/web/src/lib/opencode/__tests__/providers.test.ts
@@ -73,7 +73,7 @@ describe('syncProviderAccessForInstance', () => {
   it('calls provider auth endpoints for each enabled provider', async () => {
     const mockFetch = vi.mocked(globalThis.fetch)
 
-    // openai enabled, anthropic enabled, fireworks/openrouter/opencode-go/ollama disabled,
+    // openai enabled, anthropic enabled, fireworks/huggingface/openrouter/opencode-go/ollama disabled,
     // opencode gets a gateway token even without a stored credential.
     mockGetEnabledCredentials.mockResolvedValue(enabledCredentials([
       ['openai', { credentialId: '1', source: 'user', version: 1 }],
@@ -101,11 +101,12 @@ describe('syncProviderAccessForInstance', () => {
     const deleteCalls = mockFetch.mock.calls.filter(
       (call) => (call[1] as RequestInit)?.method === 'DELETE',
     )
-    expect(deleteCalls).toHaveLength(4)
+    expect(deleteCalls).toHaveLength(5)
     expect(deleteCalls[0]![0]).toBe(`${fakeInstance.baseUrl}/auth/fireworks-ai`)
-    expect(deleteCalls[1]![0]).toBe(`${fakeInstance.baseUrl}/auth/openrouter`)
-    expect(deleteCalls[2]![0]).toBe(`${fakeInstance.baseUrl}/auth/opencode-go`)
-    expect(deleteCalls[3]![0]).toBe(`${fakeInstance.baseUrl}/auth/ollama`)
+    expect(deleteCalls[1]![0]).toBe(`${fakeInstance.baseUrl}/auth/huggingface`)
+    expect(deleteCalls[2]![0]).toBe(`${fakeInstance.baseUrl}/auth/openrouter`)
+    expect(deleteCalls[3]![0]).toBe(`${fakeInstance.baseUrl}/auth/opencode-go`)
+    expect(deleteCalls[4]![0]).toBe(`${fakeInstance.baseUrl}/auth/ollama`)
 
     // Verify gateway tokens were issued for enabled providers
     expect(mockIssueToken).toHaveBeenCalledTimes(3)

--- a/apps/web/src/lib/providers/__tests__/catalog.test.ts
+++ b/apps/web/src/lib/providers/__tests__/catalog.test.ts
@@ -18,6 +18,7 @@ describe('providers catalog', () => {
 
   it('maps canonical provider ids to the runtime provider ids used by OpenCode', () => {
     expect(toRuntimeProviderId('fireworks')).toBe('fireworks-ai')
+    expect(toRuntimeProviderId('huggingface')).toBe('huggingface')
     expect(toRuntimeProviderId('opencode-go')).toBe('opencode-go')
     expect(toRuntimeProviderId('ollama')).toBe('ollama')
     expect(resolveRuntimeProviderId('fireworks')).toBe('fireworks-ai')
@@ -40,15 +41,20 @@ describe('providers catalog', () => {
     expect(config.provider.ollama?.options.baseURL).toBe(
       'http://web:3000/api/internal/providers/ollama',
     )
+    expect(config.provider.huggingface?.options.baseURL).toBe(
+      'http://web:3000/api/internal/providers/huggingface',
+    )
     expect(config.provider.ollama?.name).toBe('Ollama')
     expect(config.provider.ollama?.npm).toBe('@ai-sdk/openai-compatible')
     expect(getProviderLabel('fireworks-ai')).toBe('Fireworks AI')
+    expect(getProviderLabel('huggingface')).toBe('Hugging Face')
     expect(getProviderLabel('opencode-go')).toBe('OpenCode Go')
     expect(getProviderLabel('ollama')).toBe('Ollama')
   })
 
   it('declares which providers require managed credentials', () => {
     expect(providerRequiresCredential('openai')).toBe(true)
+    expect(providerRequiresCredential('huggingface')).toBe(true)
     expect(providerRequiresCredential('opencode')).toBe(false)
     expect(providerRequiresCredential('opencode-go')).toBe(true)
     expect(providerRequiresCredential('ollama')).toBe(true)

--- a/apps/web/src/lib/providers/__tests__/gateway-adapters.test.ts
+++ b/apps/web/src/lib/providers/__tests__/gateway-adapters.test.ts
@@ -95,12 +95,15 @@ describe('provider gateway adapters', () => {
   })
 
   it('applies bearer auth headers and supports Opencode x-api-key fallback', () => {
+    const huggingface = getProviderGatewayAdapter('huggingface')
     const openRouter = getProviderGatewayAdapter('openrouter')
     const opencode = getProviderGatewayAdapter('opencode')
     const opencodeGo = getProviderGatewayAdapter('opencode-go')
     const headers = new Headers({ authorization: 'Bearer old-key' })
 
     expect(openRouter.baseUrl()).toBe('https://openrouter.ai/api/v1')
+    expect(huggingface.baseUrl()).toBe('https://router.huggingface.co/v1')
+    expect(huggingface.extractGatewayToken(new Headers({ authorization: 'Bearer hf-gateway-token ' }))).toBe('hf-gateway-token')
     expect(openRouter.resolveCredentialAuth({ apiKey: ' provider-key ' })).toEqual({
       ok: true,
       allowMissingApiKey: false,
@@ -111,6 +114,8 @@ describe('provider gateway adapters', () => {
     expect(headers.has('authorization')).toBe(false)
     expect(applyProviderAuthHeaders(headers, openRouter, 'new-key')).toBe(true)
     expect(headers.get('authorization')).toBe('Bearer new-key')
+    expect(applyProviderAuthHeaders(headers, huggingface, 'hf-provider-key')).toBe(true)
+    expect(headers.get('authorization')).toBe('Bearer hf-provider-key')
 
     expect(opencode.baseUrl()).toBe('https://opencode.ai/zen/v1')
     expect(opencode.extractGatewayToken(new Headers({ 'x-api-key': 'gateway-key' }))).toBe('gateway-key')

--- a/apps/web/src/lib/providers/catalog.ts
+++ b/apps/web/src/lib/providers/catalog.ts
@@ -36,6 +36,12 @@ const PROVIDER_METADATA: Record<ProviderId, ProviderMetadata> = {
     runtimeId: 'fireworks-ai',
     gatewayPath: 'fireworks',
   },
+  huggingface: {
+    label: 'Hugging Face',
+    requiresCredential: true,
+    runtimeId: 'huggingface',
+    gatewayPath: 'huggingface',
+  },
   openrouter: {
     label: 'OpenRouter',
     requiresCredential: true,

--- a/apps/web/src/lib/providers/gateway-adapters.ts
+++ b/apps/web/src/lib/providers/gateway-adapters.ts
@@ -32,6 +32,7 @@ const PROVIDER_BASE_URL: Record<ProviderId, string> = {
   openai: 'https://api.openai.com/v1',
   anthropic: 'https://api.anthropic.com/v1',
   fireworks: 'https://api.fireworks.ai/inference/v1',
+  huggingface: 'https://router.huggingface.co/v1',
   openrouter: 'https://openrouter.ai/api/v1',
   opencode: 'https://opencode.ai/zen/v1',
   'opencode-go': 'https://opencode.ai/zen/go/v1',
@@ -221,6 +222,12 @@ const PROVIDER_ADAPTERS: Record<ProviderId, ProviderGatewayAdapter> = {
     extractGatewayToken: extractBearerToken,
     normalizeJsonPayload: normalizeFireworksPayload,
     shouldNormalizeJsonPayload: isFireworksJsonRequest,
+  },
+  huggingface: {
+    ...DEFAULT_PROVIDER_ADAPTER,
+    authScheme: 'bearer',
+    baseUrl: staticBaseUrl('huggingface'),
+    extractGatewayToken: extractBearerToken,
   },
   openrouter: {
     ...DEFAULT_PROVIDER_ADAPTER,

--- a/apps/web/src/lib/providers/types.ts
+++ b/apps/web/src/lib/providers/types.ts
@@ -4,6 +4,7 @@ export const PROVIDERS = [
   'openai',
   'anthropic',
   'fireworks',
+  'huggingface',
   'openrouter',
   'opencode',
   'opencode-go',

--- a/apps/web/src/lib/spawner/__tests__/docker.test.ts
+++ b/apps/web/src/lib/spawner/__tests__/docker.test.ts
@@ -90,6 +90,7 @@ describe('docker', () => {
         provider?: {
           fireworks?: { options?: { baseURL?: string } }
           'fireworks-ai'?: { options?: { baseURL?: string } }
+          huggingface?: { options?: { baseURL?: string } }
         }
       }
       expect(writtenConfig.permission?.edit).toMatchObject({
@@ -113,6 +114,9 @@ describe('docker', () => {
       )
       expect(writtenConfig.provider?.['fireworks-ai']?.options?.baseURL).toBe(
         'http://web:3000/api/internal/providers/fireworks'
+      )
+      expect(writtenConfig.provider?.huggingface?.options?.baseURL).toBe(
+        'http://web:3000/api/internal/providers/huggingface'
       )
 
       expect(mockDockerConstructor).toHaveBeenCalledWith({

--- a/apps/web/src/lib/spawner/__tests__/runtime-artifacts.test.ts
+++ b/apps/web/src/lib/spawner/__tests__/runtime-artifacts.test.ts
@@ -135,6 +135,7 @@ describe('runtime artifacts', () => {
       provider?: {
         fireworks?: { options?: { baseURL?: string } }
         'fireworks-ai'?: { options?: { baseURL?: string } }
+        huggingface?: { options?: { baseURL?: string } }
       }
     }
 
@@ -145,6 +146,9 @@ describe('runtime artifacts', () => {
     )
     expect(config.provider?.['fireworks-ai']?.options?.baseURL).toBe(
       'http://web:3000/api/internal/providers/fireworks'
+    )
+    expect(config.provider?.huggingface?.options?.baseURL).toBe(
+      'http://web:3000/api/internal/providers/huggingface'
     )
     expect(config.provider?.ollama).toBeUndefined()
     expect(config.provider?.['opencode-go']).toBeUndefined()

--- a/apps/web/tests/opencode-providers.test.ts
+++ b/apps/web/tests/opencode-providers.test.ts
@@ -96,6 +96,7 @@ describe('syncProviderAccessForInstance', () => {
     // DELETE auth for managed providers without credentials (best-effort)
     expect(urls).toContain('http://opencode-alice:4096/auth/anthropic')
     expect(urls).toContain('http://opencode-alice:4096/auth/fireworks-ai')
+    expect(urls).toContain('http://opencode-alice:4096/auth/huggingface')
     expect(urls).toContain('http://opencode-alice:4096/auth/openrouter')
     expect(urls).toContain('http://opencode-alice:4096/auth/opencode')
     // Dispose refresh

--- a/apps/web/tests/providers-gateway.test.ts
+++ b/apps/web/tests/providers-gateway.test.ts
@@ -635,6 +635,42 @@ describe('providers gateway', () => {
     expect(headers.get('x-api-key')).toBe(null)
   })
 
+  it('proxies to Hugging Face with real api key', async () => {
+    mockVerifyGatewayToken.mockReturnValue({
+      userId: 'user-1',
+      workspaceSlug: 'ws',
+      providerId: 'huggingface',
+      version: 1,
+      exp: Math.floor(Date.now() / 1000) + 1000,
+    })
+    mockGetActiveCredentialForUser.mockResolvedValue({
+      id: 'cred-hf',
+      type: 'api',
+      secret: 'encrypted',
+      version: 1,
+    })
+    mockDecryptProviderSecret.mockReturnValue({ apiKey: 'hf-key' })
+
+    ;(global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response('ok', { status: 200 })
+    )
+
+    await callProxy({
+      provider: 'huggingface',
+      method: 'GET',
+      path: ['v1', 'models'],
+      headers: {
+        Authorization: 'Bearer internal-token',
+      },
+    })
+
+    const [url, options] = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(url).toBe('https://router.huggingface.co/v1/models?foo=bar')
+    const headers = options.headers as Headers
+    expect(headers.get('authorization')).toBe('Bearer hf-key')
+    expect(headers.get('x-api-key')).toBe(null)
+  })
+
   it('proxies to Fireworks with real api key', async () => {
     mockVerifyGatewayToken.mockReturnValue({
       userId: 'user-1',

--- a/apps/web/tests/providers-routes.test.ts
+++ b/apps/web/tests/providers-routes.test.ts
@@ -169,6 +169,7 @@ describe('GET /api/u/[slug]/providers', () => {
       },
       { providerId: 'anthropic', status: 'missing' },
       { providerId: 'fireworks', status: 'missing' },
+      { providerId: 'huggingface', status: 'missing' },
       { providerId: 'openrouter', status: 'missing' },
       { providerId: 'opencode', status: 'missing' },
       { providerId: 'opencode-go', status: 'missing' },
@@ -281,6 +282,44 @@ describe('POST /api/u/[slug]/providers/[provider]', () => {
       instance: { baseUrl: 'http://alice.test', authHeader: 'Basic b3BlbmNvZGU6c2VjcmV0' },
       slug: 'alice',
       userId: 'user-1',
+    })
+  })
+
+  it('creates and enables a Hugging Face credential', async () => {
+    mockGetAuthenticatedUser.mockResolvedValue(session('admin', 'ADMIN'))
+    mockFindUnique.mockResolvedValueOnce({ id: 'user-1' })
+    mockFindUnique.mockResolvedValueOnce(null)
+    mockFindFirst.mockResolvedValue({ version: 0 })
+    mockUpdateMany.mockResolvedValue({ count: 1 })
+    mockCreate.mockResolvedValue({
+      id: 'cred-hf',
+      providerId: 'huggingface',
+      type: 'api',
+      status: 'enabled',
+      version: 1,
+    })
+
+    const { status, body } = await callPostProvider('alice', 'huggingface', { apiKey: 'hf-token' })
+
+    expect(status).toBe(201)
+    expect(body).toEqual({
+      credential: {
+        id: 'cred-hf',
+        providerId: 'huggingface',
+        type: 'api',
+        status: 'enabled',
+        version: 1,
+      },
+      restartRequired: false,
+    })
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: { userId: 'user-1', providerId: 'huggingface' },
+      data: { status: 'disabled' },
+    })
+    expect(mockAuditEvent).toHaveBeenCalledWith({
+      actorUserId: 'user-1',
+      action: 'provider_credential.created',
+      metadata: { providerId: 'huggingface', credentialId: 'cred-hf' },
     })
   })
 


### PR DESCRIPTION
## Summary

- Adds Hugging Face as a supported provider in the provider catalog
- Configures Hugging Face gateway adapter with bearer token authentication to https://router.huggingface.co/v1
- Adds provider metadata with runtime ID and gateway path configuration
- Includes comprehensive test coverage for gateway proxying and credential creation

## Tests Run

- Unit tests: `pnpm test` - 481 test files passed, 4678 tests passed (15 skipped)
- Linting: `pnpm lint` - 16 warnings (all pre-existing, unrelated to this change)
- Podman images: `bash scripts/check-podman-images.sh` - Both web and workspace images built successfully

## Review Notes

This is a straightforward provider addition following the existing pattern for providers like OpenAI, Anthropic, and Fireworks:

- Uses standard bearer token authentication scheme
- No special payload normalization required (Hugging Face API is OpenAI-compatible)
- Gateway adapter follows the default provider adapter pattern
- Tests verify gateway proxying, authorization header forwarding, provider status enumeration, and credential creation workflow

## Checklist

- Tests pass: `pnpm test`
- Linter passes: `pnpm lint`
- Podman images build locally: `bash scripts/check-podman-images.sh`
- No sensitive files committed
- Follows conventional commit format
- Changes are minimal and focused
- Self-reviewed against code conventions