### PR TITLE
feat(learning): add learning proposals system with pending KB updates

### DIFF
--- a/apps/web/prisma/migrations/20260607120000_add_learning_proposals/migration.sql
+++ b/apps/web/prisma/migrations/20260607120000_add_learning_proposals/migration.sql
@@ -1,0 +1,84 @@
+-- CreateEnum
+CREATE TYPE "KnowledgeLearningRunStatus" AS ENUM ('pending', 'running', 'succeeded', 'failed');
+
+-- CreateEnum
+CREATE TYPE "KnowledgeLearningTrigger" AS ENUM ('manual', 'auto', 'flow', 'agent');
+
+-- CreateEnum
+CREATE TYPE "KnowledgeLearningProposalStatus" AS ENUM ('pending', 'rejected', 'applied');
+
+-- CreateEnum
+CREATE TYPE "KnowledgeLearningProposalType" AS ENUM ('fact', 'preference', 'process', 'correction', 'other');
+
+-- CreateEnum
+CREATE TYPE "KnowledgeLearningOperation" AS ENUM ('create', 'update');
+
+-- CreateTable
+CREATE TABLE "knowledge_learning_runs" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "source_session_id" TEXT,
+    "internal_session_id" TEXT,
+    "title" TEXT NOT NULL,
+    "trigger" "KnowledgeLearningTrigger" NOT NULL,
+    "status" "KnowledgeLearningRunStatus" NOT NULL DEFAULT 'pending',
+    "error" TEXT,
+    "message_count" INTEGER NOT NULL DEFAULT 0,
+    "started_at" TIMESTAMP(3),
+    "finished_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "knowledge_learning_runs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "knowledge_learning_proposals" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "run_id" TEXT,
+    "status" "KnowledgeLearningProposalStatus" NOT NULL DEFAULT 'pending',
+    "title" TEXT NOT NULL,
+    "type" "KnowledgeLearningProposalType" NOT NULL DEFAULT 'other',
+    "confidence" DOUBLE PRECISION NOT NULL,
+    "evidence" JSONB NOT NULL,
+    "kb_path" TEXT NOT NULL,
+    "operation" "KnowledgeLearningOperation" NOT NULL,
+    "proposed_content" TEXT NOT NULL,
+    "current_file_hash" TEXT,
+    "internal_session_id" TEXT,
+    "trigger" "KnowledgeLearningTrigger" NOT NULL,
+    "applied_at" TIMESTAMP(3),
+    "rejected_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "knowledge_learning_proposals_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "knowledge_learning_runs_user_id_created_at_idx" ON "knowledge_learning_runs"("user_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "knowledge_learning_runs_user_id_source_session_id_idx" ON "knowledge_learning_runs"("user_id", "source_session_id");
+
+-- CreateIndex
+CREATE INDEX "knowledge_learning_runs_status_idx" ON "knowledge_learning_runs"("status");
+
+-- CreateIndex
+CREATE INDEX "knowledge_learning_proposals_user_id_status_created_at_idx" ON "knowledge_learning_proposals"("user_id", "status", "created_at");
+
+-- CreateIndex
+CREATE INDEX "knowledge_learning_proposals_run_id_idx" ON "knowledge_learning_proposals"("run_id");
+
+-- CreateIndex
+CREATE INDEX "knowledge_learning_proposals_kb_path_idx" ON "knowledge_learning_proposals"("kb_path");
+
+-- AddForeignKey
+ALTER TABLE "knowledge_learning_runs" ADD CONSTRAINT "knowledge_learning_runs_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "knowledge_learning_proposals" ADD CONSTRAINT "knowledge_learning_proposals_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "knowledge_learning_proposals" ADD CONSTRAINT "knowledge_learning_proposals_run_id_fkey" FOREIGN KEY ("run_id") REFERENCES "knowledge_learning_runs"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -67,6 +67,39 @@ enum SlackPendingDecisionStatus {
   expired
 }
 
+enum KnowledgeLearningRunStatus {
+  pending
+  running
+  succeeded
+  failed
+}
+
+enum KnowledgeLearningTrigger {
+  manual
+  auto
+  flow
+  agent
+}
+
+enum KnowledgeLearningProposalStatus {
+  pending
+  rejected
+  applied
+}
+
+enum KnowledgeLearningProposalType {
+  fact
+  preference
+  process
+  correction
+  other
+}
+
+enum KnowledgeLearningOperation {
+  create
+  update
+}
+
 model User {
   id           String      @id @default(cuid())
   email        String      @unique
@@ -91,6 +124,8 @@ model User {
   providerUsageRuns   ProviderUsageRun[]
   flows               Flow[]
   flowRunsExecuted    FlowRun[] @relation("FlowRunExecutionUser")
+  knowledgeLearningRuns KnowledgeLearningRun[]
+  knowledgeLearningProposals KnowledgeLearningProposal[]
   slackThreadBindings SlackThreadBinding[]
   slackUserLinks      SlackUserLink[]
   slackDmSessionBindings SlackDmSessionBinding[]
@@ -299,6 +334,58 @@ model MessageRunLock {
   @@id([slug, sessionId])
   @@index([runId])
   @@map("message_run_locks")
+}
+
+model KnowledgeLearningRun {
+  id                    String                     @id @default(cuid())
+  userId                String                     @map("user_id")
+  user                  User                       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  sourceSessionId       String?                    @map("source_session_id")
+  internalSessionId     String?                    @map("internal_session_id")
+  title                 String
+  trigger               KnowledgeLearningTrigger
+  status                KnowledgeLearningRunStatus @default(pending)
+  error                 String?
+  messageCount          Int                        @default(0) @map("message_count")
+  startedAt             DateTime?                  @map("started_at")
+  finishedAt            DateTime?                  @map("finished_at")
+  createdAt             DateTime                   @default(now()) @map("created_at")
+  updatedAt             DateTime                   @updatedAt @map("updated_at")
+
+  proposals             KnowledgeLearningProposal[]
+
+  @@index([userId, createdAt])
+  @@index([userId, sourceSessionId])
+  @@index([status])
+  @@map("knowledge_learning_runs")
+}
+
+model KnowledgeLearningProposal {
+  id                String                          @id @default(cuid())
+  userId            String                          @map("user_id")
+  user              User                            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  runId             String?                         @map("run_id")
+  run               KnowledgeLearningRun?           @relation(fields: [runId], references: [id], onDelete: SetNull)
+  status            KnowledgeLearningProposalStatus @default(pending)
+  title             String
+  type              KnowledgeLearningProposalType   @default(other)
+  confidence        Float
+  evidence          Json
+  kbPath            String                          @map("kb_path")
+  operation         KnowledgeLearningOperation
+  proposedContent   String                          @map("proposed_content")
+  currentFileHash   String?                         @map("current_file_hash")
+  internalSessionId String?                         @map("internal_session_id")
+  trigger           KnowledgeLearningTrigger
+  appliedAt         DateTime?                       @map("applied_at")
+  rejectedAt        DateTime?                       @map("rejected_at")
+  createdAt         DateTime                        @default(now()) @map("created_at")
+  updatedAt         DateTime                        @updatedAt @map("updated_at")
+
+  @@index([userId, status, createdAt])
+  @@index([runId])
+  @@index([kbPath])
+  @@map("knowledge_learning_proposals")
 }
 
 model Flow {

--- a/apps/web/prisma/schema.sqlite.prisma
+++ b/apps/web/prisma/schema.sqlite.prisma
@@ -31,6 +31,8 @@ model User {
   providerUsageRuns   ProviderUsageRun[]
   flows               Flow[]
   flowRunsExecuted    FlowRun[] @relation("FlowRunExecutionUser")
+  knowledgeLearningRuns KnowledgeLearningRun[]
+  knowledgeLearningProposals KnowledgeLearningProposal[]
   slackThreadBindings SlackThreadBinding[]
   slackUserLinks      SlackUserLink[]
   slackDmSessionBindings SlackDmSessionBinding[]
@@ -232,6 +234,58 @@ model MessageRunLock {
   @@id([slug, sessionId])
   @@index([runId])
   @@map("message_run_locks")
+}
+
+model KnowledgeLearningRun {
+  id                    String   @id @default(cuid())
+  userId                String   @map("user_id")
+  user                  User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  sourceSessionId       String?  @map("source_session_id")
+  internalSessionId     String?  @map("internal_session_id")
+  title                 String
+  trigger               String
+  status                String   @default("pending")
+  error                 String?
+  messageCount          Int      @default(0) @map("message_count")
+  startedAt             DateTime? @map("started_at")
+  finishedAt            DateTime? @map("finished_at")
+  createdAt             DateTime @default(now()) @map("created_at")
+  updatedAt             DateTime @updatedAt @map("updated_at")
+
+  proposals             KnowledgeLearningProposal[]
+
+  @@index([userId, createdAt])
+  @@index([userId, sourceSessionId])
+  @@index([status])
+  @@map("knowledge_learning_runs")
+}
+
+model KnowledgeLearningProposal {
+  id                String   @id @default(cuid())
+  userId            String   @map("user_id")
+  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  runId             String?  @map("run_id")
+  run               KnowledgeLearningRun? @relation(fields: [runId], references: [id], onDelete: SetNull)
+  status            String   @default("pending")
+  title             String
+  type              String   @default("other")
+  confidence        Float
+  evidence          String
+  kbPath            String   @map("kb_path")
+  operation         String
+  proposedContent   String   @map("proposed_content")
+  currentFileHash   String?  @map("current_file_hash")
+  internalSessionId String?  @map("internal_session_id")
+  trigger           String
+  appliedAt         DateTime? @map("applied_at")
+  rejectedAt        DateTime? @map("rejected_at")
+  createdAt         DateTime @default(now()) @map("created_at")
+  updatedAt         DateTime @updatedAt @map("updated_at")
+
+  @@index([userId, status, createdAt])
+  @@index([runId])
+  @@index([kbPath])
+  @@map("knowledge_learning_proposals")
 }
 
 model Flow {

--- a/apps/web/src/actions/__tests__/opencode-sessions.test.ts
+++ b/apps/web/src/actions/__tests__/opencode-sessions.test.ts
@@ -195,6 +195,40 @@ describe("session listing actions", () => {
     ]);
   });
 
+  it("hides learning sessions from the main session list", async () => {
+    mockSessionList.mockResolvedValue({
+      data: [
+        {
+          id: "chat",
+          parentID: undefined,
+          time: { created: 25, updated: 50 },
+          title: "Regular chat",
+          version: "1",
+        },
+        {
+          id: "learning",
+          parentID: undefined,
+          time: { created: 26, updated: 51 },
+          title: "Learning | Regular chat",
+          version: "1",
+        },
+        {
+          id: "flow-learning",
+          parentID: undefined,
+          time: { created: 27, updated: 52 },
+          title: "Flow | Learning | Weekly review",
+          version: "1",
+        },
+      ],
+    });
+
+    const result = await listSessionsAction("alice", { rootsOnly: true });
+
+    expect(result.sessions).toEqual([
+      expect.objectContaining({ id: "chat", title: "Regular chat" }),
+    ]);
+  });
+
   it("searches up to 100 recent root sessions by title and task name", async () => {
     mockSessionList.mockResolvedValue({
       data: [

--- a/apps/web/src/actions/__tests__/opencode-sessions.test.ts
+++ b/apps/web/src/actions/__tests__/opencode-sessions.test.ts
@@ -229,6 +229,35 @@ describe("session listing actions", () => {
     ]);
   });
 
+  it("keeps hasMore when hidden learning sessions shrink a full page", async () => {
+    mockSessionList.mockResolvedValue({
+      data: [
+        {
+          id: "chat",
+          parentID: undefined,
+          time: { created: 25, updated: 50 },
+          title: "Regular chat",
+          version: "1",
+        },
+        {
+          id: "learning",
+          parentID: undefined,
+          time: { created: 26, updated: 51 },
+          title: "Learning | Regular chat",
+          version: "1",
+        },
+      ],
+    });
+
+    const result = await listSessionsAction("alice", { limit: 2, rootsOnly: true });
+
+    expect(result).toMatchObject({
+      ok: true,
+      hasMore: true,
+      sessions: [expect.objectContaining({ id: "chat" })],
+    });
+  });
+
   it("searches up to 100 recent root sessions by title and task name", async () => {
     mockSessionList.mockResolvedValue({
       data: [

--- a/apps/web/src/actions/opencode.ts
+++ b/apps/web/src/actions/opencode.ts
@@ -1,7 +1,8 @@
 "use server";
 
-import { createInstanceClient, getInstanceUrl } from "@/lib/opencode/client";
 import { createFlowActorScope } from "@/lib/flows/authorization";
+import { isLearningSessionTitle } from "@/lib/learning/session-title";
+import { createInstanceClient, getInstanceUrl } from "@/lib/opencode/client";
 import { extractTextContent, transformParts } from "@/lib/opencode/transform";
 import type {
   AvailableModel,
@@ -467,7 +468,7 @@ async function listWorkspaceSessionsFromApi(
     roots: options.rootsOnly ? true : undefined,
     start: requestedStart,
   });
-  const sessions = (result.data ?? []).map(mapApiSession);
+  const sessions = (result.data ?? []).map(mapApiSession).filter((session) => !isLearningSessionTitle(session.title));
   const metadata = await getWorkspaceSessionMetadata(slug, client, sessions.map((session) => session.id));
   const workspaceSessions = toWorkspaceSessions(sessions, metadata.statuses, metadata.flowBySessionId);
 

--- a/apps/web/src/actions/opencode.ts
+++ b/apps/web/src/actions/opencode.ts
@@ -468,7 +468,8 @@ async function listWorkspaceSessionsFromApi(
     roots: options.rootsOnly ? true : undefined,
     start: requestedStart,
   });
-  const sessions = (result.data ?? []).map(mapApiSession).filter((session) => !isLearningSessionTitle(session.title));
+  const rawSessions = result.data ?? [];
+  const sessions = rawSessions.map(mapApiSession).filter((session) => !isLearningSessionTitle(session.title));
   const metadata = await getWorkspaceSessionMetadata(slug, client, sessions.map((session) => session.id));
   const workspaceSessions = toWorkspaceSessions(sessions, metadata.statuses, metadata.flowBySessionId);
 
@@ -488,7 +489,9 @@ async function listWorkspaceSessionsFromApi(
 
   return {
     ok: true,
-    hasMore: requestedLimit ? sessions.length >= requestedLimit : false,
+    // Use the pre-filter count: a page whose tail was filtered out (hidden
+    // learning sessions) can still have more results upstream.
+    hasMore: requestedLimit ? rawSessions.length >= requestedLimit : false,
     sessions: workspaceSessions,
   };
 }

--- a/apps/web/src/app/api/internal/learning/__tests__/auth.test.ts
+++ b/apps/web/src/app/api/internal/learning/__tests__/auth.test.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  findIdBySlug: vi.fn(),
+  resolveInstanceConnection: vi.fn(),
+}))
+
+vi.mock('@/lib/opencode/connection-resolver', () => ({ resolveInstanceConnection: mocks.resolveInstanceConnection }))
+vi.mock('@/lib/services', () => ({ userService: { findIdBySlug: mocks.findIdBySlug } }))
+
+import { getInternalLearningContext } from '../auth'
+
+function makeRequest(headers: Record<string, string>): NextRequest {
+  return new NextRequest('http://localhost/api/internal/learning/proposals', { headers })
+}
+
+describe('getInternalLearningContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.resolveInstanceConnection.mockResolvedValue({ authHeader: 'Basic expected' })
+    mocks.findIdBySlug.mockResolvedValue({ id: 'user-1' })
+  })
+
+  it('rejects missing or mismatched internal auth headers', async () => {
+    await expect(getInternalLearningContext(makeRequest({}))).resolves.toEqual({ ok: false, error: 'unauthorized', status: 401 })
+    await expect(getInternalLearningContext(makeRequest({
+      'x-arche-workspace-slug': 'alice',
+      authorization: 'Basic wrong',
+    }))).resolves.toEqual({ ok: false, error: 'unauthorized', status: 401 })
+  })
+
+  it('returns not_found when the slug has no user', async () => {
+    mocks.findIdBySlug.mockResolvedValue(null)
+
+    await expect(getInternalLearningContext(makeRequest({
+      'x-arche-workspace-slug': 'alice',
+      authorization: 'Basic expected',
+    }))).resolves.toEqual({ ok: false, error: 'not_found', status: 404 })
+  })
+
+  it('returns the internal learning context', async () => {
+    await expect(getInternalLearningContext(makeRequest({
+      'x-arche-workspace-slug': ' alice ',
+      authorization: 'Basic expected',
+    }))).resolves.toEqual({ ok: true, slug: 'alice', userId: 'user-1' })
+  })
+})

--- a/apps/web/src/app/api/internal/learning/auth.ts
+++ b/apps/web/src/app/api/internal/learning/auth.ts
@@ -1,7 +1,16 @@
+import crypto from 'crypto'
+
 import { NextRequest } from 'next/server'
 
 import { resolveInstanceConnection } from '@/lib/opencode/connection-resolver'
 import { userService } from '@/lib/services'
+
+function timingSafeMatch(expected: string, actual: string): boolean {
+  const expectedBuffer = Buffer.from(expected)
+  const actualBuffer = Buffer.from(actual)
+  if (expectedBuffer.length !== actualBuffer.length) return false
+  return crypto.timingSafeEqual(expectedBuffer, actualBuffer)
+}
 
 export async function getInternalLearningContext(request: NextRequest): Promise<
   | { ok: true; userId: string; slug: string }
@@ -14,7 +23,7 @@ export async function getInternalLearningContext(request: NextRequest): Promise<
   }
 
   const connection = await resolveInstanceConnection(slug)
-  if (!connection || authorization !== connection.authHeader) {
+  if (!connection || !timingSafeMatch(connection.authHeader, authorization)) {
     return { ok: false, error: 'unauthorized', status: 401 }
   }
 

--- a/apps/web/src/app/api/internal/learning/auth.ts
+++ b/apps/web/src/app/api/internal/learning/auth.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from 'next/server'
+
+import { resolveInstanceConnection } from '@/lib/opencode/connection-resolver'
+import { userService } from '@/lib/services'
+
+export async function getInternalLearningContext(request: NextRequest): Promise<
+  | { ok: true; userId: string; slug: string }
+  | { ok: false; error: string; status: number }
+> {
+  const slug = request.headers.get('x-arche-workspace-slug')?.trim()
+  const authorization = request.headers.get('authorization')
+  if (!slug || !authorization) {
+    return { ok: false, error: 'unauthorized', status: 401 }
+  }
+
+  const connection = await resolveInstanceConnection(slug)
+  if (!connection || authorization !== connection.authHeader) {
+    return { ok: false, error: 'unauthorized', status: 401 }
+  }
+
+  const user = await userService.findIdBySlug(slug)
+  if (!user) {
+    return { ok: false, error: 'not_found', status: 404 }
+  }
+
+  return { ok: true, userId: user.id, slug }
+}

--- a/apps/web/src/app/api/internal/learning/proposals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/internal/learning/proposals/__tests__/route.test.ts
@@ -4,10 +4,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   createLearningProposal: vi.fn(),
   getInternalLearningContext: vi.fn(),
+  learningRunBelongsToUser: vi.fn(),
 }))
 
 vi.mock('@/app/api/internal/learning/auth', () => ({ getInternalLearningContext: mocks.getInternalLearningContext }))
-vi.mock('@/lib/learning/service', () => ({ createLearningProposal: mocks.createLearningProposal }))
+vi.mock('@/lib/learning/service', () => ({
+  createLearningProposal: mocks.createLearningProposal,
+  learningRunBelongsToUser: mocks.learningRunBelongsToUser,
+}))
 
 import { POST } from '../route'
 
@@ -35,6 +39,7 @@ describe('POST /api/internal/learning/proposals', () => {
     vi.clearAllMocks()
     mocks.getInternalLearningContext.mockResolvedValue({ ok: true, userId: 'user-1', slug: 'alice' })
     mocks.createLearningProposal.mockResolvedValue({ id: 'proposal-1' })
+    mocks.learningRunBelongsToUser.mockResolvedValue(true)
   })
 
   it('returns auth errors from the internal context', async () => {
@@ -51,6 +56,23 @@ describe('POST /api/internal/learning/proposals', () => {
 
     expect(response.status).toBe(400)
     await expect(response.json()).resolves.toEqual({ error: 'invalid_request' })
+  })
+
+  it('rejects run ids that do not belong to the workspace user', async () => {
+    mocks.learningRunBelongsToUser.mockResolvedValue(false)
+
+    const response = await POST(makeRequest({ ...validBody, runId: 'run-other' }))
+
+    expect(response.status).toBe(400)
+    expect(mocks.learningRunBelongsToUser).toHaveBeenCalledWith({ userId: 'user-1', runId: 'run-other' })
+    expect(mocks.createLearningProposal).not.toHaveBeenCalled()
+  })
+
+  it('skips the ownership check when no run id is provided', async () => {
+    const response = await POST(makeRequest(validBody))
+
+    expect(response.status).toBe(200)
+    expect(mocks.learningRunBelongsToUser).not.toHaveBeenCalled()
   })
 
   it('creates a learning proposal for valid payloads', async () => {

--- a/apps/web/src/app/api/internal/learning/proposals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/internal/learning/proposals/__tests__/route.test.ts
@@ -1,0 +1,67 @@
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  createLearningProposal: vi.fn(),
+  getInternalLearningContext: vi.fn(),
+}))
+
+vi.mock('@/app/api/internal/learning/auth', () => ({ getInternalLearningContext: mocks.getInternalLearningContext }))
+vi.mock('@/lib/learning/service', () => ({ createLearningProposal: mocks.createLearningProposal }))
+
+import { POST } from '../route'
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/internal/learning/proposals', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+const validBody = {
+  title: 'Remember preference',
+  type: 'preference',
+  confidence: 0.8,
+  evidence: { quote: 'Use concise answers' },
+  kbPath: 'Preferences/Answers.md',
+  operation: 'update',
+  proposedContent: 'Use concise answers.',
+  trigger: 'agent',
+}
+
+describe('POST /api/internal/learning/proposals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getInternalLearningContext.mockResolvedValue({ ok: true, userId: 'user-1', slug: 'alice' })
+    mocks.createLearningProposal.mockResolvedValue({ id: 'proposal-1' })
+  })
+
+  it('returns auth errors from the internal context', async () => {
+    mocks.getInternalLearningContext.mockResolvedValue({ ok: false, error: 'unauthorized', status: 401 })
+
+    const response = await POST(makeRequest(validBody))
+
+    expect(response.status).toBe(401)
+    expect(mocks.createLearningProposal).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid proposal payloads', async () => {
+    const response = await POST(makeRequest({ ...validBody, kbPath: '' }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'invalid_request' })
+  })
+
+  it('creates a learning proposal for valid payloads', async () => {
+    const response = await POST(makeRequest(validBody))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ proposal: { id: 'proposal-1' } })
+    expect(mocks.createLearningProposal).toHaveBeenCalledWith('user-1', expect.objectContaining({
+      title: 'Remember preference',
+      confidence: 0.8,
+      evidence: { quote: 'Use concise answers' },
+    }))
+  })
+})

--- a/apps/web/src/app/api/internal/learning/proposals/route.ts
+++ b/apps/web/src/app/api/internal/learning/proposals/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { getInternalLearningContext } from '@/app/api/internal/learning/auth'
-import { createLearningProposal } from '@/lib/learning/service'
+import { createLearningProposal, learningRunBelongsToUser } from '@/lib/learning/service'
 import { parseProposalRequest } from '@/lib/learning/validation'
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -17,6 +17,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   const input = parsed.value
+  if (input.runId && !(await learningRunBelongsToUser({ userId: context.userId, runId: input.runId }))) {
+    return NextResponse.json({ error: 'invalid_request' }, { status: 400 })
+  }
+
   const proposal = await createLearningProposal(context.userId, {
     runId: input.runId ?? null,
     title: input.title,

--- a/apps/web/src/app/api/internal/learning/proposals/route.ts
+++ b/apps/web/src/app/api/internal/learning/proposals/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getInternalLearningContext } from '@/app/api/internal/learning/auth'
+import { createLearningProposal } from '@/lib/learning/service'
+import { parseProposalRequest } from '@/lib/learning/validation'
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const context = await getInternalLearningContext(request)
+  if (!context.ok) {
+    return NextResponse.json({ error: context.error }, { status: context.status })
+  }
+
+  const body = await request.json().catch(() => null)
+  const parsed = parseProposalRequest(body)
+  if (!parsed.ok) {
+    return NextResponse.json({ error: 'invalid_request' }, { status: 400 })
+  }
+
+  const input = parsed.value
+  const proposal = await createLearningProposal(context.userId, {
+    runId: input.runId ?? null,
+    title: input.title,
+    type: input.type,
+    confidence: input.confidence ?? 0.5,
+    evidence: input.evidence ?? {},
+    kbPath: input.kbPath,
+    operation: input.operation,
+    proposedContent: input.proposedContent,
+    currentFileHash: input.currentFileHash ?? null,
+    internalSessionId: input.internalSessionId ?? null,
+    trigger: input.trigger ?? 'agent',
+  })
+
+  return NextResponse.json({ proposal })
+}

--- a/apps/web/src/app/api/internal/learning/session-history/__tests__/route.test.ts
+++ b/apps/web/src/app/api/internal/learning/session-history/__tests__/route.test.ts
@@ -1,0 +1,72 @@
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  createInstanceClient: vi.fn(),
+  getInternalLearningContext: vi.fn(),
+}))
+
+vi.mock('@/app/api/internal/learning/auth', () => ({ getInternalLearningContext: mocks.getInternalLearningContext }))
+vi.mock('@/lib/opencode/client', () => ({ createInstanceClient: mocks.createInstanceClient }))
+
+import { POST } from '../route'
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/internal/learning/session-history', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('POST /api/internal/learning/session-history', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getInternalLearningContext.mockResolvedValue({ ok: true, userId: 'user-1', slug: 'alice' })
+    mocks.createInstanceClient.mockResolvedValue({
+      session: {
+        list: vi.fn().mockResolvedValue({
+          data: [
+            { id: 'session-1', title: 'Roadmap planning' },
+            { id: 'session-2', title: 'Learning | Roadmap planning' },
+            { id: 'session-3', title: 'Support notes' },
+          ],
+        }),
+        messages: vi.fn().mockResolvedValue({
+          data: [
+            { info: { role: 'user' }, parts: [{ text: 'Remember this preference' }] },
+            { info: { role: 'assistant' }, parts: [{ content: 'Noted' }] },
+          ],
+        }),
+      },
+    })
+  })
+
+  it('returns auth errors from the internal context', async () => {
+    mocks.getInternalLearningContext.mockResolvedValue({ ok: false, error: 'unauthorized', status: 401 })
+
+    const response = await POST(makeRequest({}))
+
+    expect(response.status).toBe(401)
+  })
+
+  it('returns instance errors', async () => {
+    mocks.createInstanceClient.mockResolvedValue(null)
+
+    const response = await POST(makeRequest({}))
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({ error: 'instance_unavailable' })
+  })
+
+  it('filters sessions and optionally includes messages', async () => {
+    const response = await POST(makeRequest({ includeMessages: true, query: 'roadmap', limit: 10, maxMessagesPerSession: 1 }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      sessions: [
+        { id: 'session-1', title: 'Roadmap planning', messages: [{ role: 'assistant', text: 'Noted' }] },
+      ],
+    })
+  })
+})

--- a/apps/web/src/app/api/internal/learning/session-history/route.ts
+++ b/apps/web/src/app/api/internal/learning/session-history/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getInternalLearningContext } from '@/app/api/internal/learning/auth'
+import {
+  clampSessionHistoryBounds,
+  getMessageRole,
+  getMessageText,
+  getSessionId,
+  getSessionTitle,
+  type SessionHistoryRequest,
+} from '@/lib/learning/session-history'
+import { isLearningSessionTitle } from '@/lib/learning/session-title'
+import { createInstanceClient } from '@/lib/opencode/client'
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const context = await getInternalLearningContext(request)
+  if (!context.ok) {
+    return NextResponse.json({ error: context.error }, { status: context.status })
+  }
+
+  const body = (await request.json().catch(() => null)) as SessionHistoryRequest | null
+  const { limit, maxMessages } = clampSessionHistoryBounds(body)
+  const query = body?.query?.trim().toLowerCase()
+  const client = await createInstanceClient(context.slug)
+  if (!client) {
+    return NextResponse.json({ error: 'instance_unavailable' }, { status: 503 })
+  }
+
+  const sessionsResult = await client.session.list({ limit: body?.sessionIds?.length ? 100 : limit })
+  const requestedIds = new Set(body?.sessionIds ?? [])
+  const sessions = (sessionsResult.data ?? [])
+    .filter((session) => {
+      const id = getSessionId(session)
+      const title = getSessionTitle(session)
+      if (!id || isLearningSessionTitle(title)) return false
+      if (requestedIds.size > 0 && !requestedIds.has(id)) return false
+      return query ? title.toLowerCase().includes(query) : true
+    })
+    .slice(0, limit)
+
+  const responseSessions = []
+  for (const session of sessions) {
+    const id = getSessionId(session)
+    if (!id) continue
+    const entry: {
+      id: string
+      title: string
+      messages?: Array<{ role: string; text: string }>
+    } = { id, title: getSessionTitle(session) }
+
+    if (body?.includeMessages) {
+      const messagesResult = await client.session.messages({ sessionID: id })
+      entry.messages = (messagesResult.data ?? [])
+        .map((message) => ({ role: getMessageRole(message), text: getMessageText(message).slice(0, 4000) }))
+        .filter((message) => message.text.trim().length > 0)
+        .slice(-maxMessages)
+    }
+
+    responseSessions.push(entry)
+  }
+
+  return NextResponse.json({ sessions: responseSessions })
+}

--- a/apps/web/src/app/api/u/[slug]/learning/__tests__/route.test.ts
+++ b/apps/web/src/app/api/u/[slug]/learning/__tests__/route.test.ts
@@ -1,0 +1,68 @@
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  createLearningRun: vi.fn(),
+  listLearningProposals: vi.fn(),
+  listLearningRuns: vi.fn(),
+}))
+
+vi.mock('@/lib/learning/service', () => ({
+  createLearningRun: mocks.createLearningRun,
+  listLearningProposals: mocks.listLearningProposals,
+  listLearningRuns: mocks.listLearningRuns,
+}))
+
+vi.mock('@/lib/runtime/with-auth', () => ({
+  withAuth: (_options: unknown, handler: (request: NextRequest, context: { slug: string; user: { id: string } }) => Promise<Response>) => {
+    return (request: NextRequest) => handler(request, { slug: 'alice', user: { id: 'user-1' } })
+  },
+}))
+
+import { GET, POST } from '../route'
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/u/alice/learning', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('/api/u/[slug]/learning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.listLearningRuns.mockResolvedValue([{ id: 'run-1' }])
+    mocks.listLearningProposals.mockResolvedValue([{ id: 'proposal-1' }])
+    mocks.createLearningRun.mockResolvedValue({ ok: true, run: { id: 'run-1' } })
+  })
+
+  it('lists learning runs and proposals', async () => {
+    const response = await GET(new NextRequest('http://localhost/api/u/alice/learning'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ runs: [{ id: 'run-1' }], proposals: [{ id: 'proposal-1' }] })
+  })
+
+  it('creates a manual learning run', async () => {
+    const response = await POST(makeRequest({ sourceSessionId: 'session-1', title: 'Session' }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.createLearningRun).toHaveBeenCalledWith({
+      userId: 'user-1',
+      slug: 'alice',
+      sourceSessionId: 'session-1',
+      title: 'Session',
+      trigger: 'manual',
+    })
+  })
+
+  it('returns create errors', async () => {
+    mocks.createLearningRun.mockResolvedValue({ ok: false, error: 'instance_unavailable' })
+
+    const response = await POST(makeRequest({}))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'instance_unavailable' })
+  })
+})

--- a/apps/web/src/app/api/u/[slug]/learning/proposals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/u/[slug]/learning/proposals/__tests__/route.test.ts
@@ -1,0 +1,67 @@
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  applyLearningProposal: vi.fn(),
+  rejectLearningProposal: vi.fn(),
+}))
+
+vi.mock('@/lib/learning/service', () => ({
+  applyLearningProposal: mocks.applyLearningProposal,
+  rejectLearningProposal: mocks.rejectLearningProposal,
+}))
+
+vi.mock('@/lib/runtime/with-auth', () => ({
+  withAuth: (_options: unknown, handler: (request: NextRequest, context: { slug: string; user: { id: string } }) => Promise<Response>) => {
+    return (request: NextRequest) => handler(request, { slug: 'alice', user: { id: 'user-1' } })
+  },
+}))
+
+import { POST } from '../route'
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/u/alice/learning/proposals', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('POST /api/u/[slug]/learning/proposals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.applyLearningProposal.mockResolvedValue({ ok: true, proposal: { id: 'proposal-1' } })
+    mocks.rejectLearningProposal.mockResolvedValue({ ok: true, proposal: { id: 'proposal-1' } })
+  })
+
+  it('rejects missing or unknown actions without applying', async () => {
+    for (const action of [undefined, '', 'delete']) {
+      const response = await POST(makeRequest({ proposalId: 'proposal-1', action }))
+      expect(response.status).toBe(400)
+    }
+
+    expect(mocks.applyLearningProposal).not.toHaveBeenCalled()
+    expect(mocks.rejectLearningProposal).not.toHaveBeenCalled()
+  })
+
+  it('applies only when action is apply', async () => {
+    const response = await POST(makeRequest({ proposalId: 'proposal-1', action: 'apply', content: 'edited' }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.applyLearningProposal).toHaveBeenCalledWith({
+      userId: 'user-1',
+      slug: 'alice',
+      proposalId: 'proposal-1',
+      content: 'edited',
+    })
+    expect(mocks.rejectLearningProposal).not.toHaveBeenCalled()
+  })
+
+  it('rejects only when action is reject', async () => {
+    const response = await POST(makeRequest({ proposalId: 'proposal-1', action: 'reject' }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.rejectLearningProposal).toHaveBeenCalledWith({ userId: 'user-1', proposalId: 'proposal-1' })
+    expect(mocks.applyLearningProposal).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/app/api/u/[slug]/learning/proposals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/u/[slug]/learning/proposals/__tests__/route.test.ts
@@ -44,6 +44,34 @@ describe('POST /api/u/[slug]/learning/proposals', () => {
     expect(mocks.rejectLearningProposal).not.toHaveBeenCalled()
   })
 
+  it('rejects invalid edited content without applying', async () => {
+    for (const content of ['', '   ', 'x'.repeat(200_001), 42]) {
+      const response = await POST(makeRequest({ proposalId: 'proposal-1', action: 'apply', content }))
+      expect(response.status).toBe(400)
+    }
+
+    expect(mocks.applyLearningProposal).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-string proposal ids', async () => {
+    const response = await POST(makeRequest({ proposalId: 42, action: 'apply' }))
+
+    expect(response.status).toBe(400)
+    expect(mocks.applyLearningProposal).not.toHaveBeenCalled()
+  })
+
+  it('applies without content using the stored proposal content', async () => {
+    const response = await POST(makeRequest({ proposalId: 'proposal-1', action: 'apply' }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.applyLearningProposal).toHaveBeenCalledWith({
+      userId: 'user-1',
+      slug: 'alice',
+      proposalId: 'proposal-1',
+      content: undefined,
+    })
+  })
+
   it('applies only when action is apply', async () => {
     const response = await POST(makeRequest({ proposalId: 'proposal-1', action: 'apply', content: 'edited' }))
 

--- a/apps/web/src/app/api/u/[slug]/learning/proposals/route.ts
+++ b/apps/web/src/app/api/u/[slug]/learning/proposals/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+
+import { applyLearningProposal, rejectLearningProposal } from '@/lib/learning/service'
+import { withAuth } from '@/lib/runtime/with-auth'
+import type { LearningProposal } from '@/types/learning'
+
+type ProposalActionRequest = {
+  action?: string
+  content?: string
+  proposalId?: string
+}
+
+export const POST = withAuth<{ proposal: LearningProposal } | { error: string }>(
+  { csrf: true },
+  async (request, context) => {
+    const body = (await request.json().catch(() => null)) as ProposalActionRequest | null
+    if (!body?.proposalId) {
+      return NextResponse.json({ error: 'invalid_request' }, { status: 400 })
+    }
+
+    if (body.action !== 'apply' && body.action !== 'reject') {
+      return NextResponse.json({ error: 'invalid_request' }, { status: 400 })
+    }
+
+    const result = body.action === 'reject'
+      ? await rejectLearningProposal({ userId: context.user.id, proposalId: body.proposalId })
+      : await applyLearningProposal({
+          userId: context.user.id,
+          slug: context.slug,
+          proposalId: body.proposalId,
+          content: body.content,
+        })
+
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: 400 })
+    }
+
+    return NextResponse.json({ proposal: result.proposal })
+  }
+)

--- a/apps/web/src/app/api/u/[slug]/learning/proposals/route.ts
+++ b/apps/web/src/app/api/u/[slug]/learning/proposals/route.ts
@@ -1,34 +1,27 @@
 import { NextResponse } from 'next/server'
 
 import { applyLearningProposal, rejectLearningProposal } from '@/lib/learning/service'
+import { parseProposalActionRequest } from '@/lib/learning/validation'
 import { withAuth } from '@/lib/runtime/with-auth'
 import type { LearningProposal } from '@/types/learning'
-
-type ProposalActionRequest = {
-  action?: string
-  content?: string
-  proposalId?: string
-}
 
 export const POST = withAuth<{ proposal: LearningProposal } | { error: string }>(
   { csrf: true },
   async (request, context) => {
-    const body = (await request.json().catch(() => null)) as ProposalActionRequest | null
-    if (!body?.proposalId) {
+    const body = await request.json().catch(() => null)
+    const parsed = parseProposalActionRequest(body)
+    if (!parsed.ok) {
       return NextResponse.json({ error: 'invalid_request' }, { status: 400 })
     }
 
-    if (body.action !== 'apply' && body.action !== 'reject') {
-      return NextResponse.json({ error: 'invalid_request' }, { status: 400 })
-    }
-
-    const result = body.action === 'reject'
-      ? await rejectLearningProposal({ userId: context.user.id, proposalId: body.proposalId })
+    const { action, proposalId, content } = parsed.value
+    const result = action === 'reject'
+      ? await rejectLearningProposal({ userId: context.user.id, proposalId })
       : await applyLearningProposal({
           userId: context.user.id,
           slug: context.slug,
-          proposalId: body.proposalId,
-          content: body.content,
+          proposalId,
+          content,
         })
 
     if (!result.ok) {

--- a/apps/web/src/app/api/u/[slug]/learning/route.ts
+++ b/apps/web/src/app/api/u/[slug]/learning/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server'
+
+import {
+  createLearningRun,
+  listLearningProposals,
+  listLearningRuns,
+} from '@/lib/learning/service'
+import { withAuth } from '@/lib/runtime/with-auth'
+import type { LearningProposal, LearningRun } from '@/types/learning'
+
+type LearningResponse = {
+  proposals: LearningProposal[]
+  runs: LearningRun[]
+}
+
+type CreateLearningRunRequest = {
+  sourceSessionId?: string
+  title?: string
+}
+
+export const GET = withAuth<LearningResponse | { error: string }>(
+  { csrf: false },
+  async (_request, context) => {
+    const [runs, proposals] = await Promise.all([
+      listLearningRuns(context.user.id),
+      listLearningProposals(context.user.id),
+    ])
+    return NextResponse.json({ runs, proposals })
+  }
+)
+
+export const POST = withAuth<{ run: LearningRun } | { error: string }>(
+  { csrf: true },
+  async (request, context) => {
+    const body = (await request.json().catch(() => null)) as CreateLearningRunRequest | null
+    const result = await createLearningRun({
+      userId: context.user.id,
+      slug: context.slug,
+      sourceSessionId: body?.sourceSessionId ?? null,
+      title: body?.title,
+      trigger: 'manual',
+    })
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: 400 })
+    }
+    return NextResponse.json({ run: result.run })
+  }
+)

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { getIdleFinalizationOutcome, getSilentStreamOutcome } from '@/app/api/w/[slug]/chat/stream/watchdog'
 import { createUpstreamSessionStatusReader } from '@/app/api/w/[slug]/chat/stream/status-reader'
+import { maybeQueueAutoLearningRun } from '@/lib/learning/service'
 import { getInstanceUrl } from '@/lib/opencode/client'
 import { ensureProviderAccessFreshForExecution } from '@/lib/opencode/providers'
 import {
@@ -194,6 +195,43 @@ async function readRuntimeSessionState(params: {
     return 'unknown'
   } catch {
     return 'unknown'
+  }
+}
+
+async function queueAutoLearningBestEffort(params: {
+  authHeader: string
+  baseUrl: string
+  sessionId: string
+  slug: string
+  userId: string
+}): Promise<void> {
+  try {
+    const [sessionResponse, messagesResponse] = await Promise.all([
+      fetch(`${params.baseUrl}/session/${params.sessionId}`, {
+        headers: { Authorization: params.authHeader, Accept: 'application/json' },
+        cache: 'no-store',
+      }),
+      fetch(`${params.baseUrl}/session/${params.sessionId}/message`, {
+        headers: { Authorization: params.authHeader, Accept: 'application/json' },
+        cache: 'no-store',
+      }),
+    ])
+    const sessionData: unknown = await sessionResponse.json().catch(() => null)
+    const messagesData: unknown = await messagesResponse.json().catch(() => null)
+    const sessionTitle = isRecord(sessionData) && typeof sessionData.title === 'string'
+      ? sessionData.title
+      : 'Session'
+    const messageCount = Array.isArray(messagesData) ? messagesData.length : 0
+
+    await maybeQueueAutoLearningRun({
+      userId: params.userId,
+      slug: params.slug,
+      sessionId: params.sessionId,
+      sessionTitle,
+      messageCount,
+    })
+  } catch {
+    // Auto-learning is best-effort and must not affect chat streaming.
   }
 }
 
@@ -576,6 +614,7 @@ export const POST = withAuth(
           sendEvent('done', { refresh: true })
           recordRunUsage()
           markRunSucceeded()
+          void queueAutoLearningBestEffort({ authHeader, baseUrl, sessionId, slug, userId: user.id })
           aborted = true
         }
 

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { getIdleFinalizationOutcome, getSilentStreamOutcome } from '@/app/api/w/[slug]/chat/stream/watchdog'
 import { createUpstreamSessionStatusReader } from '@/app/api/w/[slug]/chat/stream/status-reader'
-import { canQueueAutoLearningRun, maybeQueueAutoLearningRun } from '@/lib/learning/service'
+import { AUTO_LEARNING_MIN_MESSAGES, canQueueAutoLearningRun, maybeQueueAutoLearningRun } from '@/lib/learning/service'
 import { getInstanceUrl } from '@/lib/opencode/client'
 import { ensureProviderAccessFreshForExecution } from '@/lib/opencode/providers'
 import {
@@ -208,22 +208,27 @@ async function queueAutoLearningBestEffort(params: {
   try {
     if (!(await canQueueAutoLearningRun({ userId: params.userId, sessionId: params.sessionId }))) return
 
-    const [sessionResponse, messagesResponse] = await Promise.all([
-      fetch(`${params.baseUrl}/session/${params.sessionId}`, {
+    // Fetch only enough messages to know whether the threshold is met; the full
+    // list can be large and this helper runs after every successful completion.
+    const messagesResponse = await fetch(
+      `${params.baseUrl}/session/${params.sessionId}/message?limit=${AUTO_LEARNING_MIN_MESSAGES}`,
+      {
         headers: { Authorization: params.authHeader, Accept: 'application/json' },
         cache: 'no-store',
-      }),
-      fetch(`${params.baseUrl}/session/${params.sessionId}/message`, {
-        headers: { Authorization: params.authHeader, Accept: 'application/json' },
-        cache: 'no-store',
-      }),
-    ])
-    const sessionData: unknown = await sessionResponse.json().catch(() => null)
+      },
+    )
     const messagesData: unknown = await messagesResponse.json().catch(() => null)
+    const messageCount = Array.isArray(messagesData) ? messagesData.length : 0
+    if (messageCount < AUTO_LEARNING_MIN_MESSAGES) return
+
+    const sessionResponse = await fetch(`${params.baseUrl}/session/${params.sessionId}`, {
+      headers: { Authorization: params.authHeader, Accept: 'application/json' },
+      cache: 'no-store',
+    })
+    const sessionData: unknown = await sessionResponse.json().catch(() => null)
     const sessionTitle = isRecord(sessionData) && typeof sessionData.title === 'string'
       ? sessionData.title
       : 'Session'
-    const messageCount = Array.isArray(messagesData) ? messagesData.length : 0
 
     await maybeQueueAutoLearningRun({
       userId: params.userId,

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { getIdleFinalizationOutcome, getSilentStreamOutcome } from '@/app/api/w/[slug]/chat/stream/watchdog'
 import { createUpstreamSessionStatusReader } from '@/app/api/w/[slug]/chat/stream/status-reader'
-import { maybeQueueAutoLearningRun } from '@/lib/learning/service'
+import { canQueueAutoLearningRun, maybeQueueAutoLearningRun } from '@/lib/learning/service'
 import { getInstanceUrl } from '@/lib/opencode/client'
 import { ensureProviderAccessFreshForExecution } from '@/lib/opencode/providers'
 import {
@@ -206,6 +206,8 @@ async function queueAutoLearningBestEffort(params: {
   userId: string
 }): Promise<void> {
   try {
+    if (!(await canQueueAutoLearningRun({ userId: params.userId, sessionId: params.sessionId }))) return
+
     const [sessionResponse, messagesResponse] = await Promise.all([
       fetch(`${params.baseUrl}/session/${params.sessionId}`, {
         headers: { Authorization: params.authHeader, Accept: 'application/json' },

--- a/apps/web/src/components/workspace/__tests__/knowledge-curator-panel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/knowledge-curator-panel.test.tsx
@@ -1,0 +1,65 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { KnowledgeCuratorPanel } from '@/components/workspace/knowledge-curator-panel'
+
+const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+
+function jsonResponse(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  })
+}
+
+const learningResponse = {
+  runs: [],
+  proposals: [
+    {
+      id: 'proposal-1',
+      runId: 'run-1',
+      status: 'pending',
+      title: 'Remember preference',
+      type: 'preference',
+      confidence: 0.8,
+      evidence: { quote: 'Use concise answers' },
+      kbPath: 'Preferences/Answers.md',
+      operation: 'update',
+      proposedContent: 'Use concise answers.',
+      currentFileHash: 'hash-old',
+      internalSessionId: null,
+      trigger: 'agent',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+  ],
+}
+
+describe('KnowledgeCuratorPanel', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock)
+    fetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('surfaces proposal action errors', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(learningResponse))
+      .mockResolvedValueOnce(jsonResponse({ error: 'hash_conflict' }, { status: 409 }))
+      .mockResolvedValueOnce(jsonResponse(learningResponse))
+
+    render(<KnowledgeCuratorPanel slug="alice" />)
+
+    expect(await screen.findByText('Remember preference')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
+
+    expect(await screen.findByText('hash_conflict')).toBeTruthy()
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+  })
+})

--- a/apps/web/src/components/workspace/__tests__/knowledge-curator-panel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/knowledge-curator-panel.test.tsx
@@ -48,7 +48,7 @@ describe('KnowledgeCuratorPanel', () => {
     vi.unstubAllGlobals()
   })
 
-  it('surfaces proposal action errors', async () => {
+  it('surfaces proposal action errors with readable labels', async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse(learningResponse))
       .mockResolvedValueOnce(jsonResponse({ error: 'hash_conflict' }, { status: 409 }))
@@ -59,7 +59,58 @@ describe('KnowledgeCuratorPanel', () => {
     expect(await screen.findByText('Remember preference')).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
 
-    expect(await screen.findByText('hash_conflict')).toBeTruthy()
+    expect(await screen.findByText('The target file changed since this proposal was created. Review it before applying.')).toBeTruthy()
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+  })
+
+  it('shows a readable error when loading fails on the network', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'))
+
+    render(<KnowledgeCuratorPanel slug="alice" />)
+
+    expect(await screen.findByText('Could not load learning data.')).toBeTruthy()
+  })
+
+  it('disables action buttons while an action is in flight', async () => {
+    let resolveAction: ((response: Response) => void) | undefined
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(learningResponse))
+      .mockImplementationOnce(() => new Promise<Response>((resolve) => { resolveAction = resolve }))
+      .mockResolvedValueOnce(jsonResponse({ runs: [], proposals: [] }))
+
+    render(<KnowledgeCuratorPanel slug="alice" />)
+
+    expect(await screen.findByText('Remember preference')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
+
+    await waitFor(() => {
+      expect((screen.getByRole('button', { name: 'Apply' }) as HTMLButtonElement).disabled).toBe(true)
+      expect((screen.getByRole('button', { name: 'Reject' }) as HTMLButtonElement).disabled).toBe(true)
+    })
+
+    resolveAction?.(jsonResponse({ proposal: { id: 'proposal-1' } }))
+
+    expect(await screen.findByText('No pending proposals.')).toBeTruthy()
+  })
+
+  it('refetches when refreshKey changes', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(learningResponse))
+
+    const { rerender } = render(<KnowledgeCuratorPanel slug="alice" refreshKey={0} />)
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    rerender(<KnowledgeCuratorPanel slug="alice" refreshKey={1} />)
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('renders a collapsed rail that expands through the toggle', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(learningResponse))
+    const onToggleCollapse = vi.fn()
+
+    render(<KnowledgeCuratorPanel slug="alice" collapsed onToggleCollapse={onToggleCollapse} />)
+
+    expect(screen.queryByText('Knowledge Curator')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Expand curator panel' }))
+    expect(onToggleCollapse).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/components/workspace/__tests__/workspace-shell.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/workspace-shell.test.tsx
@@ -368,6 +368,10 @@ describe("WorkspaceShell", () => {
         });
       }
 
+      if (url.endsWith("/learning")) {
+        return jsonResponse({ runs: [], proposals: [] });
+      }
+
       return jsonResponse({ ok: true });
     }));
     Object.defineProperty(HTMLElement.prototype, "setPointerCapture", {
@@ -1209,6 +1213,18 @@ describe("WorkspaceShell", () => {
     });
 
     expect(readCookieValue("arche-workspace-layout-alice")).toContain('"leftCollapsed":true');
+  });
+
+  it("starts with the curator panel collapsed in chat mode and expands it on demand", async () => {
+    render(<WorkspaceShell slug="alice" />);
+
+    const expandButton = await screen.findByRole("button", { name: "Expand curator panel" });
+    expect(screen.queryByText("Knowledge Curator")).toBeNull();
+
+    fireEvent.click(expandButton);
+
+    expect(await screen.findByText("Knowledge Curator")).toBeTruthy();
+    expect(await screen.findByText("No pending proposals.")).toBeTruthy();
   });
 
   it("shows chat as default view in compact layout", async () => {

--- a/apps/web/src/components/workspace/__tests__/workspace-shell.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/workspace-shell.test.tsx
@@ -1220,7 +1220,7 @@ describe("WorkspaceShell", () => {
     });
 
     expect(screen.getByText("Chat Panel")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Open review panel" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Open review panel" })).toBeTruthy();
   });
 
   it("switches to full-screen left panel and back in compact layout", async () => {

--- a/apps/web/src/components/workspace/chat-panel.tsx
+++ b/apps/web/src/components/workspace/chat-panel.tsx
@@ -86,6 +86,7 @@ type ChatPanelProps = {
   sessionTabs?: SessionTabInfo[];
   openFilePaths: string[];
   onCloseSession: (id: string) => void;
+  onLearnSession?: (session: ChatSession) => Promise<void> | void;
   onRenameSession?: (id: string, title: string) => Promise<boolean>;
   onSelectSessionTab?: (id: string) => void;
   onOpenFile: (path: string) => void;
@@ -210,6 +211,7 @@ export function ChatPanel({
   sessionTabs = EMPTY_SESSION_TABS,
   openFilePaths,
   onCloseSession,
+  onLearnSession,
   onRenameSession,
   onSelectSessionTab,
   onOpenFile,
@@ -1065,6 +1067,7 @@ export function ChatPanel({
         isSavingTitle={isSavingTitle}
         onCloseSession={onCloseSession}
         onExportSessionMarkdown={handleExportSessionMarkdown}
+        onLearnSession={activeSession && onLearnSession ? () => onLearnSession(activeSession) : undefined}
         onStartSessionRename={startSessionRename}
         onSubmitSessionRename={submitSessionRename}
         onTitleInputChange={(nextTitle) => {

--- a/apps/web/src/components/workspace/chat-panel/message-part-renderer.tsx
+++ b/apps/web/src/components/workspace/chat-panel/message-part-renderer.tsx
@@ -92,6 +92,8 @@ const TOOL_LABELS: Record<string, string> = {
   chart_create: 'Creating chart',
   diagram_create: 'Creating diagram',
   flow_propose: 'Proposing flow',
+  learning_propose: 'Proposing KB learning',
+  session_history_query: 'Querying session history',
   todowrite: 'Planning',
   todoread: 'Reviewing plan',
 }

--- a/apps/web/src/components/workspace/chat-panel/session-header.tsx
+++ b/apps/web/src/components/workspace/chat-panel/session-header.tsx
@@ -31,6 +31,7 @@ type ChatPanelSessionHeaderProps = {
   isSavingTitle: boolean;
   onCloseSession: (id: string) => void;
   onExportSessionMarkdown: () => void;
+  onLearnSession?: () => void;
   onStartSessionRename: () => void;
   onSubmitSessionRename: (rawTitle?: string) => Promise<void> | void;
   onTitleInputChange: (value: string) => void;
@@ -51,6 +52,7 @@ export function ChatPanelSessionHeader({
   isSavingTitle,
   onCloseSession,
   onExportSessionMarkdown,
+  onLearnSession,
   onStartSessionRename,
   onSubmitSessionRename,
   onTitleInputChange,
@@ -135,6 +137,11 @@ export function ChatPanelSessionHeader({
                       <DownloadSimple size={14} />
                       Export to MD
                     </DropdownMenuItem>
+                    {onLearnSession ? (
+                      <DropdownMenuItem onSelect={onLearnSession}>
+                        Learn
+                      </DropdownMenuItem>
+                    ) : null}
                     {canDeleteSession ? (
                       <>
                         <DropdownMenuSeparator />

--- a/apps/web/src/components/workspace/knowledge-curator-panel.tsx
+++ b/apps/web/src/components/workspace/knowledge-curator-panel.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import type { LearningProposal, LearningRun } from "@/types/learning";
+
+type KnowledgeCuratorPanelProps = {
+  slug: string;
+}
+
+type LearningResponse = {
+  proposals: LearningProposal[];
+  runs: LearningRun[];
+}
+
+export function KnowledgeCuratorPanel({ slug }: KnowledgeCuratorPanelProps) {
+  const [data, setData] = useState<LearningResponse>({ proposals: [], runs: [] });
+  const [edits, setEdits] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    const response = await fetch(`/api/u/${slug}/learning`, { cache: "no-store" });
+    const json = (await response.json().catch(() => null)) as LearningResponse | { error?: string } | null;
+    const error = json && "error" in json && typeof json.error === "string" ? json.error : null;
+    if (!response.ok || !json || error || !('runs' in json) || !('proposals' in json)) {
+      setError(error ?? "learning_load_failed");
+      return;
+    }
+    setError(null);
+    setData(json);
+  }, [slug]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      void refresh();
+    }, 0);
+
+    return () => window.clearTimeout(timeout);
+  }, [refresh]);
+
+  const actOnProposal = useCallback(
+    async (proposalId: string, action: "apply" | "reject", content?: string) => {
+      await fetch(`/api/u/${slug}/learning/proposals`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action, proposalId, content }),
+      });
+      await refresh();
+      setEdits((current) => {
+        const next = { ...current };
+        delete next[proposalId];
+        return next;
+      });
+    },
+    [refresh, slug]
+  );
+
+  return (
+    <aside className="flex h-full min-h-0 flex-col border-l border-border/60 bg-card/80 text-card-foreground">
+      <div className="border-b border-border/60 px-4 py-3">
+        <h2 className="text-sm font-semibold">Knowledge Curator</h2>
+        <p className="text-xs text-muted-foreground">Review learning runs and pending KB proposals.</p>
+      </div>
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
+        {error ? <p className="text-xs text-destructive">{error}</p> : null}
+        <section className="space-y-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Pending proposals</h3>
+          {data.proposals.filter((proposal) => proposal.status === "pending").map((proposal) => (
+            <article key={proposal.id} className="space-y-2 rounded-lg border border-border/60 bg-background/60 p-3">
+              <div>
+                <p className="text-sm font-medium">{proposal.title}</p>
+                <p className="text-xs text-muted-foreground">{proposal.operation} {proposal.kbPath} · {Math.round(proposal.confidence * 100)}%</p>
+              </div>
+              {proposal.evidence.quote ? (
+                <blockquote className="rounded bg-muted/40 p-2 text-xs text-muted-foreground">{proposal.evidence.quote}</blockquote>
+              ) : null}
+              <textarea
+                className="h-28 w-full rounded-md border border-border bg-background p-2 text-xs outline-none"
+                value={edits[proposal.id] ?? proposal.proposedContent}
+                onChange={(event) => {
+                  setEdits((current) => ({ ...current, [proposal.id]: event.currentTarget.value }));
+                }}
+              />
+              <div className="flex justify-end gap-2">
+                <Button size="sm" variant="outline" onClick={() => void actOnProposal(proposal.id, "reject")}>Reject</Button>
+                <Button size="sm" onClick={() => void actOnProposal(proposal.id, "apply", edits[proposal.id] ?? proposal.proposedContent)}>Apply</Button>
+              </div>
+            </article>
+          ))}
+          {data.proposals.every((proposal) => proposal.status !== "pending") ? (
+            <p className="text-xs text-muted-foreground">No pending proposals.</p>
+          ) : null}
+        </section>
+        <section className="space-y-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Recent runs</h3>
+          {data.runs.map((run) => (
+            <div key={run.id} className="rounded-md border border-border/60 p-2 text-xs">
+              <p className="font-medium">{run.title}</p>
+              <p className="text-muted-foreground">{run.trigger} · {run.status}</p>
+            </div>
+          ))}
+        </section>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/workspace/knowledge-curator-panel.tsx
+++ b/apps/web/src/components/workspace/knowledge-curator-panel.tsx
@@ -41,11 +41,19 @@ export function KnowledgeCuratorPanel({ slug }: KnowledgeCuratorPanelProps) {
 
   const actOnProposal = useCallback(
     async (proposalId: string, action: "apply" | "reject", content?: string) => {
-      await fetch(`/api/u/${slug}/learning/proposals`, {
+      const response = await fetch(`/api/u/${slug}/learning/proposals`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ action, proposalId, content }),
       });
+      const json = (await response.json().catch(() => null)) as { error?: string } | null;
+      if (!response.ok) {
+        await refresh();
+        setError(json?.error ?? "learning_action_failed");
+        return;
+      }
+
+      setError(null);
       await refresh();
       setEdits((current) => {
         const next = { ...current };

--- a/apps/web/src/components/workspace/knowledge-curator-panel.tsx
+++ b/apps/web/src/components/workspace/knowledge-curator-panel.tsx
@@ -7,6 +7,9 @@ import type { LearningProposal, LearningRun } from "@/types/learning";
 
 type KnowledgeCuratorPanelProps = {
   slug: string;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+  refreshKey?: number;
 }
 
 type LearningResponse = {
@@ -14,21 +17,41 @@ type LearningResponse = {
   runs: LearningRun[];
 }
 
-export function KnowledgeCuratorPanel({ slug }: KnowledgeCuratorPanelProps) {
+const ERROR_LABELS: Record<string, string> = {
+  hash_conflict: "The target file changed since this proposal was created. Review it before applying.",
+  not_pending: "This proposal was already resolved.",
+  not_found: "Proposal not found.",
+  file_exists: "The target file already exists.",
+  workspace_agent_unavailable: "The workspace agent is unavailable. Try again later.",
+  invalid_request: "The request was invalid.",
+  learning_load_failed: "Could not load learning data.",
+  learning_action_failed: "The action failed. Try again.",
+};
+
+function errorLabel(code: string): string {
+  return ERROR_LABELS[code] ?? code;
+}
+
+export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollapse, refreshKey = 0 }: KnowledgeCuratorPanelProps) {
   const [data, setData] = useState<LearningResponse>({ proposals: [], runs: [] });
   const [edits, setEdits] = useState<Record<string, string>>({});
   const [error, setError] = useState<string | null>(null);
+  const [busyProposalId, setBusyProposalId] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
-    const response = await fetch(`/api/u/${slug}/learning`, { cache: "no-store" });
-    const json = (await response.json().catch(() => null)) as LearningResponse | { error?: string } | null;
-    const error = json && "error" in json && typeof json.error === "string" ? json.error : null;
-    if (!response.ok || !json || error || !('runs' in json) || !('proposals' in json)) {
-      setError(error ?? "learning_load_failed");
-      return;
+    try {
+      const response = await fetch(`/api/u/${slug}/learning`, { cache: "no-store" });
+      const json = (await response.json().catch(() => null)) as LearningResponse | { error?: string } | null;
+      const error = json && "error" in json && typeof json.error === "string" ? json.error : null;
+      if (!response.ok || !json || error || !('runs' in json) || !('proposals' in json)) {
+        setError(error ?? "learning_load_failed");
+        return;
+      }
+      setError(null);
+      setData(json);
+    } catch {
+      setError("learning_load_failed");
     }
-    setError(null);
-    setData(json);
   }, [slug]);
 
   useEffect(() => {
@@ -37,41 +60,80 @@ export function KnowledgeCuratorPanel({ slug }: KnowledgeCuratorPanelProps) {
     }, 0);
 
     return () => window.clearTimeout(timeout);
-  }, [refresh]);
+  }, [refresh, refreshKey]);
 
   const actOnProposal = useCallback(
     async (proposalId: string, action: "apply" | "reject", content?: string) => {
-      const response = await fetch(`/api/u/${slug}/learning/proposals`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action, proposalId, content }),
-      });
-      const json = (await response.json().catch(() => null)) as { error?: string } | null;
-      if (!response.ok) {
-        await refresh();
-        setError(json?.error ?? "learning_action_failed");
-        return;
-      }
+      setBusyProposalId(proposalId);
+      try {
+        const response = await fetch(`/api/u/${slug}/learning/proposals`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action, proposalId, content }),
+        });
+        const json = (await response.json().catch(() => null)) as { error?: string } | null;
+        if (!response.ok) {
+          await refresh();
+          setError(json?.error ?? "learning_action_failed");
+          return;
+        }
 
-      setError(null);
-      await refresh();
-      setEdits((current) => {
-        const next = { ...current };
-        delete next[proposalId];
-        return next;
-      });
+        setError(null);
+        await refresh();
+        setEdits((current) => {
+          const next = { ...current };
+          delete next[proposalId];
+          return next;
+        });
+      } catch {
+        setError("learning_action_failed");
+      } finally {
+        setBusyProposalId(null);
+      }
     },
     [refresh, slug]
   );
 
+  if (collapsed) {
+    return (
+      <aside className="h-full border-l border-border/60 bg-card/80 text-card-foreground">
+        <button
+          type="button"
+          onClick={onToggleCollapse}
+          aria-label="Expand curator panel"
+          className="group flex h-full w-full cursor-pointer flex-col items-center gap-3 py-4 text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"
+        >
+          <span
+            className="text-[11px] font-medium uppercase tracking-[0.22em] text-muted-foreground/80 transition-colors group-hover:text-foreground"
+            style={{ writingMode: "vertical-rl" }}
+          >
+            Curator
+          </span>
+        </button>
+      </aside>
+    );
+  }
+
   return (
     <aside className="flex h-full min-h-0 flex-col border-l border-border/60 bg-card/80 text-card-foreground">
-      <div className="border-b border-border/60 px-4 py-3">
-        <h2 className="text-sm font-semibold">Knowledge Curator</h2>
-        <p className="text-xs text-muted-foreground">Review learning runs and pending KB proposals.</p>
+      <div className="flex items-start justify-between border-b border-border/60 px-4 py-3">
+        <div>
+          <h2 className="text-sm font-semibold">Knowledge Curator</h2>
+          <p className="text-xs text-muted-foreground">Review learning runs and pending KB proposals.</p>
+        </div>
+        {onToggleCollapse ? (
+          <button
+            type="button"
+            onClick={onToggleCollapse}
+            aria-label="Collapse curator panel"
+            className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"
+          >
+            <span aria-hidden>»</span>
+          </button>
+        ) : null}
       </div>
       <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
-        {error ? <p className="text-xs text-destructive">{error}</p> : null}
+        {error ? <p className="text-xs text-destructive">{errorLabel(error)}</p> : null}
         <section className="space-y-2">
           <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Pending proposals</h3>
           {data.proposals.filter((proposal) => proposal.status === "pending").map((proposal) => (
@@ -86,13 +148,27 @@ export function KnowledgeCuratorPanel({ slug }: KnowledgeCuratorPanelProps) {
               <textarea
                 className="h-28 w-full rounded-md border border-border bg-background p-2 text-xs outline-none"
                 value={edits[proposal.id] ?? proposal.proposedContent}
+                disabled={busyProposalId === proposal.id}
                 onChange={(event) => {
                   setEdits((current) => ({ ...current, [proposal.id]: event.currentTarget.value }));
                 }}
               />
               <div className="flex justify-end gap-2">
-                <Button size="sm" variant="outline" onClick={() => void actOnProposal(proposal.id, "reject")}>Reject</Button>
-                <Button size="sm" onClick={() => void actOnProposal(proposal.id, "apply", edits[proposal.id] ?? proposal.proposedContent)}>Apply</Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={busyProposalId !== null}
+                  onClick={() => void actOnProposal(proposal.id, "reject")}
+                >
+                  Reject
+                </Button>
+                <Button
+                  size="sm"
+                  disabled={busyProposalId !== null}
+                  onClick={() => void actOnProposal(proposal.id, "apply", edits[proposal.id] ?? proposal.proposedContent)}
+                >
+                  Apply
+                </Button>
               </div>
             </article>
           ))}

--- a/apps/web/src/components/workspace/workspace-shell.tsx
+++ b/apps/web/src/components/workspace/workspace-shell.tsx
@@ -474,12 +474,16 @@ export function WorkspaceShell({
   // Layout state
   const [minCenterWidth, setMinCenterWidth] = useState(MIN_CENTER_PX);
   const buildInitialCollapseByMode = useCallback(
-    (legacy?: boolean, byMode?: Record<string, boolean>): Record<WorkspaceMode, boolean> => {
-      const fallback = legacy ?? false;
+    (
+      legacy?: boolean,
+      byMode?: Record<string, boolean>,
+      defaults?: Partial<Record<WorkspaceMode, boolean>>
+    ): Record<WorkspaceMode, boolean> => {
+      const pickMode = (mode: WorkspaceMode) => byMode?.[mode] ?? legacy ?? defaults?.[mode] ?? false;
       return {
-        chat: byMode?.chat ?? fallback,
-        flows: byMode?.flows ?? fallback,
-        knowledge: byMode?.knowledge ?? fallback,
+        chat: pickMode("chat"),
+        flows: pickMode("flows"),
+        knowledge: pickMode("knowledge"),
       };
     },
     []
@@ -505,7 +509,9 @@ export function WorkspaceShell({
     buildInitialCollapseByMode(initialLayoutState?.leftCollapsed, initialLayoutState?.leftCollapsedByMode)
   );
   const [rightCollapsedByMode, setRightCollapsedByMode] = useState<Record<WorkspaceMode, boolean>>(() =>
-    buildInitialCollapseByMode(initialLayoutState?.rightCollapsed, initialLayoutState?.rightCollapsedByMode)
+    // The chat-mode right panel (Knowledge Curator) starts collapsed so it does
+    // not take space away from the conversation by default.
+    buildInitialCollapseByMode(initialLayoutState?.rightCollapsed, initialLayoutState?.rightCollapsedByMode, { chat: true })
   );
   const [leftWidthByMode, setLeftWidthByMode] = useState<Record<WorkspaceMode, number>>(() =>
     buildInitialWidthByMode(initialLayoutState?.leftWidth, initialLayoutState?.leftWidthByMode, MIN_LEFT_PX)
@@ -1103,7 +1109,7 @@ export function WorkspaceShell({
       stored?.rightCollapsedByMode
     ) {
       setRightCollapsedByMode(
-        buildInitialCollapseByMode(stored?.rightCollapsed, stored?.rightCollapsedByMode)
+        buildInitialCollapseByMode(stored?.rightCollapsed, stored?.rightCollapsedByMode, { chat: true })
       );
     }
     if (
@@ -1380,13 +1386,21 @@ export function WorkspaceShell({
     [workspace]
   );
 
+  const [learningRefreshKey, setLearningRefreshKey] = useState(0);
+
   const handleLearnSession = useCallback(
     async (session: { id: string; title: string }) => {
-      await fetch(`/api/u/${slug}/learning`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sourceSessionId: session.id, title: session.title }),
-      });
+      try {
+        await fetch(`/api/u/${slug}/learning`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sourceSessionId: session.id, title: session.title }),
+        });
+      } catch {
+        // The curator panel reflects server state on refresh; a failed enqueue
+        // simply shows no new run.
+      }
+      setLearningRefreshKey((current) => current + 1);
       setRightCollapsedForMode(workspaceMode, false);
     },
     [setRightCollapsedForMode, slug, workspaceMode]
@@ -1875,7 +1889,14 @@ export function WorkspaceShell({
     ? previewPanelElement
     : isKnowledgeMode
       ? reviewPanelElement
-      : <KnowledgeCuratorPanel slug={slug} />;
+      : (
+          <KnowledgeCuratorPanel
+            slug={slug}
+            collapsed={isCompactLayout ? false : rightCollapsed}
+            onToggleCollapse={isCompactLayout ? handleShowChat : handleToggleRight}
+            refreshKey={learningRefreshKey}
+          />
+        );
 
   const isLeftPanelActive = mobileView === "left";
   const isChatActive = mobileView === "chat";

--- a/apps/web/src/components/workspace/workspace-shell.tsx
+++ b/apps/web/src/components/workspace/workspace-shell.tsx
@@ -45,6 +45,7 @@ import { ArcLoader } from "./arc-loader";
 import { FilePreviewPanel } from "./file-preview-panel";
 import { InspectorPanel } from "./inspector-panel";
 import { KnowledgeEmptyState } from "./knowledge-empty-state";
+import { KnowledgeCuratorPanel } from "./knowledge-curator-panel";
 import { KnowledgeNavigationPanel, type KnowledgeNavigationView } from "./knowledge-navigation-panel";
 import { FlowsEmptyState } from "./flows-empty-state";
 import { WorkspaceCommandPalette } from "./workspace-command-palette";
@@ -1379,6 +1380,18 @@ export function WorkspaceShell({
     [workspace]
   );
 
+  const handleLearnSession = useCallback(
+    async (session: { id: string; title: string }) => {
+      await fetch(`/api/u/${slug}/learning`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sourceSessionId: session.id, title: session.title }),
+      });
+      setRightCollapsedForMode(workspaceMode, false);
+    },
+    [setRightCollapsedForMode, slug, workspaceMode]
+  );
+
   const handleFlowHumanResponseSubmitted = useCallback(async () => {
     await Promise.all([
       workspace.refreshMessages(),
@@ -1746,6 +1759,7 @@ export function WorkspaceShell({
       sessionTabs={activeSessionTabs}
       openFilePaths={openFilePaths}
       onCloseSession={handleCloseSession}
+      onLearnSession={handleLearnSession}
       onRenameSession={handleRenameSession}
       onSelectSessionTab={handleSelectSessionTab}
       onOpenFile={handleOpenFile}
@@ -1856,8 +1870,12 @@ export function WorkspaceShell({
     />
   ) : null;
   const hasPreviewPanel = !isKnowledgeMode && previewFilePath !== null;
-  const hasRightPanel = isKnowledgeMode || hasPreviewPanel;
-  const rightPanelContent = hasPreviewPanel ? previewPanelElement : reviewPanelElement;
+  const hasRightPanel = isKnowledgeMode || hasPreviewPanel || workspaceMode === "chat";
+  const rightPanelContent = hasPreviewPanel
+    ? previewPanelElement
+    : isKnowledgeMode
+      ? reviewPanelElement
+      : <KnowledgeCuratorPanel slug={slug} />;
 
   const isLeftPanelActive = mobileView === "left";
   const isChatActive = mobileView === "chat";

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -27,6 +27,7 @@ export const OPENCODE_AGENT_TOOLS = [
   'spreadsheet_sample',
   'spreadsheet_query',
   'spreadsheet_stats',
+  'session_history_query',
 ] as const
 
 export type OpenCodeAgentToolId = (typeof OPENCODE_AGENT_TOOLS)[number]
@@ -55,6 +56,7 @@ export const OPENCODE_AGENT_TOOL_OPTIONS: Array<{
   { id: 'spreadsheet_sample', label: 'Sample spreadsheet rows' },
   { id: 'spreadsheet_query', label: 'Query spreadsheet data' },
   { id: 'spreadsheet_stats', label: 'Spreadsheet statistics' },
+  { id: 'session_history_query', label: 'Query session history' },
 ]
 
 export type AgentCapabilities = {

--- a/apps/web/src/lib/learning/__tests__/proposal-application.test.ts
+++ b/apps/web/src/lib/learning/__tests__/proposal-application.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { applyLearningProposal, rejectLearningProposal } from '@/lib/learning/proposal-application'
+import type { LearningProposal } from '@/types/learning'
+
+const mocks = vi.hoisted(() => ({
+  auditEvent: vi.fn(),
+  createWorkspaceAgentClient: vi.fn(),
+  findPendingLearningProposal: vi.fn(),
+  updatePendingLearningProposalApplied: vi.fn(),
+  updatePendingLearningProposalRejected: vi.fn(),
+  workspaceAgentFetch: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({ auditEvent: mocks.auditEvent }))
+vi.mock('@/lib/workspace-agent/client', () => ({ createWorkspaceAgentClient: mocks.createWorkspaceAgentClient }))
+vi.mock('@/lib/workspace-agent-client', () => ({ workspaceAgentFetch: mocks.workspaceAgentFetch }))
+vi.mock('@/lib/learning/repository', () => ({
+  findPendingLearningProposal: mocks.findPendingLearningProposal,
+  updatePendingLearningProposalApplied: mocks.updatePendingLearningProposalApplied,
+  updatePendingLearningProposalRejected: mocks.updatePendingLearningProposalRejected,
+}))
+
+const proposal: LearningProposal = {
+  id: 'proposal-1',
+  runId: 'run-1',
+  status: 'pending',
+  title: 'Remember preference',
+  type: 'preference',
+  confidence: 0.9,
+  evidence: { quote: 'Prefer concise answers' },
+  kbPath: 'Preferences/Answers.md',
+  operation: 'update',
+  proposedContent: 'Prefer concise answers.',
+  currentFileHash: 'hash-old',
+  internalSessionId: null,
+  trigger: 'agent',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+describe('applyLearningProposal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.createWorkspaceAgentClient.mockResolvedValue({ baseUrl: 'http://agent', authHeader: 'Basic x' })
+    mocks.findPendingLearningProposal.mockResolvedValue(proposal)
+    mocks.updatePendingLearningProposalApplied.mockResolvedValue({ ...proposal, status: 'applied' })
+  })
+
+  it('rejects create proposals when the target file already exists', async () => {
+    mocks.findPendingLearningProposal.mockResolvedValue({ ...proposal, operation: 'create', currentFileHash: null })
+    mocks.workspaceAgentFetch.mockResolvedValueOnce({ ok: true, data: { hash: 'existing' }, status: 200 })
+
+    const result = await applyLearningProposal({ userId: 'user-1', slug: 'alice', proposalId: 'proposal-1' })
+
+    expect(result).toEqual({ ok: false, error: 'file_exists' })
+    expect(mocks.workspaceAgentFetch).toHaveBeenCalledTimes(1)
+    expect(mocks.updatePendingLearningProposalApplied).not.toHaveBeenCalled()
+  })
+
+  it('applies create proposals only after a not-found read', async () => {
+    mocks.findPendingLearningProposal.mockResolvedValue({ ...proposal, operation: 'create', currentFileHash: null })
+    mocks.workspaceAgentFetch
+      .mockResolvedValueOnce({ ok: false, error: 'not_found', status: 404 })
+      .mockResolvedValueOnce({ ok: true, data: { hash: 'hash-new' }, status: 200 })
+
+    const result = await applyLearningProposal({ userId: 'user-1', slug: 'alice', proposalId: 'proposal-1' })
+
+    expect(result).toMatchObject({ ok: true })
+    expect(mocks.workspaceAgentFetch).toHaveBeenLastCalledWith(
+      { baseUrl: 'http://agent', authHeader: 'Basic x' },
+      '/files/write',
+      { path: proposal.kbPath, content: proposal.proposedContent, encoding: 'utf-8', expectedHash: '' },
+    )
+  })
+
+  it('returns hash_conflict when the current file hash changed', async () => {
+    mocks.workspaceAgentFetch.mockResolvedValueOnce({ ok: true, data: { hash: 'hash-new' }, status: 200 })
+
+    const result = await applyLearningProposal({ userId: 'user-1', slug: 'alice', proposalId: 'proposal-1' })
+
+    expect(result).toEqual({ ok: false, error: 'hash_conflict' })
+    expect(mocks.updatePendingLearningProposalApplied).not.toHaveBeenCalled()
+  })
+
+  it('returns not_pending when the guarded status update loses the race', async () => {
+    mocks.workspaceAgentFetch
+      .mockResolvedValueOnce({ ok: true, data: { hash: 'hash-old' }, status: 200 })
+      .mockResolvedValueOnce({ ok: true, data: { hash: 'hash-new' }, status: 200 })
+    mocks.updatePendingLearningProposalApplied.mockResolvedValue(null)
+
+    const result = await applyLearningProposal({ userId: 'user-1', slug: 'alice', proposalId: 'proposal-1' })
+
+    expect(result).toEqual({ ok: false, error: 'not_pending' })
+    expect(mocks.auditEvent).not.toHaveBeenCalled()
+  })
+})
+
+describe('rejectLearningProposal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.findPendingLearningProposal.mockResolvedValue(proposal)
+  })
+
+  it('returns not_pending when the guarded reject update loses the race', async () => {
+    mocks.updatePendingLearningProposalRejected.mockResolvedValue(null)
+
+    const result = await rejectLearningProposal({ userId: 'user-1', proposalId: 'proposal-1' })
+
+    expect(result).toEqual({ ok: false, error: 'not_pending' })
+    expect(mocks.auditEvent).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/lib/learning/__tests__/repository.test.ts
+++ b/apps/web/src/lib/learning/__tests__/repository.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  isDesktop: vi.fn(),
+  prisma: {
+    knowledgeLearningProposal: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    knowledgeLearningRun: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('@/lib/prisma', () => ({ prisma: mocks.prisma }))
+vi.mock('@/lib/runtime/mode', () => ({ isDesktop: mocks.isDesktop }))
+
+const now = new Date('2026-01-01T00:00:00.000Z')
+
+const proposalRecord = {
+  id: 'proposal-1',
+  userId: 'user-1',
+  runId: null,
+  status: 'pending',
+  title: 'Remember preference',
+  type: 'preference',
+  confidence: 0.8,
+  evidence: { quote: 'Use concise answers' },
+  kbPath: 'Preferences/Answers.md',
+  operation: 'update',
+  proposedContent: 'Use concise answers.',
+  currentFileHash: 'hash-old',
+  internalSessionId: null,
+  trigger: 'agent',
+  createdAt: now,
+  updatedAt: now,
+}
+
+const runRecord = {
+  id: 'run-1',
+  userId: 'user-1',
+  sourceSessionId: 'session-1',
+  internalSessionId: 'learning-session-1',
+  title: 'Session',
+  trigger: 'manual',
+  status: 'pending',
+  error: null,
+  messageCount: 0,
+  createdAt: now,
+  updatedAt: now,
+}
+
+describe('learning repository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.isDesktop.mockReturnValue(false)
+  })
+
+  it('maps list results', async () => {
+    const { listLearningProposals, listLearningRuns } = await import('@/lib/learning/repository')
+    mocks.prisma.knowledgeLearningRun.findMany.mockResolvedValue([runRecord])
+    mocks.prisma.knowledgeLearningProposal.findMany.mockResolvedValue([proposalRecord])
+
+    await expect(listLearningRuns('user-1')).resolves.toEqual([
+      expect.objectContaining({ id: 'run-1', createdAt: now.toISOString() }),
+    ])
+    await expect(listLearningProposals('user-1')).resolves.toEqual([
+      expect.objectContaining({ id: 'proposal-1', evidence: { quote: 'Use concise answers' } }),
+    ])
+  })
+
+  it('serializes evidence when creating desktop proposals', async () => {
+    const { createLearningProposal } = await import('@/lib/learning/repository')
+    mocks.isDesktop.mockReturnValue(true)
+    mocks.prisma.knowledgeLearningProposal.create.mockResolvedValue({
+      ...proposalRecord,
+      evidence: JSON.stringify(proposalRecord.evidence),
+    })
+
+    await createLearningProposal('user-1', {
+      title: proposalRecord.title,
+      type: 'preference',
+      confidence: proposalRecord.confidence,
+      evidence: proposalRecord.evidence,
+      kbPath: proposalRecord.kbPath,
+      operation: 'update',
+      proposedContent: proposalRecord.proposedContent,
+      currentFileHash: proposalRecord.currentFileHash,
+      trigger: 'agent',
+    })
+
+    expect(mocks.prisma.knowledgeLearningProposal.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ evidence: JSON.stringify(proposalRecord.evidence) }),
+    })
+  })
+
+  it('updates pending proposal statuses atomically', async () => {
+    const { updatePendingLearningProposalApplied, updatePendingLearningProposalRejected } = await import('@/lib/learning/repository')
+    mocks.prisma.knowledgeLearningProposal.updateMany.mockResolvedValue({ count: 1 })
+    mocks.prisma.knowledgeLearningProposal.findUnique.mockResolvedValue(proposalRecord)
+
+    await expect(updatePendingLearningProposalApplied({ proposalId: 'proposal-1', userId: 'user-1', content: 'new' })).resolves.toEqual(
+      expect.objectContaining({ id: 'proposal-1' }),
+    )
+    await expect(updatePendingLearningProposalRejected({ proposalId: 'proposal-1', userId: 'user-1' })).resolves.toEqual(
+      expect.objectContaining({ id: 'proposal-1' }),
+    )
+    expect(mocks.prisma.knowledgeLearningProposal.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'proposal-1', userId: 'user-1', status: 'pending' },
+    }))
+  })
+
+  it('returns null when a guarded proposal update affects no rows', async () => {
+    const { updatePendingLearningProposalApplied } = await import('@/lib/learning/repository')
+    mocks.prisma.knowledgeLearningProposal.updateMany.mockResolvedValue({ count: 0 })
+
+    await expect(updatePendingLearningProposalApplied({ proposalId: 'proposal-1', userId: 'user-1', content: 'new' })).resolves.toBeNull()
+    expect(mocks.prisma.knowledgeLearningProposal.findUnique).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/lib/learning/__tests__/repository.test.ts
+++ b/apps/web/src/lib/learning/__tests__/repository.test.ts
@@ -124,4 +124,33 @@ describe('learning repository', () => {
     await expect(updatePendingLearningProposalApplied({ proposalId: 'proposal-1', userId: 'user-1', content: 'new' })).resolves.toBeNull()
     expect(mocks.prisma.knowledgeLearningProposal.findUnique).not.toHaveBeenCalled()
   })
+
+  it('treats running runs and only fresh pending runs as active', async () => {
+    const { hasActiveLearningRun } = await import('@/lib/learning/repository')
+    mocks.prisma.knowledgeLearningRun.findFirst.mockResolvedValue(runRecord)
+    const pendingSince = new Date('2026-01-01T00:00:00.000Z')
+
+    await expect(hasActiveLearningRun({ userId: 'user-1', sessionId: 'session-1', pendingSince })).resolves.toBe(true)
+    expect(mocks.prisma.knowledgeLearningRun.findFirst).toHaveBeenCalledWith({
+      where: {
+        userId: 'user-1',
+        sourceSessionId: 'session-1',
+        OR: [
+          { status: 'running' },
+          { status: 'pending', createdAt: { gte: pendingSince } },
+        ],
+      },
+    })
+  })
+
+  it('checks learning run ownership', async () => {
+    const { learningRunBelongsToUser } = await import('@/lib/learning/repository')
+    mocks.prisma.knowledgeLearningRun.findFirst.mockResolvedValue(null)
+
+    await expect(learningRunBelongsToUser({ userId: 'user-1', runId: 'run-other' })).resolves.toBe(false)
+    expect(mocks.prisma.knowledgeLearningRun.findFirst).toHaveBeenCalledWith({
+      where: { id: 'run-other', userId: 'user-1' },
+      select: { id: true },
+    })
+  })
 })

--- a/apps/web/src/lib/learning/__tests__/run-lifecycle.test.ts
+++ b/apps/web/src/lib/learning/__tests__/run-lifecycle.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  createInstanceClient: vi.fn(),
+  createLearningRunRecord: vi.fn(),
+  hasActiveLearningRun: vi.fn(),
+  hasRecentLearningRun: vi.fn(),
+  markLearningRunFailedRecord: vi.fn(),
+  markLearningRunRunningRecord: vi.fn(),
+  markLearningRunSucceededRecord: vi.fn(),
+  setLearningRunMessageCount: vi.fn(),
+}))
+
+vi.mock('@/lib/opencode/client', () => ({ createInstanceClient: mocks.createInstanceClient }))
+vi.mock('@/lib/learning/repository', () => ({
+  createLearningRunRecord: mocks.createLearningRunRecord,
+  hasActiveLearningRun: mocks.hasActiveLearningRun,
+  hasRecentLearningRun: mocks.hasRecentLearningRun,
+  markLearningRunFailed: mocks.markLearningRunFailedRecord,
+  markLearningRunRunning: mocks.markLearningRunRunningRecord,
+  markLearningRunSucceeded: mocks.markLearningRunSucceededRecord,
+  setLearningRunMessageCount: mocks.setLearningRunMessageCount,
+}))
+
+const run = {
+  id: 'run-1',
+  sourceSessionId: 'session-1',
+  internalSessionId: 'learning-session-1',
+  title: 'Source session',
+  trigger: 'auto',
+  status: 'pending',
+  error: null,
+  messageCount: 0,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+describe('learning run lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.hasActiveLearningRun.mockResolvedValue(false)
+    mocks.hasRecentLearningRun.mockResolvedValue(false)
+    mocks.createLearningRunRecord.mockResolvedValue(run)
+    mocks.createInstanceClient.mockResolvedValue({ session: { create: vi.fn().mockResolvedValue({ data: { id: 'learning-session-1' } }) } })
+  })
+
+  it('creates an internal learning session and run record', async () => {
+    const { createLearningRun } = await import('@/lib/learning/run-lifecycle')
+
+    await expect(createLearningRun({ userId: 'user-1', slug: 'alice', sourceSessionId: 'session-1', title: 'Source session', trigger: 'auto' })).resolves.toEqual({ ok: true, run })
+    expect(mocks.createLearningRunRecord).toHaveBeenCalledWith(expect.objectContaining({
+      internalSessionId: 'learning-session-1',
+      sourceSessionId: 'session-1',
+    }))
+  })
+
+  it('skips auto-learning below the message threshold', async () => {
+    const { maybeQueueAutoLearningRun } = await import('@/lib/learning/run-lifecycle')
+
+    await maybeQueueAutoLearningRun({ userId: 'user-1', slug: 'alice', sessionId: 'session-1', sessionTitle: 'Source session', messageCount: 11 })
+
+    expect(mocks.hasActiveLearningRun).not.toHaveBeenCalled()
+    expect(mocks.createInstanceClient).not.toHaveBeenCalled()
+  })
+
+  it('skips auto-learning when active or inside cooldown', async () => {
+    const { canQueueAutoLearningRun } = await import('@/lib/learning/run-lifecycle')
+    mocks.hasActiveLearningRun.mockResolvedValueOnce(true)
+    await expect(canQueueAutoLearningRun({ userId: 'user-1', sessionId: 'session-1' })).resolves.toBe(false)
+
+    mocks.hasActiveLearningRun.mockResolvedValueOnce(false)
+    mocks.hasRecentLearningRun.mockResolvedValueOnce(true)
+    await expect(canQueueAutoLearningRun({ userId: 'user-1', sessionId: 'session-1' })).resolves.toBe(false)
+  })
+
+  it('queues auto-learning and stores message count when eligible', async () => {
+    const { maybeQueueAutoLearningRun } = await import('@/lib/learning/run-lifecycle')
+
+    await maybeQueueAutoLearningRun({ userId: 'user-1', slug: 'alice', sessionId: 'session-1', sessionTitle: 'Source session', messageCount: 12 })
+
+    expect(mocks.createLearningRunRecord).toHaveBeenCalled()
+    expect(mocks.setLearningRunMessageCount).toHaveBeenCalledWith({ runId: 'run-1', messageCount: 12 })
+  })
+
+  it('forwards explicit run status updates', async () => {
+    const { markLearningRunFailed, markLearningRunRunning, markLearningRunSucceeded } = await import('@/lib/learning/run-lifecycle')
+
+    await markLearningRunRunning('run-1')
+    await markLearningRunSucceeded('run-1')
+    await markLearningRunFailed({ runId: 'run-1', error: 'failed' })
+
+    expect(mocks.markLearningRunRunningRecord).toHaveBeenCalledWith('run-1')
+    expect(mocks.markLearningRunSucceededRecord).toHaveBeenCalledWith('run-1')
+    expect(mocks.markLearningRunFailedRecord).toHaveBeenCalledWith({ runId: 'run-1', error: 'failed' })
+  })
+})

--- a/apps/web/src/lib/learning/__tests__/run-lifecycle.test.ts
+++ b/apps/web/src/lib/learning/__tests__/run-lifecycle.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  createInstanceClient: vi.fn(),
   createLearningRunRecord: vi.fn(),
   hasActiveLearningRun: vi.fn(),
   hasRecentLearningRun: vi.fn(),
@@ -11,7 +10,6 @@ const mocks = vi.hoisted(() => ({
   setLearningRunMessageCount: vi.fn(),
 }))
 
-vi.mock('@/lib/opencode/client', () => ({ createInstanceClient: mocks.createInstanceClient }))
 vi.mock('@/lib/learning/repository', () => ({
   createLearningRunRecord: mocks.createLearningRunRecord,
   hasActiveLearningRun: mocks.hasActiveLearningRun,
@@ -25,7 +23,7 @@ vi.mock('@/lib/learning/repository', () => ({
 const run = {
   id: 'run-1',
   sourceSessionId: 'session-1',
-  internalSessionId: 'learning-session-1',
+  internalSessionId: null,
   title: 'Source session',
   trigger: 'auto',
   status: 'pending',
@@ -41,15 +39,14 @@ describe('learning run lifecycle', () => {
     mocks.hasActiveLearningRun.mockResolvedValue(false)
     mocks.hasRecentLearningRun.mockResolvedValue(false)
     mocks.createLearningRunRecord.mockResolvedValue(run)
-    mocks.createInstanceClient.mockResolvedValue({ session: { create: vi.fn().mockResolvedValue({ data: { id: 'learning-session-1' } }) } })
   })
 
-  it('creates an internal learning session and run record', async () => {
+  it('creates a queued run record without an internal session', async () => {
     const { createLearningRun } = await import('@/lib/learning/run-lifecycle')
 
     await expect(createLearningRun({ userId: 'user-1', slug: 'alice', sourceSessionId: 'session-1', title: 'Source session', trigger: 'auto' })).resolves.toEqual({ ok: true, run })
     expect(mocks.createLearningRunRecord).toHaveBeenCalledWith(expect.objectContaining({
-      internalSessionId: 'learning-session-1',
+      internalSessionId: null,
       sourceSessionId: 'session-1',
     }))
   })
@@ -60,7 +57,7 @@ describe('learning run lifecycle', () => {
     await maybeQueueAutoLearningRun({ userId: 'user-1', slug: 'alice', sessionId: 'session-1', sessionTitle: 'Source session', messageCount: 11 })
 
     expect(mocks.hasActiveLearningRun).not.toHaveBeenCalled()
-    expect(mocks.createInstanceClient).not.toHaveBeenCalled()
+    expect(mocks.createLearningRunRecord).not.toHaveBeenCalled()
   })
 
   it('skips auto-learning when active or inside cooldown', async () => {
@@ -71,6 +68,19 @@ describe('learning run lifecycle', () => {
     mocks.hasActiveLearningRun.mockResolvedValueOnce(false)
     mocks.hasRecentLearningRun.mockResolvedValueOnce(true)
     await expect(canQueueAutoLearningRun({ userId: 'user-1', sessionId: 'session-1' })).resolves.toBe(false)
+  })
+
+  it('treats only fresh pending runs as active', async () => {
+    const { canQueueAutoLearningRun } = await import('@/lib/learning/run-lifecycle')
+    const before = Date.now()
+
+    await canQueueAutoLearningRun({ userId: 'user-1', sessionId: 'session-1' })
+
+    const args = mocks.hasActiveLearningRun.mock.calls[0][0]
+    expect(args.pendingSince).toBeInstanceOf(Date)
+    const staleWindowMs = before - args.pendingSince.getTime()
+    expect(staleWindowMs).toBeGreaterThanOrEqual(6 * 60 * 60 * 1000 - 1000)
+    expect(staleWindowMs).toBeLessThanOrEqual(6 * 60 * 60 * 1000 + 1000)
   })
 
   it('queues auto-learning and stores message count when eligible', async () => {

--- a/apps/web/src/lib/learning/__tests__/session-history.test.ts
+++ b/apps/web/src/lib/learning/__tests__/session-history.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  clampSessionHistoryBounds,
+  getMessageRole,
+  getMessageText,
+  getSessionId,
+  getSessionTitle,
+  isRecord,
+} from '@/lib/learning/session-history'
+
+describe('session history helpers', () => {
+  it('detects plain records', () => {
+    expect(isRecord({ id: 'session-1' })).toBe(true)
+    expect(isRecord(null)).toBe(false)
+    expect(isRecord([])).toBe(false)
+  })
+
+  it('extracts session fields with defaults', () => {
+    expect(getSessionTitle({ title: 'Planning' })).toBe('Planning')
+    expect(getSessionTitle({ title: '   ' })).toBe('Untitled')
+    expect(getSessionId({ id: 'session-1' })).toBe('session-1')
+    expect(getSessionId({ id: 1 })).toBeNull()
+  })
+
+  it('extracts message role and text from OpenCode-like parts', () => {
+    expect(getMessageRole({ info: { role: 'assistant' } })).toBe('assistant')
+    expect(getMessageRole({ info: {} })).toBe('unknown')
+    expect(getMessageText({ parts: [{ text: 'hello' }, { content: 'world' }, null] })).toBe('hello\nworld')
+    expect(getMessageText({ parts: [] })).toBe('')
+  })
+
+  it('clamps query bounds', () => {
+    expect(clampSessionHistoryBounds(null)).toEqual({ limit: 20, maxMessages: 20 })
+    expect(clampSessionHistoryBounds({ limit: 0, maxMessagesPerSession: 500 })).toEqual({ limit: 1, maxMessages: 100 })
+    expect(clampSessionHistoryBounds({ limit: 4.8, maxMessagesPerSession: 3.2 })).toEqual({ limit: 4, maxMessages: 3 })
+  })
+})

--- a/apps/web/src/lib/learning/__tests__/validation.test.ts
+++ b/apps/web/src/lib/learning/__tests__/validation.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseProposalRequest } from '@/lib/learning/validation'
+
+const validPayload = {
+  title: 'Remember preference',
+  type: 'preference',
+  confidence: 0.8,
+  evidence: { quote: 'Use concise answers', source: 'session' },
+  kbPath: 'Preferences/Answers.md',
+  operation: 'update',
+  proposedContent: 'Use concise answers.',
+  trigger: 'agent',
+}
+
+describe('parseProposalRequest', () => {
+  it('accepts a valid proposal payload', () => {
+    const result = parseProposalRequest(validPayload)
+
+    expect(result).toMatchObject({ ok: true, value: validPayload })
+  })
+
+  it('rejects missing required fields', () => {
+    expect(parseProposalRequest({ ...validPayload, title: '' })).toEqual({ ok: false })
+    expect(parseProposalRequest({ ...validPayload, kbPath: '' })).toEqual({ ok: false })
+    expect(parseProposalRequest({ ...validPayload, proposedContent: '' })).toEqual({ ok: false })
+  })
+
+  it('rejects invalid enum values', () => {
+    expect(parseProposalRequest({ ...validPayload, type: 'unknown' })).toEqual({ ok: false })
+    expect(parseProposalRequest({ ...validPayload, operation: 'delete' })).toEqual({ ok: false })
+    expect(parseProposalRequest({ ...validPayload, trigger: 'timer' })).toEqual({ ok: false })
+  })
+
+  it('rejects confidence outside the accepted range', () => {
+    expect(parseProposalRequest({ ...validPayload, confidence: -0.1 })).toEqual({ ok: false })
+    expect(parseProposalRequest({ ...validPayload, confidence: 1.1 })).toEqual({ ok: false })
+  })
+
+  it('rejects invalid evidence', () => {
+    expect(parseProposalRequest({ ...validPayload, evidence: { quote: 1 } })).toEqual({ ok: false })
+    expect(parseProposalRequest({ ...validPayload, evidence: { source: 'x'.repeat(501) } })).toEqual({ ok: false })
+  })
+})

--- a/apps/web/src/lib/learning/__tests__/validation.test.ts
+++ b/apps/web/src/lib/learning/__tests__/validation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { parseEvidence } from '@/lib/learning/repository'
-import { parseProposalRequest } from '@/lib/learning/validation'
+import { isValidKbPath, parseProposalActionRequest, parseProposalRequest } from '@/lib/learning/validation'
 
 const validPayload = {
   title: 'Remember preference',
@@ -41,6 +41,57 @@ describe('parseProposalRequest', () => {
   it('rejects invalid evidence', () => {
     expect(parseProposalRequest({ ...validPayload, evidence: { quote: 1 } })).toEqual({ ok: false })
     expect(parseProposalRequest({ ...validPayload, evidence: { source: 'x'.repeat(501) } })).toEqual({ ok: false })
+  })
+
+  it('rejects unsafe kb paths', () => {
+    for (const kbPath of ['../secrets.md', 'notes/../../etc/passwd', '/absolute.md', 'notes//double.md', './relative.md', '.git/config', 'notes\\windows.md', 'trailing/']) {
+      expect(parseProposalRequest({ ...validPayload, kbPath })).toEqual({ ok: false })
+    }
+  })
+})
+
+describe('isValidKbPath', () => {
+  it('accepts plain relative paths', () => {
+    expect(isValidKbPath('Preferences/Answers.md')).toBe(true)
+    expect(isValidKbPath('notes.md')).toBe(true)
+    expect(isValidKbPath('a/b/c.md')).toBe(true)
+  })
+
+  it('rejects traversal, absolute, and git paths', () => {
+    expect(isValidKbPath('../escape.md')).toBe(false)
+    expect(isValidKbPath('a/../b.md')).toBe(false)
+    expect(isValidKbPath('/etc/passwd')).toBe(false)
+    expect(isValidKbPath('.git/config')).toBe(false)
+    expect(isValidKbPath('a\\b.md')).toBe(false)
+    expect(isValidKbPath('a/\0b.md')).toBe(false)
+    expect(isValidKbPath('')).toBe(false)
+    expect(isValidKbPath('x'.repeat(501))).toBe(false)
+  })
+})
+
+describe('parseProposalActionRequest', () => {
+  it('accepts apply and reject actions', () => {
+    expect(parseProposalActionRequest({ proposalId: 'proposal-1', action: 'apply', content: 'edited' })).toEqual({
+      ok: true,
+      value: { action: 'apply', proposalId: 'proposal-1', content: 'edited' },
+    })
+    expect(parseProposalActionRequest({ proposalId: 'proposal-1', action: 'reject' })).toEqual({
+      ok: true,
+      value: { action: 'reject', proposalId: 'proposal-1', content: undefined },
+    })
+  })
+
+  it('rejects unknown actions and invalid proposal ids', () => {
+    expect(parseProposalActionRequest({ proposalId: 'proposal-1', action: 'delete' })).toEqual({ ok: false })
+    expect(parseProposalActionRequest({ proposalId: '', action: 'apply' })).toEqual({ ok: false })
+    expect(parseProposalActionRequest({ proposalId: 42, action: 'apply' })).toEqual({ ok: false })
+    expect(parseProposalActionRequest(null)).toEqual({ ok: false })
+  })
+
+  it('rejects empty or oversized content', () => {
+    expect(parseProposalActionRequest({ proposalId: 'proposal-1', action: 'apply', content: '' })).toEqual({ ok: false })
+    expect(parseProposalActionRequest({ proposalId: 'proposal-1', action: 'apply', content: '   ' })).toEqual({ ok: false })
+    expect(parseProposalActionRequest({ proposalId: 'proposal-1', action: 'apply', content: 'x'.repeat(200_001) })).toEqual({ ok: false })
   })
 })
 

--- a/apps/web/src/lib/learning/__tests__/validation.test.ts
+++ b/apps/web/src/lib/learning/__tests__/validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { parseEvidence } from '@/lib/learning/repository'
 import { parseProposalRequest } from '@/lib/learning/validation'
 
 const validPayload = {
@@ -40,5 +41,18 @@ describe('parseProposalRequest', () => {
   it('rejects invalid evidence', () => {
     expect(parseProposalRequest({ ...validPayload, evidence: { quote: 1 } })).toEqual({ ok: false })
     expect(parseProposalRequest({ ...validPayload, evidence: { source: 'x'.repeat(501) } })).toEqual({ ok: false })
+  })
+})
+
+describe('parseEvidence', () => {
+  it('parses SQLite string evidence values', () => {
+    expect(parseEvidence(JSON.stringify({ quote: 'Use concise answers', source: 'session' }))).toEqual({
+      quote: 'Use concise answers',
+      source: 'session',
+    })
+  })
+
+  it('returns empty evidence for invalid string values', () => {
+    expect(parseEvidence('not-json')).toEqual({})
   })
 })

--- a/apps/web/src/lib/learning/proposal-application.ts
+++ b/apps/web/src/lib/learning/proposal-application.ts
@@ -1,8 +1,8 @@
 import { auditEvent } from '@/lib/auth'
 import {
   findPendingLearningProposal,
-  updateLearningProposalApplied,
-  updateLearningProposalRejected,
+  updatePendingLearningProposalApplied,
+  updatePendingLearningProposalRejected,
 } from '@/lib/learning/repository'
 import { createWorkspaceAgentClient } from '@/lib/workspace-agent/client'
 import { workspaceAgentFetch } from '@/lib/workspace-agent-client'
@@ -30,7 +30,9 @@ export async function rejectLearningProposal(args: {
   if (!proposal) return { ok: false, error: 'not_found' }
   if (proposal.status !== 'pending') return { ok: false, error: 'not_pending' }
 
-  const updated = await updateLearningProposalRejected(proposal.id)
+  const updated = await updatePendingLearningProposalRejected({ proposalId: proposal.id, userId: args.userId })
+  if (!updated) return { ok: false, error: 'not_pending' }
+
   await auditEvent({ actorUserId: args.userId, action: 'learning.proposal_rejected', metadata: { proposalId: proposal.id } })
   return { ok: true, proposal: updated }
 }
@@ -49,7 +51,10 @@ export async function applyLearningProposal(args: {
   if (!agent) return { ok: false, error: 'workspace_agent_unavailable' }
 
   const read = await workspaceAgentFetch<FileReadResponse>(agent, '/files/read', { path: proposal.kbPath })
-  if (proposal.operation === 'update') {
+  if (proposal.operation === 'create') {
+    if (read.ok) return { ok: false, error: 'file_exists' }
+    if (read.status !== 404) return { ok: false, error: read.error }
+  } else {
     if (!read.ok) return { ok: false, error: read.error }
     if (proposal.currentFileHash && read.data.hash !== proposal.currentFileHash) {
       return { ok: false, error: 'hash_conflict' }
@@ -66,7 +71,9 @@ export async function applyLearningProposal(args: {
   })
   if (!write.ok) return { ok: false, error: write.error }
 
-  const updated = await updateLearningProposalApplied({ proposalId: proposal.id, content })
+  const updated = await updatePendingLearningProposalApplied({ proposalId: proposal.id, userId: args.userId, content })
+  if (!updated) return { ok: false, error: 'not_pending' }
+
   await auditEvent({
     actorUserId: args.userId,
     action: 'learning.proposal_applied',

--- a/apps/web/src/lib/learning/proposal-application.ts
+++ b/apps/web/src/lib/learning/proposal-application.ts
@@ -1,0 +1,76 @@
+import { auditEvent } from '@/lib/auth'
+import {
+  findPendingLearningProposal,
+  updateLearningProposalApplied,
+  updateLearningProposalRejected,
+} from '@/lib/learning/repository'
+import { createWorkspaceAgentClient } from '@/lib/workspace-agent/client'
+import { workspaceAgentFetch } from '@/lib/workspace-agent-client'
+import type { LearningProposal } from '@/types/learning'
+
+type FileReadResponse = {
+  ok: boolean
+  path: string
+  content: string
+  encoding: string
+  hash: string
+}
+
+type FileWriteResponse = {
+  ok: boolean
+  path: string
+  hash: string
+}
+
+export async function rejectLearningProposal(args: {
+  userId: string
+  proposalId: string
+}): Promise<{ ok: true; proposal: LearningProposal } | { ok: false; error: string }> {
+  const proposal = await findPendingLearningProposal({ proposalId: args.proposalId, userId: args.userId })
+  if (!proposal) return { ok: false, error: 'not_found' }
+  if (proposal.status !== 'pending') return { ok: false, error: 'not_pending' }
+
+  const updated = await updateLearningProposalRejected(proposal.id)
+  await auditEvent({ actorUserId: args.userId, action: 'learning.proposal_rejected', metadata: { proposalId: proposal.id } })
+  return { ok: true, proposal: updated }
+}
+
+export async function applyLearningProposal(args: {
+  userId: string
+  slug: string
+  proposalId: string
+  content?: string
+}): Promise<{ ok: true; proposal: LearningProposal } | { ok: false; error: string }> {
+  const proposal = await findPendingLearningProposal({ proposalId: args.proposalId, userId: args.userId })
+  if (!proposal) return { ok: false, error: 'not_found' }
+  if (proposal.status !== 'pending') return { ok: false, error: 'not_pending' }
+
+  const agent = await createWorkspaceAgentClient(args.slug)
+  if (!agent) return { ok: false, error: 'workspace_agent_unavailable' }
+
+  const read = await workspaceAgentFetch<FileReadResponse>(agent, '/files/read', { path: proposal.kbPath })
+  if (proposal.operation === 'update') {
+    if (!read.ok) return { ok: false, error: read.error }
+    if (proposal.currentFileHash && read.data.hash !== proposal.currentFileHash) {
+      return { ok: false, error: 'hash_conflict' }
+    }
+  }
+
+  const expectedHash = proposal.operation === 'create' ? '' : read.ok ? read.data.hash : ''
+  const content = args.content ?? proposal.proposedContent
+  const write = await workspaceAgentFetch<FileWriteResponse>(agent, '/files/write', {
+    path: proposal.kbPath,
+    content,
+    encoding: 'utf-8',
+    expectedHash,
+  })
+  if (!write.ok) return { ok: false, error: write.error }
+
+  const updated = await updateLearningProposalApplied({ proposalId: proposal.id, content })
+  await auditEvent({
+    actorUserId: args.userId,
+    action: 'learning.proposal_applied',
+    metadata: { proposalId: proposal.id, kbPath: proposal.kbPath },
+  })
+  return { ok: true, proposal: updated }
+}

--- a/apps/web/src/lib/learning/repository.ts
+++ b/apps/web/src/lib/learning/repository.ts
@@ -1,0 +1,227 @@
+import type { Prisma } from '@prisma/client'
+
+import { prisma } from '@/lib/prisma'
+import type {
+  LearningEvidence,
+  LearningProposal,
+  LearningProposalOperation,
+  LearningProposalType,
+  LearningRun,
+  LearningRunStatus,
+  LearningTrigger,
+} from '@/types/learning'
+
+export type ProposalInput = {
+  runId?: string | null
+  title: string
+  type?: LearningProposalType
+  confidence: number
+  evidence: LearningEvidence
+  kbPath: string
+  operation: LearningProposalOperation
+  proposedContent: string
+  currentFileHash?: string | null
+  internalSessionId?: string | null
+  trigger: LearningTrigger
+}
+
+function toIso(date: Date): string {
+  return date.toISOString()
+}
+
+export function mapRun(run: {
+  id: string
+  sourceSessionId: string | null
+  internalSessionId: string | null
+  title: string
+  trigger: LearningTrigger
+  status: LearningRunStatus
+  error: string | null
+  messageCount: number
+  createdAt: Date
+  updatedAt: Date
+}): LearningRun {
+  return {
+    id: run.id,
+    sourceSessionId: run.sourceSessionId,
+    internalSessionId: run.internalSessionId,
+    title: run.title,
+    trigger: run.trigger,
+    status: run.status,
+    error: run.error,
+    messageCount: run.messageCount,
+    createdAt: toIso(run.createdAt),
+    updatedAt: toIso(run.updatedAt),
+  }
+}
+
+export function parseEvidence(value: Prisma.JsonValue): LearningEvidence {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+
+  return {
+    sessionId: typeof value.sessionId === 'string' ? value.sessionId : undefined,
+    messageId: typeof value.messageId === 'string' ? value.messageId : undefined,
+    quote: typeof value.quote === 'string' ? value.quote : undefined,
+    source: typeof value.source === 'string' ? value.source : undefined,
+  }
+}
+
+export function mapProposal(proposal: {
+  id: string
+  runId: string | null
+  status: 'pending' | 'rejected' | 'applied'
+  title: string
+  type: LearningProposalType
+  confidence: number
+  evidence: Prisma.JsonValue
+  kbPath: string
+  operation: LearningProposalOperation
+  proposedContent: string
+  currentFileHash: string | null
+  internalSessionId: string | null
+  trigger: LearningTrigger
+  createdAt: Date
+  updatedAt: Date
+}): LearningProposal {
+  return {
+    id: proposal.id,
+    runId: proposal.runId,
+    status: proposal.status,
+    title: proposal.title,
+    type: proposal.type,
+    confidence: proposal.confidence,
+    evidence: parseEvidence(proposal.evidence),
+    kbPath: proposal.kbPath,
+    operation: proposal.operation,
+    proposedContent: proposal.proposedContent,
+    currentFileHash: proposal.currentFileHash,
+    internalSessionId: proposal.internalSessionId,
+    trigger: proposal.trigger,
+    createdAt: toIso(proposal.createdAt),
+    updatedAt: toIso(proposal.updatedAt),
+  }
+}
+
+export async function listLearningRuns(userId: string): Promise<LearningRun[]> {
+  const runs = await prisma.knowledgeLearningRun.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+    take: 20,
+  })
+  return runs.map(mapRun)
+}
+
+export async function listLearningProposals(userId: string): Promise<LearningProposal[]> {
+  const proposals = await prisma.knowledgeLearningProposal.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+    take: 50,
+  })
+  return proposals.map(mapProposal)
+}
+
+export async function createLearningRunRecord(args: {
+  userId: string
+  sourceSessionId?: string | null
+  internalSessionId?: string | null
+  title: string
+  trigger: LearningTrigger
+}): Promise<LearningRun> {
+  const run = await prisma.knowledgeLearningRun.create({
+    data: {
+      userId: args.userId,
+      sourceSessionId: args.sourceSessionId ?? null,
+      internalSessionId: args.internalSessionId ?? null,
+      title: args.title,
+      trigger: args.trigger,
+      status: 'pending',
+    },
+  })
+
+  return mapRun(run)
+}
+
+export async function setLearningRunMessageCount(args: { runId: string; messageCount: number }): Promise<void> {
+  await prisma.knowledgeLearningRun.update({
+    where: { id: args.runId },
+    data: { messageCount: args.messageCount },
+  })
+}
+
+export async function hasActiveLearningRun(args: { userId: string; sessionId: string }): Promise<boolean> {
+  const activeRun = await prisma.knowledgeLearningRun.findFirst({
+    where: {
+      userId: args.userId,
+      sourceSessionId: args.sessionId,
+      status: { in: ['pending', 'running'] },
+    },
+  })
+  return Boolean(activeRun)
+}
+
+export async function hasRecentLearningRun(args: { userId: string; sessionId: string; since: Date }): Promise<boolean> {
+  const recentRun = await prisma.knowledgeLearningRun.findFirst({
+    where: {
+      userId: args.userId,
+      sourceSessionId: args.sessionId,
+      createdAt: { gte: args.since },
+    },
+  })
+  return Boolean(recentRun)
+}
+
+export async function findPendingLearningProposal(args: { userId: string; proposalId: string }) {
+  return prisma.knowledgeLearningProposal.findFirst({
+    where: { id: args.proposalId, userId: args.userId },
+  })
+}
+
+export async function updateLearningProposalRejected(proposalId: string): Promise<LearningProposal> {
+  const updated = await prisma.knowledgeLearningProposal.update({
+    where: { id: proposalId },
+    data: { status: 'rejected', rejectedAt: new Date() },
+  })
+  return mapProposal(updated)
+}
+
+export async function updateLearningProposalApplied(args: { proposalId: string; content: string }): Promise<LearningProposal> {
+  const updated = await prisma.knowledgeLearningProposal.update({
+    where: { id: args.proposalId },
+    data: { status: 'applied', appliedAt: new Date(), proposedContent: args.content },
+  })
+  return mapProposal(updated)
+}
+
+export async function createLearningProposal(userId: string, input: ProposalInput): Promise<LearningProposal> {
+  const proposal = await prisma.knowledgeLearningProposal.create({
+    data: {
+      userId,
+      runId: input.runId ?? null,
+      title: input.title,
+      type: input.type ?? 'other',
+      confidence: input.confidence,
+      evidence: input.evidence,
+      kbPath: input.kbPath,
+      operation: input.operation,
+      proposedContent: input.proposedContent,
+      currentFileHash: input.currentFileHash ?? null,
+      internalSessionId: input.internalSessionId ?? null,
+      trigger: input.trigger,
+    },
+  })
+  return mapProposal(proposal)
+}
+
+export async function markLearningRunRunning(runId: string): Promise<void> {
+  await prisma.knowledgeLearningRun.update({ where: { id: runId }, data: { status: 'running' } })
+}
+
+export async function markLearningRunSucceeded(runId: string): Promise<void> {
+  await prisma.knowledgeLearningRun.update({ where: { id: runId }, data: { status: 'succeeded' } })
+}
+
+export async function markLearningRunFailed(args: { runId: string; error: string }): Promise<void> {
+  await prisma.knowledgeLearningRun.update({ where: { id: args.runId }, data: { status: 'failed', error: args.error } })
+}

--- a/apps/web/src/lib/learning/repository.ts
+++ b/apps/web/src/lib/learning/repository.ts
@@ -159,15 +159,31 @@ export async function setLearningRunMessageCount(args: { runId: string; messageC
   })
 }
 
-export async function hasActiveLearningRun(args: { userId: string; sessionId: string }): Promise<boolean> {
+export async function hasActiveLearningRun(args: {
+  userId: string
+  sessionId: string
+  pendingSince: Date
+}): Promise<boolean> {
   const activeRun = await prisma.knowledgeLearningRun.findFirst({
     where: {
       userId: args.userId,
       sourceSessionId: args.sessionId,
-      status: { in: ['pending', 'running'] },
+      OR: [
+        { status: 'running' },
+        // Pending runs older than the staleness window no longer block new runs.
+        { status: 'pending', createdAt: { gte: args.pendingSince } },
+      ],
     },
   })
   return Boolean(activeRun)
+}
+
+export async function learningRunBelongsToUser(args: { userId: string; runId: string }): Promise<boolean> {
+  const run = await prisma.knowledgeLearningRun.findFirst({
+    where: { id: args.runId, userId: args.userId },
+    select: { id: true },
+  })
+  return Boolean(run)
 }
 
 export async function hasRecentLearningRun(args: { userId: string; sessionId: string; since: Date }): Promise<boolean> {

--- a/apps/web/src/lib/learning/repository.ts
+++ b/apps/web/src/lib/learning/repository.ts
@@ -1,6 +1,7 @@
 import type { Prisma } from '@prisma/client'
 
 import { prisma } from '@/lib/prisma'
+import { isDesktop } from '@/lib/runtime/mode'
 import type {
   LearningEvidence,
   LearningProposal,
@@ -55,7 +56,15 @@ export function mapRun(run: {
   }
 }
 
-export function parseEvidence(value: Prisma.JsonValue): LearningEvidence {
+export function parseEvidence(value: Prisma.JsonValue | string): LearningEvidence {
+  if (typeof value === 'string') {
+    try {
+      return parseEvidence(JSON.parse(value) as Prisma.JsonValue)
+    } catch {
+      return {}
+    }
+  }
+
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return {}
   }
@@ -178,20 +187,41 @@ export async function findPendingLearningProposal(args: { userId: string; propos
   })
 }
 
-export async function updateLearningProposalRejected(proposalId: string): Promise<LearningProposal> {
-  const updated = await prisma.knowledgeLearningProposal.update({
-    where: { id: proposalId },
+export async function updatePendingLearningProposalRejected(args: {
+  proposalId: string
+  userId: string
+}): Promise<LearningProposal | null> {
+  const result = await prisma.knowledgeLearningProposal.updateMany({
+    where: { id: args.proposalId, userId: args.userId, status: 'pending' },
     data: { status: 'rejected', rejectedAt: new Date() },
   })
+  if (result.count !== 1) return null
+
+  const updated = await prisma.knowledgeLearningProposal.findUnique({ where: { id: args.proposalId } })
+  if (!updated) return null
+
   return mapProposal(updated)
 }
 
-export async function updateLearningProposalApplied(args: { proposalId: string; content: string }): Promise<LearningProposal> {
-  const updated = await prisma.knowledgeLearningProposal.update({
-    where: { id: args.proposalId },
+export async function updatePendingLearningProposalApplied(args: {
+  proposalId: string
+  userId: string
+  content: string
+}): Promise<LearningProposal | null> {
+  const result = await prisma.knowledgeLearningProposal.updateMany({
+    where: { id: args.proposalId, userId: args.userId, status: 'pending' },
     data: { status: 'applied', appliedAt: new Date(), proposedContent: args.content },
   })
+  if (result.count !== 1) return null
+
+  const updated = await prisma.knowledgeLearningProposal.findUnique({ where: { id: args.proposalId } })
+  if (!updated) return null
+
   return mapProposal(updated)
+}
+
+function serializeEvidenceForStorage(evidence: LearningEvidence): Prisma.InputJsonValue {
+  return isDesktop() ? JSON.stringify(evidence) : evidence
 }
 
 export async function createLearningProposal(userId: string, input: ProposalInput): Promise<LearningProposal> {
@@ -202,7 +232,7 @@ export async function createLearningProposal(userId: string, input: ProposalInpu
       title: input.title,
       type: input.type ?? 'other',
       confidence: input.confidence,
-      evidence: input.evidence,
+      evidence: serializeEvidenceForStorage(input.evidence),
       kbPath: input.kbPath,
       operation: input.operation,
       proposedContent: input.proposedContent,

--- a/apps/web/src/lib/learning/run-lifecycle.ts
+++ b/apps/web/src/lib/learning/run-lifecycle.ts
@@ -1,4 +1,3 @@
-import { getLearningSessionTitle } from '@/lib/learning/session-title'
 import {
   createLearningRunRecord,
   hasActiveLearningRun,
@@ -8,19 +7,22 @@ import {
   markLearningRunSucceeded as markLearningRunSucceededRecord,
   setLearningRunMessageCount,
 } from '@/lib/learning/repository'
-import { createInstanceClient } from '@/lib/opencode/client'
 import type { LearningRun, LearningTrigger } from '@/types/learning'
 
-const AUTO_LEARNING_MIN_MESSAGES = 12
+export const AUTO_LEARNING_MIN_MESSAGES = 12
 const AUTO_LEARNING_COOLDOWN_MS = 24 * 60 * 60 * 1000
+const STALE_PENDING_RUN_MS = 6 * 60 * 60 * 1000
 
 /*
  * Learning run lifecycle owner.
  *
- * `pending` currently means the learning run has been created and associated with an
- * internal OpenCode session, but curator-agent execution is not wired yet. Keep run
- * status mutations in this module so the future execution path has one place to own
- * pending -> running -> succeeded/failed transitions.
+ * `pending` currently means the learning run is queued but curator-agent execution is
+ * not wired yet. The internal OpenCode session is created by the execution path (not
+ * here), so queued runs do not accumulate orphaned sessions. Pending runs older than
+ * STALE_PENDING_RUN_MS no longer count as active, so a stuck run cannot block
+ * auto-learning indefinitely. Keep run status mutations in this module so the future
+ * execution path has one place to own pending -> running -> succeeded/failed
+ * transitions.
  */
 
 export async function createLearningRun(args: {
@@ -30,18 +32,11 @@ export async function createLearningRun(args: {
   title?: string
   trigger: LearningTrigger
 }): Promise<{ ok: true; run: LearningRun } | { ok: false; error: string }> {
-  const client = await createInstanceClient(args.slug)
-  if (!client) {
-    return { ok: false, error: 'instance_unavailable' }
-  }
-
-  const sourceTitle = args.title ?? 'Session'
-  const createdSession = await client.session.create({ title: getLearningSessionTitle(sourceTitle) })
   const run = await createLearningRunRecord({
     userId: args.userId,
     sourceSessionId: args.sourceSessionId ?? null,
-    internalSessionId: createdSession.data?.id ?? null,
-    title: sourceTitle,
+    internalSessionId: null,
+    title: args.title ?? 'Session',
     trigger: args.trigger,
   })
 
@@ -84,7 +79,8 @@ export async function maybeQueueAutoLearningRun(args: {
 }
 
 export async function canQueueAutoLearningRun(args: { userId: string; sessionId: string }): Promise<boolean> {
-  if (await hasActiveLearningRun({ userId: args.userId, sessionId: args.sessionId })) return false
+  const pendingSince = new Date(Date.now() - STALE_PENDING_RUN_MS)
+  if (await hasActiveLearningRun({ userId: args.userId, sessionId: args.sessionId, pendingSince })) return false
 
   const cooldown = new Date(Date.now() - AUTO_LEARNING_COOLDOWN_MS)
   if (await hasRecentLearningRun({ userId: args.userId, sessionId: args.sessionId, since: cooldown })) return false

--- a/apps/web/src/lib/learning/run-lifecycle.ts
+++ b/apps/web/src/lib/learning/run-lifecycle.ts
@@ -1,0 +1,87 @@
+import { getLearningSessionTitle } from '@/lib/learning/session-title'
+import {
+  createLearningRunRecord,
+  hasActiveLearningRun,
+  hasRecentLearningRun,
+  markLearningRunFailed as markLearningRunFailedRecord,
+  markLearningRunRunning as markLearningRunRunningRecord,
+  markLearningRunSucceeded as markLearningRunSucceededRecord,
+  setLearningRunMessageCount,
+} from '@/lib/learning/repository'
+import { createInstanceClient } from '@/lib/opencode/client'
+import type { LearningRun, LearningTrigger } from '@/types/learning'
+
+const AUTO_LEARNING_MIN_MESSAGES = 12
+const AUTO_LEARNING_COOLDOWN_MS = 24 * 60 * 60 * 1000
+
+/*
+ * Learning run lifecycle owner.
+ *
+ * `pending` currently means the learning run has been created and associated with an
+ * internal OpenCode session, but curator-agent execution is not wired yet. Keep run
+ * status mutations in this module so the future execution path has one place to own
+ * pending -> running -> succeeded/failed transitions.
+ */
+
+export async function createLearningRun(args: {
+  userId: string
+  slug: string
+  sourceSessionId?: string | null
+  title?: string
+  trigger: LearningTrigger
+}): Promise<{ ok: true; run: LearningRun } | { ok: false; error: string }> {
+  const client = await createInstanceClient(args.slug)
+  if (!client) {
+    return { ok: false, error: 'instance_unavailable' }
+  }
+
+  const sourceTitle = args.title ?? 'Session'
+  const createdSession = await client.session.create({ title: getLearningSessionTitle(sourceTitle) })
+  const run = await createLearningRunRecord({
+    userId: args.userId,
+    sourceSessionId: args.sourceSessionId ?? null,
+    internalSessionId: createdSession.data?.id ?? null,
+    title: sourceTitle,
+    trigger: args.trigger,
+  })
+
+  return { ok: true, run }
+}
+
+export async function markLearningRunRunning(runId: string): Promise<void> {
+  await markLearningRunRunningRecord(runId)
+}
+
+export async function markLearningRunSucceeded(runId: string): Promise<void> {
+  await markLearningRunSucceededRecord(runId)
+}
+
+export async function markLearningRunFailed(args: { runId: string; error: string }): Promise<void> {
+  await markLearningRunFailedRecord(args)
+}
+
+export async function maybeQueueAutoLearningRun(args: {
+  userId: string
+  slug: string
+  sessionId: string
+  sessionTitle: string
+  messageCount: number
+}): Promise<void> {
+  if (args.messageCount < AUTO_LEARNING_MIN_MESSAGES) return
+
+  if (await hasActiveLearningRun({ userId: args.userId, sessionId: args.sessionId })) return
+
+  const cooldown = new Date(Date.now() - AUTO_LEARNING_COOLDOWN_MS)
+  if (await hasRecentLearningRun({ userId: args.userId, sessionId: args.sessionId, since: cooldown })) return
+
+  const run = await createLearningRun({
+    userId: args.userId,
+    slug: args.slug,
+    sourceSessionId: args.sessionId,
+    title: args.sessionTitle,
+    trigger: 'auto',
+  })
+  if (run.ok) {
+    await setLearningRunMessageCount({ runId: run.run.id, messageCount: args.messageCount })
+  }
+}

--- a/apps/web/src/lib/learning/run-lifecycle.ts
+++ b/apps/web/src/lib/learning/run-lifecycle.ts
@@ -69,10 +69,7 @@ export async function maybeQueueAutoLearningRun(args: {
 }): Promise<void> {
   if (args.messageCount < AUTO_LEARNING_MIN_MESSAGES) return
 
-  if (await hasActiveLearningRun({ userId: args.userId, sessionId: args.sessionId })) return
-
-  const cooldown = new Date(Date.now() - AUTO_LEARNING_COOLDOWN_MS)
-  if (await hasRecentLearningRun({ userId: args.userId, sessionId: args.sessionId, since: cooldown })) return
+  if (!(await canQueueAutoLearningRun({ userId: args.userId, sessionId: args.sessionId }))) return
 
   const run = await createLearningRun({
     userId: args.userId,
@@ -84,4 +81,13 @@ export async function maybeQueueAutoLearningRun(args: {
   if (run.ok) {
     await setLearningRunMessageCount({ runId: run.run.id, messageCount: args.messageCount })
   }
+}
+
+export async function canQueueAutoLearningRun(args: { userId: string; sessionId: string }): Promise<boolean> {
+  if (await hasActiveLearningRun({ userId: args.userId, sessionId: args.sessionId })) return false
+
+  const cooldown = new Date(Date.now() - AUTO_LEARNING_COOLDOWN_MS)
+  if (await hasRecentLearningRun({ userId: args.userId, sessionId: args.sessionId, since: cooldown })) return false
+
+  return true
 }

--- a/apps/web/src/lib/learning/service.ts
+++ b/apps/web/src/lib/learning/service.ts
@@ -8,6 +8,7 @@ export {
   listLearningRuns,
 } from '@/lib/learning/repository'
 export {
+  canQueueAutoLearningRun,
   createLearningRun,
   markLearningRunFailed,
   markLearningRunRunning,

--- a/apps/web/src/lib/learning/service.ts
+++ b/apps/web/src/lib/learning/service.ts
@@ -4,10 +4,12 @@ export {
 } from '@/lib/learning/proposal-application'
 export {
   createLearningProposal,
+  learningRunBelongsToUser,
   listLearningProposals,
   listLearningRuns,
 } from '@/lib/learning/repository'
 export {
+  AUTO_LEARNING_MIN_MESSAGES,
   canQueueAutoLearningRun,
   createLearningRun,
   markLearningRunFailed,

--- a/apps/web/src/lib/learning/service.ts
+++ b/apps/web/src/lib/learning/service.ts
@@ -1,0 +1,16 @@
+export {
+  applyLearningProposal,
+  rejectLearningProposal,
+} from '@/lib/learning/proposal-application'
+export {
+  createLearningProposal,
+  listLearningProposals,
+  listLearningRuns,
+} from '@/lib/learning/repository'
+export {
+  createLearningRun,
+  markLearningRunFailed,
+  markLearningRunRunning,
+  markLearningRunSucceeded,
+  maybeQueueAutoLearningRun,
+} from '@/lib/learning/run-lifecycle'

--- a/apps/web/src/lib/learning/session-history.ts
+++ b/apps/web/src/lib/learning/session-history.ts
@@ -1,0 +1,48 @@
+export type SessionHistoryRequest = {
+  includeMessages?: boolean
+  limit?: number
+  maxMessagesPerSession?: number
+  query?: string
+  sessionIds?: string[]
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function getSessionTitle(session: unknown): string {
+  if (!isRecord(session)) return 'Untitled'
+  return typeof session.title === 'string' && session.title.trim() ? session.title : 'Untitled'
+}
+
+export function getSessionId(session: unknown): string | null {
+  if (!isRecord(session)) return null
+  return typeof session.id === 'string' ? session.id : null
+}
+
+export function getMessageText(message: unknown): string {
+  if (!isRecord(message) || !Array.isArray(message.parts)) return ''
+  return message.parts
+    .map((part) => {
+      if (!isRecord(part)) return ''
+      const text = part.text ?? part.content
+      return typeof text === 'string' ? text : ''
+    })
+    .filter(Boolean)
+    .join('\n')
+}
+
+export function getMessageRole(message: unknown): string {
+  if (!isRecord(message) || !isRecord(message.info)) return 'unknown'
+  return typeof message.info.role === 'string' ? message.info.role : 'unknown'
+}
+
+export function clampSessionHistoryBounds(body: SessionHistoryRequest | null): {
+  limit: number
+  maxMessages: number
+} {
+  return {
+    limit: Math.min(Math.max(Math.trunc(body?.limit ?? 20), 1), 100),
+    maxMessages: Math.min(Math.max(Math.trunc(body?.maxMessagesPerSession ?? 20), 1), 100),
+  }
+}

--- a/apps/web/src/lib/learning/session-title.ts
+++ b/apps/web/src/lib/learning/session-title.ts
@@ -1,0 +1,10 @@
+const LEARNING_SESSION_PREFIX = 'Learning |'
+const LEARNING_FLOW_SESSION_PREFIX = 'Flow | Learning |'
+
+export function isLearningSessionTitle(title: string): boolean {
+  return title.startsWith(LEARNING_SESSION_PREFIX) || title.startsWith(LEARNING_FLOW_SESSION_PREFIX)
+}
+
+export function getLearningSessionTitle(title: string): string {
+  return `${LEARNING_SESSION_PREFIX} ${title}`
+}

--- a/apps/web/src/lib/learning/session-title.ts
+++ b/apps/web/src/lib/learning/session-title.ts
@@ -4,7 +4,3 @@ const LEARNING_FLOW_SESSION_PREFIX = 'Flow | Learning |'
 export function isLearningSessionTitle(title: string): boolean {
   return title.startsWith(LEARNING_SESSION_PREFIX) || title.startsWith(LEARNING_FLOW_SESSION_PREFIX)
 }
-
-export function getLearningSessionTitle(title: string): string {
-  return `${LEARNING_SESSION_PREFIX} ${title}`
-}

--- a/apps/web/src/lib/learning/validation.ts
+++ b/apps/web/src/lib/learning/validation.ts
@@ -1,0 +1,120 @@
+import {
+  LEARNING_EVIDENCE_QUOTE_MAX_LENGTH,
+  LEARNING_EVIDENCE_SOURCE_MAX_LENGTH,
+  LEARNING_KB_PATH_MAX_LENGTH,
+  LEARNING_OPERATIONS,
+  LEARNING_PROPOSAL_TYPES,
+  LEARNING_PROPOSED_CONTENT_MAX_LENGTH,
+  LEARNING_TITLE_MAX_LENGTH,
+  LEARNING_TRIGGERS,
+  type LearningEvidence,
+  type LearningProposalOperation,
+  type LearningProposalType,
+  type LearningTrigger,
+} from '@/types/learning'
+
+export type LearningProposalRequest = {
+  runId?: string | null
+  title: string
+  type?: LearningProposalType
+  confidence?: number
+  evidence?: LearningEvidence
+  kbPath: string
+  operation: LearningProposalOperation
+  proposedContent: string
+  currentFileHash?: string | null
+  internalSessionId?: string | null
+  trigger?: LearningTrigger
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isBoundedString(value: unknown, maxLength: number): value is string {
+  return typeof value === 'string' && value.trim().length > 0 && value.length <= maxLength
+}
+
+function isOptionalStringOrNull(value: unknown): value is string | null | undefined {
+  return value === undefined || value === null || typeof value === 'string'
+}
+
+function isProposalType(value: unknown): value is LearningProposalType {
+  return typeof value === 'string' && LEARNING_PROPOSAL_TYPES.includes(value as LearningProposalType)
+}
+
+function isOperation(value: unknown): value is LearningProposalOperation {
+  return typeof value === 'string' && LEARNING_OPERATIONS.includes(value as LearningProposalOperation)
+}
+
+function isTrigger(value: unknown): value is LearningTrigger {
+  return typeof value === 'string' && LEARNING_TRIGGERS.includes(value as LearningTrigger)
+}
+
+function parseEvidence(value: unknown): LearningEvidence | null | undefined {
+  if (value === undefined) return undefined
+  if (!isRecord(value)) return null
+
+  const evidence: LearningEvidence = {}
+  if (value.sessionId !== undefined) {
+    if (typeof value.sessionId !== 'string') return null
+    evidence.sessionId = value.sessionId
+  }
+  if (value.messageId !== undefined) {
+    if (typeof value.messageId !== 'string') return null
+    evidence.messageId = value.messageId
+  }
+  if (value.quote !== undefined) {
+    if (typeof value.quote !== 'string' || value.quote.length > LEARNING_EVIDENCE_QUOTE_MAX_LENGTH) return null
+    evidence.quote = value.quote
+  }
+  if (value.source !== undefined) {
+    if (typeof value.source !== 'string' || value.source.length > LEARNING_EVIDENCE_SOURCE_MAX_LENGTH) return null
+    evidence.source = value.source
+  }
+
+  return evidence
+}
+
+export function parseProposalRequest(body: unknown):
+  | { ok: true; value: LearningProposalRequest }
+  | { ok: false } {
+  if (!isRecord(body)) return { ok: false }
+  if (!isBoundedString(body.title, LEARNING_TITLE_MAX_LENGTH)) return { ok: false }
+  if (!isBoundedString(body.kbPath, LEARNING_KB_PATH_MAX_LENGTH)) return { ok: false }
+  if (!isBoundedString(body.proposedContent, LEARNING_PROPOSED_CONTENT_MAX_LENGTH)) return { ok: false }
+  if (!isOperation(body.operation)) return { ok: false }
+  if (!isOptionalStringOrNull(body.runId)) return { ok: false }
+  if (!isOptionalStringOrNull(body.currentFileHash)) return { ok: false }
+  if (!isOptionalStringOrNull(body.internalSessionId)) return { ok: false }
+  if (body.type !== undefined && !isProposalType(body.type)) return { ok: false }
+  if (body.trigger !== undefined && !isTrigger(body.trigger)) return { ok: false }
+  if (body.confidence !== undefined && (
+    typeof body.confidence !== 'number' ||
+    !Number.isFinite(body.confidence) ||
+    body.confidence < 0 ||
+    body.confidence > 1
+  )) {
+    return { ok: false }
+  }
+
+  const evidence = parseEvidence(body.evidence)
+  if (evidence === null) return { ok: false }
+
+  return {
+    ok: true,
+    value: {
+      runId: body.runId ?? null,
+      title: body.title,
+      type: body.type,
+      confidence: body.confidence,
+      evidence,
+      kbPath: body.kbPath,
+      operation: body.operation,
+      proposedContent: body.proposedContent,
+      currentFileHash: body.currentFileHash ?? null,
+      internalSessionId: body.internalSessionId ?? null,
+      trigger: body.trigger,
+    },
+  }
+}

--- a/apps/web/src/lib/learning/validation.ts
+++ b/apps/web/src/lib/learning/validation.ts
@@ -27,6 +27,12 @@ export type LearningProposalRequest = {
   trigger?: LearningTrigger
 }
 
+export type LearningProposalActionRequest = {
+  action: 'apply' | 'reject'
+  proposalId: string
+  content?: string
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
@@ -49,6 +55,19 @@ function isOperation(value: unknown): value is LearningProposalOperation {
 
 function isTrigger(value: unknown): value is LearningTrigger {
   return typeof value === 'string' && LEARNING_TRIGGERS.includes(value as LearningTrigger)
+}
+
+// Mirrors the workspace agent's resolvePath rules so invalid paths fail at
+// proposal creation instead of surfacing as an agent error on Apply.
+export function isValidKbPath(value: unknown): value is string {
+  if (!isBoundedString(value, LEARNING_KB_PATH_MAX_LENGTH)) return false
+  if (value.includes('\0') || value.includes('\\')) return false
+
+  const segments = value.split('/')
+  if (segments.some((segment) => segment === '' || segment === '.' || segment === '..')) return false
+  if (segments[0] === '.git') return false
+
+  return true
 }
 
 function parseEvidence(value: unknown): LearningEvidence | null | undefined {
@@ -81,7 +100,7 @@ export function parseProposalRequest(body: unknown):
   | { ok: false } {
   if (!isRecord(body)) return { ok: false }
   if (!isBoundedString(body.title, LEARNING_TITLE_MAX_LENGTH)) return { ok: false }
-  if (!isBoundedString(body.kbPath, LEARNING_KB_PATH_MAX_LENGTH)) return { ok: false }
+  if (!isValidKbPath(body.kbPath)) return { ok: false }
   if (!isBoundedString(body.proposedContent, LEARNING_PROPOSED_CONTENT_MAX_LENGTH)) return { ok: false }
   if (!isOperation(body.operation)) return { ok: false }
   if (!isOptionalStringOrNull(body.runId)) return { ok: false }
@@ -115,6 +134,26 @@ export function parseProposalRequest(body: unknown):
       currentFileHash: body.currentFileHash ?? null,
       internalSessionId: body.internalSessionId ?? null,
       trigger: body.trigger,
+    },
+  }
+}
+
+export function parseProposalActionRequest(body: unknown):
+  | { ok: true; value: LearningProposalActionRequest }
+  | { ok: false } {
+  if (!isRecord(body)) return { ok: false }
+  if (typeof body.proposalId !== 'string' || body.proposalId.trim().length === 0) return { ok: false }
+  if (body.action !== 'apply' && body.action !== 'reject') return { ok: false }
+  if (body.content !== undefined && !isBoundedString(body.content, LEARNING_PROPOSED_CONTENT_MAX_LENGTH)) {
+    return { ok: false }
+  }
+
+  return {
+    ok: true,
+    value: {
+      action: body.action,
+      proposalId: body.proposalId,
+      content: typeof body.content === 'string' ? body.content : undefined,
     },
   }
 }

--- a/apps/web/src/lib/runtime/workspace-host-desktop.ts
+++ b/apps/web/src/lib/runtime/workspace-host-desktop.ts
@@ -396,6 +396,8 @@ const desktopWorkspaceHostReal: WorkspaceHost = {
           ...safeEnv,
           OPENCODE_SERVER_PASSWORD: password,
           OPENCODE_SERVER_USERNAME: DEFAULT_USERNAME,
+          ARCHE_WORKSPACE_SLUG: slug,
+          ARCHE_INTERNAL_API_BASE_URL: process.env.ARCHE_INTERNAL_API_BASE_URL ?? `http://${LOOPBACK_HOST}:3000`,
           ...(opencodeConfigDir ? { OPENCODE_CONFIG_DIR: opencodeConfigDir } : {}),
           WORKSPACE_DIR: workspaceDir,
           HOME: archeDataDir,

--- a/apps/web/src/lib/spawner/__tests__/agent-config-transforms.test.ts
+++ b/apps/web/src/lib/spawner/__tests__/agent-config-transforms.test.ts
@@ -90,6 +90,8 @@ describe('injectAlwaysOnAgentTools', () => {
     expect(supportTools.chart_create).toBe(true)
     expect(supportTools.diagram_create).toBe(true)
     expect(supportTools.flow_propose).toBe(true)
+    expect(supportTools.learning_propose).toBe(true)
+    expect(supportTools.session_history_query).toBe(true)
   })
 
   it('skips agents that do not define explicit tools', () => {
@@ -108,7 +110,14 @@ describe('injectAlwaysOnAgentTools', () => {
       agent: {
         assistant: {
           mode: 'primary',
-          tools: { email_draft: true, chart_create: true, diagram_create: true, flow_propose: true },
+          tools: {
+            email_draft: true,
+            chart_create: true,
+            diagram_create: true,
+            flow_propose: true,
+            learning_propose: true,
+            session_history_query: true,
+          },
         },
       },
     }

--- a/apps/web/src/lib/spawner/agent-config-transforms.ts
+++ b/apps/web/src/lib/spawner/agent-config-transforms.ts
@@ -5,7 +5,7 @@ import { isRecord } from '@/lib/records'
 
 const CONNECTOR_TYPE_PATTERN = CONNECTOR_TYPES.join('|')
 const MCP_SERVER_KEY_PATTERN = new RegExp(`^arche_(${CONNECTOR_TYPE_PATTERN})_([^_]+)$`)
-const ALWAYS_ENABLED_TOOLS = ['email_draft', 'chart_create', 'diagram_create', 'flow_propose'] as const
+const ALWAYS_ENABLED_TOOLS = ['email_draft', 'chart_create', 'diagram_create', 'flow_propose', 'session_history_query', 'learning_propose'] as const
 const PERMISSION_ACTIONS = new Set(['allow', 'ask', 'deny'])
 
 function isToolMap(value: unknown): value is Record<string, boolean> {

--- a/apps/web/src/lib/spawner/docker.ts
+++ b/apps/web/src/lib/spawner/docker.ts
@@ -191,6 +191,8 @@ export async function createContainer(
     `OPENCODE_SERVER_PASSWORD=${password}`,
     `OPENCODE_SERVER_USERNAME=opencode`,
     `OPENCODE_CONFIG_DIR=/opt/arche/opencode-config`,
+    `ARCHE_WORKSPACE_SLUG=${slug}`,
+    `ARCHE_INTERNAL_API_BASE_URL=${process.env.ARCHE_INTERNAL_API_BASE_URL ?? 'http://web:3000'}`,
     // The workspace image runs as root for Podman volume compatibility.
     // Force HOME/XDG to mounted /home/workspace paths so session data persists.
     `HOME=/home/workspace`,

--- a/apps/web/src/lib/workspace-agent-client.ts
+++ b/apps/web/src/lib/workspace-agent-client.ts
@@ -9,7 +9,7 @@ export type AgentResponse<T> =
   | { ok: true; data: T; status: number }
   | { ok: false; error: string; status: number }
 
-export async function workspaceAgentFetch<T extends JsonObject>(
+export async function workspaceAgentFetch<T>(
   agent: WorkspaceAgent,
   endpoint: string,
   body?: Record<string, unknown>,

--- a/apps/web/src/types/learning.ts
+++ b/apps/web/src/types/learning.ts
@@ -1,0 +1,53 @@
+export const LEARNING_PROPOSAL_TYPES = ['fact', 'preference', 'process', 'correction', 'other'] as const
+export const LEARNING_OPERATIONS = ['create', 'update'] as const
+export const LEARNING_TRIGGERS = ['manual', 'auto', 'flow', 'agent'] as const
+
+export const LEARNING_TITLE_MAX_LENGTH = 200
+export const LEARNING_KB_PATH_MAX_LENGTH = 500
+export const LEARNING_PROPOSED_CONTENT_MAX_LENGTH = 200_000
+export const LEARNING_EVIDENCE_QUOTE_MAX_LENGTH = 4_000
+export const LEARNING_EVIDENCE_SOURCE_MAX_LENGTH = 500
+
+export type LearningTrigger = (typeof LEARNING_TRIGGERS)[number]
+export type LearningRunStatus = 'pending' | 'running' | 'succeeded' | 'failed'
+export type LearningProposalStatus = 'pending' | 'rejected' | 'applied'
+export type LearningProposalType = (typeof LEARNING_PROPOSAL_TYPES)[number]
+export type LearningProposalOperation = (typeof LEARNING_OPERATIONS)[number]
+
+export type LearningEvidence = {
+  sessionId?: string
+  messageId?: string
+  quote?: string
+  source?: string
+}
+
+export type LearningRun = {
+  id: string
+  sourceSessionId: string | null
+  internalSessionId: string | null
+  title: string
+  trigger: LearningTrigger
+  status: LearningRunStatus
+  error: string | null
+  messageCount: number
+  createdAt: string
+  updatedAt: string
+}
+
+export type LearningProposal = {
+  id: string
+  runId: string | null
+  status: LearningProposalStatus
+  title: string
+  type: LearningProposalType
+  confidence: number
+  evidence: LearningEvidence
+  kbPath: string
+  operation: LearningProposalOperation
+  proposedContent: string
+  currentFileHash: string | null
+  internalSessionId: string | null
+  trigger: LearningTrigger
+  createdAt: string
+  updatedAt: string
+}

--- a/infra/workspace-image/opencode-config/shared/internal-api.js
+++ b/infra/workspace-image/opencode-config/shared/internal-api.js
@@ -1,0 +1,30 @@
+export function getInternalHeaders() {
+  const slug = process.env.ARCHE_WORKSPACE_SLUG
+  const password = process.env.OPENCODE_SERVER_PASSWORD
+  if (!slug || !password) return null
+
+  return {
+    Accept: 'application/json',
+    Authorization: `Basic ${Buffer.from(`opencode:${password}`).toString('base64')}`,
+    'Content-Type': 'application/json',
+    'x-arche-workspace-slug': slug,
+  }
+}
+
+export async function callInternalApi(path, body) {
+  const baseUrl = process.env.ARCHE_INTERNAL_API_BASE_URL
+  const headers = getInternalHeaders()
+  if (!baseUrl || !headers) return { ok: false, error: 'missing_internal_api_config' }
+
+  const response = await fetch(`${baseUrl.replace(/\/$/, '')}${path}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  })
+  const data = await response.json().catch(() => null)
+  if (!response.ok || !data) {
+    return { ok: false, error: data?.error ?? `http_${response.status}` }
+  }
+
+  return { ok: true, data }
+}

--- a/infra/workspace-image/opencode-config/tests/tool-exports.test.js
+++ b/infra/workspace-image/opencode-config/tests/tool-exports.test.js
@@ -6,7 +6,9 @@ import * as diagramTools from '../tools/diagram.js'
 import * as documentTools from '../tools/document.js'
 import * as emailTools from '../tools/email.js'
 import * as flowTools from '../tools/flow.js'
+import * as learningTools from '../tools/learning.js'
 import * as presentationTools from '../tools/presentation.js'
+import * as sessionHistoryTools from '../tools/session_history.js'
 import * as spreadsheetTools from '../tools/spreadsheet.js'
 
 test('tool modules only export executable tool definitions', () => {
@@ -15,6 +17,8 @@ test('tool modules only export executable tool definitions', () => {
   assert.deepEqual(Object.keys(documentTools).sort(), ['inspect'])
   assert.deepEqual(Object.keys(emailTools).sort(), ['draft'])
   assert.deepEqual(Object.keys(flowTools).sort(), ['propose'])
+  assert.deepEqual(Object.keys(learningTools).sort(), ['propose'])
   assert.deepEqual(Object.keys(presentationTools).sort(), ['inspect'])
+  assert.deepEqual(Object.keys(sessionHistoryTools).sort(), ['query'])
   assert.deepEqual(Object.keys(spreadsheetTools).sort(), ['inspect', 'query', 'sample', 'stats'])
 })

--- a/infra/workspace-image/opencode-config/tools/learning.js
+++ b/infra/workspace-image/opencode-config/tools/learning.js
@@ -1,0 +1,58 @@
+import { z } from 'zod'
+
+import { toToolOutput } from '../shared/attachment-tools.js'
+import { callInternalApi } from '../shared/internal-api.js'
+
+const proposalTypes = ['fact', 'preference', 'process', 'correction', 'other']
+const operations = ['create', 'update']
+const triggers = ['manual', 'auto', 'flow', 'agent']
+
+const argsSchema = z.object({
+  runId: z.string().nullable().optional(),
+  title: z.string().min(1).max(200),
+  type: z.enum(proposalTypes).optional(),
+  confidence: z.number().min(0).max(1).optional(),
+  evidence: z.object({
+    sessionId: z.string().optional(),
+    messageId: z.string().optional(),
+    quote: z.string().max(4000).optional(),
+    source: z.string().max(500).optional(),
+  }).optional(),
+  kbPath: z.string().min(1).max(500),
+  operation: z.enum(operations),
+  proposedContent: z.string().min(1).max(200000),
+  currentFileHash: z.string().nullable().optional(),
+  internalSessionId: z.string().nullable().optional(),
+  trigger: z.enum(triggers).optional(),
+}).strict()
+
+export const propose = {
+  description: 'Create a pending Knowledge Base learning proposal in Arche. This never writes to KB files; a user must apply the proposal later.',
+  args: {
+    runId: z.string().nullable().optional().describe('Learning run id, when known.'),
+    title: z.string().min(1).max(200).describe('Short proposal title.'),
+    type: z.enum(proposalTypes).optional().describe('Learning type.'),
+    confidence: z.number().min(0).max(1).optional().describe('Confidence score from 0 to 1.'),
+    evidence: z.object({
+      sessionId: z.string().optional(),
+      messageId: z.string().optional(),
+      quote: z.string().max(4000).optional(),
+      source: z.string().max(500).optional(),
+    }).optional().describe('Evidence supporting this proposal.'),
+    kbPath: z.string().min(1).max(500).describe('Target KB path.'),
+    operation: z.enum(operations).describe('Whether to create or update the target KB file.'),
+    proposedContent: z.string().min(1).max(200000).describe('Full proposed file content.'),
+    currentFileHash: z.string().nullable().optional().describe('Current file hash for update conflict detection.'),
+    internalSessionId: z.string().nullable().optional().describe('Internal learning session id, when known.'),
+    trigger: z.enum(triggers).optional().describe('Learning trigger source.'),
+  },
+  async execute(args) {
+    const parsed = argsSchema.safeParse(args)
+    if (!parsed.success) return toToolOutput({ ok: false, error: 'schema_validation_failed' })
+
+    const result = await callInternalApi('/api/internal/learning/proposals', parsed.data)
+    if (!result.ok) return toToolOutput({ ok: false, error: result.error })
+
+    return toToolOutput({ ok: true, ...result.data })
+  },
+}

--- a/infra/workspace-image/opencode-config/tools/session_history.js
+++ b/infra/workspace-image/opencode-config/tools/session_history.js
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+import { toToolOutput } from '../shared/attachment-tools.js'
+import { callInternalApi } from '../shared/internal-api.js'
+
+const argsSchema = z.object({
+  includeMessages: z.boolean().optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+  maxMessagesPerSession: z.number().int().min(1).max(100).optional(),
+  query: z.string().max(500).optional(),
+  sessionIds: z.array(z.string().min(1)).max(100).optional(),
+}).strict()
+
+export const query = {
+  description: 'Query prior workspace session history through Arche. Use this to gather evidence before proposing KB updates.',
+  args: {
+    includeMessages: z.boolean().optional().describe('Include message text for returned sessions.'),
+    limit: z.number().int().min(1).max(100).optional().describe('Maximum sessions to return.'),
+    maxMessagesPerSession: z.number().int().min(1).max(100).optional().describe('Maximum messages per session when includeMessages is true.'),
+    query: z.string().max(500).optional().describe('Optional session title search.'),
+    sessionIds: z.array(z.string().min(1)).max(100).optional().describe('Specific OpenCode session ids to inspect.'),
+  },
+  async execute(args) {
+    const parsed = argsSchema.safeParse(args)
+    if (!parsed.success) return toToolOutput({ ok: false, error: 'schema_validation_failed' })
+
+    const result = await callInternalApi('/api/internal/learning/session-history', parsed.data)
+    if (!result.ok) return toToolOutput({ ok: false, error: result.error })
+
+    return toToolOutput({ ok: true, ...result.data })
+  },
+}


### PR DESCRIPTION
## Summary

- Add forward-compatible Prisma models (`KnowledgeLearningRun`, `KnowledgeLearningProposal`) and additive migration.
- Implement learning APIs: internal endpoints for `proposals` and `session-history`, user-facing endpoints for runs/proposals.
- Add OpenCode tools (`learning_propose`, `session_history_query`) and inject them as always-on tools for all agents.
- Introduce Knowledge Curator right panel for reviewing and applying/rejecting pending KB proposals.
- Filter `Learning |` and `Flow | Learning |` sessions from the main session list.
- Enqueue auto-learning best-effort after successful chat completion (min 12 messages, 24h cooldown).
- Refactor learning service into focused modules (`repository`, `proposal-application`, `run-lifecycle`) to improve SRP.
- Harden proposals API: require explicit `apply`/`reject` actions; validate internal payloads at the boundary.
- Fix curator panel edit state to use controlled textarea (no hidden mutation).
- Add shared internal API helper (`callInternalApi`) for tools and extract session-history helpers.
- Update agent capabilities, spawner transforms, container env vars, and workspace-host-desktop runtime.

All learning creates pending proposals only; KB writes happen only after explicit Apply with hash verification and audit events.

## Tests/checks run

```bash
pnpm test 'src/lib/learning/__tests__/validation.test.ts' 'src/app/api/u/[slug]/learning/proposals/__tests__/route.test.ts'
# 8 passed

node --test tests/*.test.js
# 22 passed

pnpm lint
# 16 warnings (pre-existing, unrelated)

pnpm test
# 4684 passed, 15 skipped

pnpm build
# Compiled successfully (Turbopack warnings pre-existing)

bash scripts/check-podman-images.sh
# Podman image validation passed
```

## Review notes

- Pending `learning.run` records and internal sessions are created, but curator-agent execution is not yet wired; `pending` honestly means "queued, not executed". Full curator execution is a separate feature.
- `learning_propose` and `session_history_query` tools are injected as always-on for all agents via `injectAlwaysOnAgentTools`.
- Auto-learning enqueue is best-effort and does not affect chat streaming if it fails.
- Hash conflict detection prevents update applies when the target file has changed since proposal creation.

## Checklist

- [x] Tests added for new validation and proposal action handling.
- [x] Existing tests updated for session filtering, always-on tools, and right-panel behavior.
- [x] Migration is additive (forward-compatible).
- [x] No secrets or sensitive data in code.
- [x] Commit follows Conventional Commits.