### PR TITLE
feat(learning): wire the curator executor for manual and auto learning runs

### DIFF
--- a/apps/web/src/app/api/u/[slug]/learning/__tests__/route.test.ts
+++ b/apps/web/src/app/api/u/[slug]/learning/__tests__/route.test.ts
@@ -3,12 +3,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   createLearningRun: vi.fn(),
+  dispatchLearningRunExecution: vi.fn(),
+  findLearningRunForUser: vi.fn(),
   listLearningProposals: vi.fn(),
   listLearningRuns: vi.fn(),
 }))
 
 vi.mock('@/lib/learning/service', () => ({
   createLearningRun: mocks.createLearningRun,
+  dispatchLearningRunExecution: mocks.dispatchLearningRunExecution,
+  findLearningRunForUser: mocks.findLearningRunForUser,
   listLearningProposals: mocks.listLearningProposals,
   listLearningRuns: mocks.listLearningRuns,
 }))
@@ -29,12 +33,20 @@ function makeRequest(body: unknown): NextRequest {
   })
 }
 
+const createdRun = {
+  id: 'run-1',
+  sourceSessionId: 'session-1',
+  title: 'Session',
+  trigger: 'manual',
+  status: 'pending',
+}
+
 describe('/api/u/[slug]/learning', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.listLearningRuns.mockResolvedValue([{ id: 'run-1' }])
     mocks.listLearningProposals.mockResolvedValue([{ id: 'proposal-1' }])
-    mocks.createLearningRun.mockResolvedValue({ ok: true, run: { id: 'run-1' } })
+    mocks.createLearningRun.mockResolvedValue({ ok: true, run: createdRun })
   })
 
   it('lists learning runs and proposals', async () => {
@@ -44,13 +56,21 @@ describe('/api/u/[slug]/learning', () => {
     await expect(response.json()).resolves.toEqual({ runs: [{ id: 'run-1' }], proposals: [{ id: 'proposal-1' }] })
   })
 
-  it('creates a manual learning run', async () => {
+  it('creates a manual learning run and dispatches the executor', async () => {
     const response = await POST(makeRequest({ sourceSessionId: 'session-1', title: 'Session' }))
 
     expect(response.status).toBe(200)
     expect(mocks.createLearningRun).toHaveBeenCalledWith({
       userId: 'user-1',
       slug: 'alice',
+      sourceSessionId: 'session-1',
+      title: 'Session',
+      trigger: 'manual',
+    })
+    expect(mocks.dispatchLearningRunExecution).toHaveBeenCalledWith({
+      runId: 'run-1',
+      slug: 'alice',
+      userId: 'user-1',
       sourceSessionId: 'session-1',
       title: 'Session',
       trigger: 'manual',
@@ -64,5 +84,43 @@ describe('/api/u/[slug]/learning', () => {
 
     expect(response.status).toBe(400)
     await expect(response.json()).resolves.toEqual({ error: 'instance_unavailable' })
+    expect(mocks.dispatchLearningRunExecution).not.toHaveBeenCalled()
+  })
+
+  it('re-dispatches a failed run on retry', async () => {
+    mocks.findLearningRunForUser.mockResolvedValue({ ...createdRun, status: 'failed', trigger: 'auto' })
+
+    const response = await POST(makeRequest({ runId: 'run-1' }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.findLearningRunForUser).toHaveBeenCalledWith({ runId: 'run-1', userId: 'user-1' })
+    expect(mocks.dispatchLearningRunExecution).toHaveBeenCalledWith({
+      runId: 'run-1',
+      slug: 'alice',
+      userId: 'user-1',
+      sourceSessionId: 'session-1',
+      title: 'Session',
+      trigger: 'auto',
+    })
+    expect(mocks.createLearningRun).not.toHaveBeenCalled()
+  })
+
+  it('rejects retrying a run that is already executing', async () => {
+    mocks.findLearningRunForUser.mockResolvedValue({ ...createdRun, status: 'running' })
+
+    const response = await POST(makeRequest({ runId: 'run-1' }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'run_not_retryable' })
+    expect(mocks.dispatchLearningRunExecution).not.toHaveBeenCalled()
+  })
+
+  it('rejects retrying an unknown run', async () => {
+    mocks.findLearningRunForUser.mockResolvedValue(null)
+
+    const response = await POST(makeRequest({ runId: 'run-missing' }))
+
+    expect(response.status).toBe(404)
+    expect(mocks.dispatchLearningRunExecution).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/app/api/u/[slug]/learning/route.ts
+++ b/apps/web/src/app/api/u/[slug]/learning/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server'
 
 import {
   createLearningRun,
+  dispatchLearningRunExecution,
+  findLearningRunForUser,
   listLearningProposals,
   listLearningRuns,
 } from '@/lib/learning/service'
@@ -16,6 +18,7 @@ type LearningResponse = {
 type CreateLearningRunRequest = {
   sourceSessionId?: string
   title?: string
+  runId?: string
 }
 
 export const GET = withAuth<LearningResponse | { error: string }>(
@@ -33,6 +36,28 @@ export const POST = withAuth<{ run: LearningRun } | { error: string }>(
   { csrf: true },
   async (request, context) => {
     const body = (await request.json().catch(() => null)) as CreateLearningRunRequest | null
+
+    // Retry: re-dispatch an existing run that never executed or failed.
+    if (body?.runId) {
+      const run = await findLearningRunForUser({ runId: body.runId, userId: context.user.id })
+      if (!run) {
+        return NextResponse.json({ error: 'not_found' }, { status: 404 })
+      }
+      if (run.status !== 'pending' && run.status !== 'failed') {
+        return NextResponse.json({ error: 'run_not_retryable' }, { status: 400 })
+      }
+
+      dispatchLearningRunExecution({
+        runId: run.id,
+        slug: context.slug,
+        userId: context.user.id,
+        sourceSessionId: run.sourceSessionId,
+        title: run.title,
+        trigger: run.trigger,
+      })
+      return NextResponse.json({ run })
+    }
+
     const result = await createLearningRun({
       userId: context.user.id,
       slug: context.slug,
@@ -43,6 +68,15 @@ export const POST = withAuth<{ run: LearningRun } | { error: string }>(
     if (!result.ok) {
       return NextResponse.json({ error: result.error }, { status: 400 })
     }
+
+    dispatchLearningRunExecution({
+      runId: result.run.id,
+      slug: context.slug,
+      userId: context.user.id,
+      sourceSessionId: result.run.sourceSessionId,
+      title: result.run.title,
+      trigger: 'manual',
+    })
     return NextResponse.json({ run: result.run })
   }
 )

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { getIdleFinalizationOutcome, getSilentStreamOutcome } from '@/app/api/w/[slug]/chat/stream/watchdog'
 import { createUpstreamSessionStatusReader } from '@/app/api/w/[slug]/chat/stream/status-reader'
-import { AUTO_LEARNING_MIN_MESSAGES, canQueueAutoLearningRun, maybeQueueAutoLearningRun } from '@/lib/learning/service'
+import { AUTO_LEARNING_MIN_MESSAGES, canQueueAutoLearningRun, dispatchLearningRunExecution, maybeQueueAutoLearningRun } from '@/lib/learning/service'
 import { getInstanceUrl } from '@/lib/opencode/client'
 import { ensureProviderAccessFreshForExecution } from '@/lib/opencode/providers'
 import {
@@ -230,13 +230,23 @@ async function queueAutoLearningBestEffort(params: {
       ? sessionData.title
       : 'Session'
 
-    await maybeQueueAutoLearningRun({
+    const queuedRun = await maybeQueueAutoLearningRun({
       userId: params.userId,
       slug: params.slug,
       sessionId: params.sessionId,
       sessionTitle,
       messageCount,
     })
+    if (queuedRun) {
+      dispatchLearningRunExecution({
+        runId: queuedRun.id,
+        slug: params.slug,
+        userId: params.userId,
+        sourceSessionId: queuedRun.sourceSessionId,
+        title: queuedRun.title,
+        trigger: 'auto',
+      })
+    }
   } catch {
     // Auto-learning is best-effort and must not affect chat streaming.
   }

--- a/apps/web/src/components/workspace/knowledge-curator-panel.tsx
+++ b/apps/web/src/components/workspace/knowledge-curator-panel.tsx
@@ -27,7 +27,14 @@ const ERROR_LABELS: Record<string, string> = {
   invalid_request: "The request was invalid.",
   learning_load_failed: "Could not load learning data.",
   learning_action_failed: "The action failed. Try again.",
+  run_not_retryable: "This run is already executing.",
+  instance_unavailable: "The workspace instance is unavailable. Try again later.",
 };
+
+const ACTIVE_RUN_POLL_INTERVAL_MS = 5_000;
+// Dispatch happens right after a run is created, so a run still pending after
+// this window lost its executor (e.g. a server restart) and can be retried.
+const STALE_PENDING_RUN_MS = 2 * 60 * 1000;
 
 function errorLabel(code: string): string {
   return ERROR_LABELS[code] ?? code;
@@ -65,6 +72,8 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
   const [edits, setEdits] = useState<Record<string, string>>({});
   const [error, setError] = useState<string | null>(null);
   const [busyProposalId, setBusyProposalId] = useState<string | null>(null);
+  const [busyRunId, setBusyRunId] = useState<string | null>(null);
+  const [refreshedAt, setRefreshedAt] = useState(0);
 
   const refresh = useCallback(async () => {
     try {
@@ -77,6 +86,7 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
       }
       setError(null);
       setData(json);
+      setRefreshedAt(Date.now());
     } catch {
       setError("learning_load_failed");
     }
@@ -89,6 +99,43 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
 
     return () => window.clearTimeout(timeout);
   }, [refresh, refreshKey]);
+
+  const hasActiveRun = data.runs.some((run) => run.status === "pending" || run.status === "running");
+
+  useEffect(() => {
+    if (collapsed || !hasActiveRun) return;
+
+    const interval = window.setInterval(() => {
+      void refresh();
+    }, ACTIVE_RUN_POLL_INTERVAL_MS);
+
+    return () => window.clearInterval(interval);
+  }, [collapsed, hasActiveRun, refresh]);
+
+  const retryRun = useCallback(
+    async (runId: string) => {
+      setBusyRunId(runId);
+      try {
+        const response = await fetch(`/api/u/${slug}/learning`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ runId }),
+        });
+        const json = (await response.json().catch(() => null)) as { error?: string } | null;
+        if (!response.ok) {
+          setError(json?.error ?? "learning_action_failed");
+        } else {
+          setError(null);
+        }
+        await refresh();
+      } catch {
+        setError("learning_action_failed");
+      } finally {
+        setBusyRunId(null);
+      }
+    },
+    [refresh, slug]
+  );
 
   const actOnProposal = useCallback(
     async (proposalId: string, action: "apply" | "reject", content?: string) => {
@@ -204,18 +251,36 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
         </section>
         <section className="space-y-2">
           <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Recent runs</h3>
-          {data.runs.map((run) => (
-            <div key={run.id} className="space-y-1 rounded-md border border-border/60 p-2 text-xs">
-              <div className="flex items-center justify-between gap-2">
-                <p className="min-w-0 truncate font-medium">{run.title}</p>
-                <RunStatusBadge status={run.status} />
+          {data.runs.map((run) => {
+            const isStalePending =
+              run.status === "pending" && refreshedAt - Date.parse(run.createdAt) > STALE_PENDING_RUN_MS;
+            const isRetryable = run.status === "failed" || isStalePending;
+            return (
+              <div key={run.id} className="space-y-1 rounded-md border border-border/60 p-2 text-xs">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="min-w-0 truncate font-medium">{run.title}</p>
+                  <RunStatusBadge status={run.status} />
+                </div>
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-muted-foreground">{run.trigger}</p>
+                  {isRetryable ? (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-6 px-2 text-[11px]"
+                      disabled={busyRunId !== null}
+                      onClick={() => void retryRun(run.id)}
+                    >
+                      {run.status === "failed" ? "Retry" : "Run now"}
+                    </Button>
+                  ) : null}
+                </div>
+                {run.status === "failed" && run.error ? (
+                  <p className="text-destructive">{errorLabel(run.error)}</p>
+                ) : null}
               </div>
-              <p className="text-muted-foreground">{run.trigger}</p>
-              {run.status === "failed" && run.error ? (
-                <p className="text-destructive">{errorLabel(run.error)}</p>
-              ) : null}
-            </div>
-          ))}
+            );
+          })}
           {data.runs.length === 0 ? (
             <p className="text-xs text-muted-foreground">No learning runs yet.</p>
           ) : null}

--- a/apps/web/src/lib/learning/__tests__/run-executor.test.ts
+++ b/apps/web/src/lib/learning/__tests__/run-executor.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  claimLearningRunForExecution: vi.fn(),
+  markLearningRunFailed: vi.fn(),
+  markLearningRunSucceeded: vi.fn(),
+  setLearningRunInternalSessionId: vi.fn(),
+  createInstanceClient: vi.fn(),
+  ensureWorkspaceRunningForExecution: vi.fn(),
+  createSessionPromptRun: vi.fn(),
+  captureSessionMessageCursor: vi.fn(),
+  waitForSessionToComplete: vi.fn(),
+  markRunFailed: vi.fn(),
+  markRunSucceeded: vi.fn(),
+}))
+
+vi.mock('@/lib/learning/repository', () => ({
+  claimLearningRunForExecution: mocks.claimLearningRunForExecution,
+  markLearningRunFailed: mocks.markLearningRunFailed,
+  markLearningRunSucceeded: mocks.markLearningRunSucceeded,
+  setLearningRunInternalSessionId: mocks.setLearningRunInternalSessionId,
+}))
+
+vi.mock('@/lib/opencode/client', () => ({
+  createInstanceClient: mocks.createInstanceClient,
+}))
+
+vi.mock('@/lib/opencode/session-execution', () => ({
+  ensureWorkspaceRunningForExecution: mocks.ensureWorkspaceRunningForExecution,
+  createSessionPromptRun: mocks.createSessionPromptRun,
+  captureSessionMessageCursor: mocks.captureSessionMessageCursor,
+  waitForSessionToComplete: mocks.waitForSessionToComplete,
+}))
+
+vi.mock('@/lib/services', () => ({
+  messageRunService: {
+    markRunFailed: mocks.markRunFailed,
+    markRunSucceeded: mocks.markRunSucceeded,
+  },
+}))
+
+import { buildCuratorPrompt, executeLearningRun } from '@/lib/learning/run-executor'
+
+const baseInput = {
+  runId: 'run-1',
+  slug: 'alice',
+  userId: 'user-1',
+  sourceSessionId: 'session-1',
+  title: 'Source session',
+  trigger: 'manual' as const,
+}
+
+function makeClient() {
+  return {
+    session: {
+      create: vi.fn().mockResolvedValue({ data: { id: 'internal-session-1' } }),
+      promptAsync: vi.fn().mockResolvedValue({ data: {} }),
+    },
+  }
+}
+
+describe('executeLearningRun', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.claimLearningRunForExecution.mockResolvedValue(true)
+    mocks.markLearningRunFailed.mockResolvedValue(undefined)
+    mocks.markLearningRunSucceeded.mockResolvedValue(undefined)
+    mocks.setLearningRunInternalSessionId.mockResolvedValue(undefined)
+    mocks.markRunFailed.mockResolvedValue(undefined)
+    mocks.markRunSucceeded.mockResolvedValue(undefined)
+    mocks.ensureWorkspaceRunningForExecution.mockResolvedValue(undefined)
+    mocks.createInstanceClient.mockResolvedValue(makeClient())
+    mocks.createSessionPromptRun.mockResolvedValue({ ok: true, run: { id: 'message-run-1' } })
+    mocks.captureSessionMessageCursor.mockResolvedValue({ messageCount: 0 })
+    mocks.waitForSessionToComplete.mockResolvedValue(null)
+  })
+
+  it('runs the curator in a hidden session and marks the run succeeded', async () => {
+    const client = makeClient()
+    mocks.createInstanceClient.mockResolvedValue(client)
+
+    await expect(executeLearningRun(baseInput)).resolves.toEqual({ ok: true })
+
+    expect(mocks.claimLearningRunForExecution).toHaveBeenCalledWith('run-1')
+    expect(mocks.ensureWorkspaceRunningForExecution).toHaveBeenCalledWith('alice', 'user-1')
+    expect(client.session.create).toHaveBeenCalledWith(
+      { title: 'Learning | Source session' },
+      { throwOnError: true },
+    )
+    expect(mocks.setLearningRunInternalSessionId).toHaveBeenCalledWith({
+      runId: 'run-1',
+      internalSessionId: 'internal-session-1',
+    })
+    expect(client.session.promptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionID: 'internal-session-1',
+        parts: [expect.objectContaining({ type: 'text' })],
+      }),
+      { throwOnError: true },
+    )
+    expect(mocks.waitForSessionToComplete).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'internal-session-1',
+      slug: 'alice',
+      usage: { messageRunId: 'message-run-1', source: 'learning', userId: 'user-1' },
+    }))
+    expect(mocks.markRunSucceeded).toHaveBeenCalledWith('message-run-1')
+    expect(mocks.markLearningRunSucceeded).toHaveBeenCalledWith('run-1')
+    expect(mocks.markLearningRunFailed).not.toHaveBeenCalled()
+  })
+
+  it('stores the real failure when the curator session fails', async () => {
+    mocks.waitForSessionToComplete.mockResolvedValue('APIError: Provider returned error 400')
+
+    await expect(executeLearningRun(baseInput)).resolves.toEqual({
+      ok: false,
+      error: 'APIError: Provider returned error 400',
+    })
+
+    expect(mocks.markRunFailed).toHaveBeenCalledWith('message-run-1', 'APIError: Provider returned error 400')
+    expect(mocks.markLearningRunFailed).toHaveBeenCalledWith({
+      runId: 'run-1',
+      error: 'APIError: Provider returned error 400',
+    })
+    expect(mocks.markLearningRunSucceeded).not.toHaveBeenCalled()
+  })
+
+  it('does not execute a run another dispatch already claimed', async () => {
+    mocks.claimLearningRunForExecution.mockResolvedValue(false)
+
+    await expect(executeLearningRun(baseInput)).resolves.toEqual({ ok: false, error: 'run_not_claimable' })
+
+    expect(mocks.ensureWorkspaceRunningForExecution).not.toHaveBeenCalled()
+    expect(mocks.markLearningRunFailed).not.toHaveBeenCalled()
+  })
+
+  it('marks the run failed when the instance is unavailable', async () => {
+    mocks.createInstanceClient.mockResolvedValue(null)
+
+    await expect(executeLearningRun(baseInput)).resolves.toEqual({ ok: false, error: 'instance_unavailable' })
+
+    expect(mocks.markLearningRunFailed).toHaveBeenCalledWith({ runId: 'run-1', error: 'instance_unavailable' })
+  })
+
+  it('marks the run failed when the workspace cannot start', async () => {
+    mocks.ensureWorkspaceRunningForExecution.mockRejectedValue(new Error('instance_start_timeout'))
+
+    await expect(executeLearningRun(baseInput)).resolves.toEqual({ ok: false, error: 'instance_start_timeout' })
+
+    expect(mocks.markLearningRunFailed).toHaveBeenCalledWith({ runId: 'run-1', error: 'instance_start_timeout' })
+  })
+})
+
+describe('buildCuratorPrompt', () => {
+  it('targets the source session when one exists', () => {
+    const prompt = buildCuratorPrompt(baseInput)
+
+    expect(prompt).toContain('sessionIds: ["session-1"]')
+    expect(prompt).toContain('runId: "run-1"')
+    expect(prompt).toContain('trigger: "manual"')
+    expect(prompt).toContain('Never write Knowledge Base files directly')
+  })
+
+  it('reviews recent sessions when there is no source session', () => {
+    const prompt = buildCuratorPrompt({ ...baseInput, sourceSessionId: null })
+
+    expect(prompt).toContain('review the most recent sessions')
+    expect(prompt).not.toContain('sessionIds:')
+  })
+})

--- a/apps/web/src/lib/learning/repository.ts
+++ b/apps/web/src/lib/learning/repository.ts
@@ -159,6 +159,36 @@ export async function setLearningRunMessageCount(args: { runId: string; messageC
   })
 }
 
+export async function setLearningRunInternalSessionId(args: {
+  runId: string
+  internalSessionId: string
+}): Promise<void> {
+  await prisma.knowledgeLearningRun.update({
+    where: { id: args.runId },
+    data: { internalSessionId: args.internalSessionId },
+  })
+}
+
+export async function findLearningRunForUser(args: {
+  runId: string
+  userId: string
+}): Promise<LearningRun | null> {
+  const run = await prisma.knowledgeLearningRun.findFirst({
+    where: { id: args.runId, userId: args.userId },
+  })
+  return run ? mapRun(run) : null
+}
+
+export async function claimLearningRunForExecution(runId: string): Promise<boolean> {
+  // Atomic pending/failed -> running transition so concurrent dispatches
+  // (create + manual retry) cannot execute the same run twice.
+  const result = await prisma.knowledgeLearningRun.updateMany({
+    where: { id: runId, status: { in: ['pending', 'failed'] } },
+    data: { status: 'running', error: null },
+  })
+  return result.count === 1
+}
+
 export async function hasActiveLearningRun(args: {
   userId: string
   sessionId: string

--- a/apps/web/src/lib/learning/run-executor.ts
+++ b/apps/web/src/lib/learning/run-executor.ts
@@ -1,0 +1,148 @@
+import {
+  claimLearningRunForExecution,
+  markLearningRunFailed,
+  setLearningRunInternalSessionId,
+  markLearningRunSucceeded,
+} from '@/lib/learning/repository'
+import { createInstanceClient } from '@/lib/opencode/client'
+import {
+  captureSessionMessageCursor,
+  createSessionPromptRun,
+  ensureWorkspaceRunningForExecution,
+  waitForSessionToComplete,
+} from '@/lib/opencode/session-execution'
+import { messageRunService } from '@/lib/services'
+import type { LearningTrigger } from '@/types/learning'
+
+const LEARNING_SESSION_TITLE_MAX_LENGTH = 160
+
+export type LearningRunExecutionInput = {
+  runId: string
+  slug: string
+  userId: string
+  sourceSessionId: string | null
+  title: string
+  trigger: LearningTrigger
+}
+
+export type LearningRunExecutionResult =
+  | { ok: true }
+  | { ok: false; error: string }
+
+function buildLearningSessionTitle(title: string): string {
+  const base = `Learning | ${title.trim() || 'Session'}`
+  return base.length > LEARNING_SESSION_TITLE_MAX_LENGTH
+    ? `${base.slice(0, LEARNING_SESSION_TITLE_MAX_LENGTH - 1)}…`
+    : base
+}
+
+export function buildCuratorPrompt(input: LearningRunExecutionInput): string {
+  const sourceInstruction = input.sourceSessionId
+    ? `Use the \`session_history_query\` tool to read the source session (sessionIds: ["${input.sourceSessionId}"], includeMessages: true).`
+    : 'Use the `session_history_query` tool to review the most recent sessions (includeMessages: true).'
+
+  return [
+    'You are the Arche knowledge curator. Review workspace activity and capture durable knowledge as Knowledge Base proposals.',
+    '',
+    `Learning run id: ${input.runId}`,
+    `Source session: ${input.sourceSessionId ?? 'none (review recent sessions)'}`,
+    '',
+    'Instructions:',
+    `1. ${sourceInstruction}`,
+    '2. Inspect the existing Knowledge Base files in the workspace (read, glob, grep) so proposals reuse the existing structure and naming, and so you can decide between updating an existing file or creating a new one.',
+    '3. For each durable fact, preference, process, or correction worth keeping, call `learning_propose` with:',
+    `   - runId: "${input.runId}"`,
+    `   - trigger: "${input.trigger}"`,
+    '   - operation "update" (full updated file content) or "create" (full new file content)',
+    '   - kbPath relative to the workspace root',
+    '   - a short title, type, confidence, and evidence quoting the session when possible',
+    '4. Never write Knowledge Base files directly; proposals are reviewed and applied by the user.',
+    '5. Skip transient, task-specific, or sensitive details. If there is nothing durable to learn, create no proposals.',
+    '',
+    'Finish with a one-paragraph summary of the proposals you created (or why none were needed).',
+  ].join('\n')
+}
+
+export async function executeLearningRun(input: LearningRunExecutionInput): Promise<LearningRunExecutionResult> {
+  // Another dispatch (e.g. a concurrent retry) already owns this run.
+  if (!(await claimLearningRunForExecution(input.runId))) {
+    return { ok: false, error: 'run_not_claimable' }
+  }
+
+  try {
+    await ensureWorkspaceRunningForExecution(input.slug, input.userId)
+
+    const client = await createInstanceClient(input.slug)
+    if (!client) {
+      throw new Error('instance_unavailable')
+    }
+
+    const sessionResult = await client.session.create(
+      { title: buildLearningSessionTitle(input.title) },
+      { throwOnError: true },
+    )
+    const sessionId = sessionResult.data?.id
+    if (!sessionId) {
+      throw new Error('learning_session_create_failed')
+    }
+
+    await setLearningRunInternalSessionId({ runId: input.runId, internalSessionId: sessionId })
+
+    const promptRun = await createSessionPromptRun({
+      client,
+      sessionId,
+      slug: input.slug,
+      source: 'learning',
+    })
+    if (!promptRun.ok) {
+      throw new Error('session_busy')
+    }
+
+    let failure: string | null
+    try {
+      const cursor = await captureSessionMessageCursor(client, sessionId)
+      await client.session.promptAsync(
+        {
+          parts: [{ text: buildCuratorPrompt(input), type: 'text' }],
+          sessionID: sessionId,
+        },
+        { throwOnError: true },
+      )
+
+      failure = await waitForSessionToComplete({
+        client,
+        cursor,
+        sessionId,
+        slug: input.slug,
+        usage: { messageRunId: promptRun.run.id, source: 'learning', userId: input.userId },
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'learning_prompt_failed'
+      await messageRunService.markRunFailed(promptRun.run.id, message).catch(() => undefined)
+      throw error
+    }
+
+    if (failure) {
+      await messageRunService.markRunFailed(promptRun.run.id, failure).catch(() => undefined)
+      await markLearningRunFailed({ runId: input.runId, error: failure })
+      return { ok: false, error: failure }
+    }
+
+    await messageRunService.markRunSucceeded(promptRun.run.id).catch(() => undefined)
+    await markLearningRunSucceeded(input.runId)
+    return { ok: true }
+  } catch (error) {
+    const message = error instanceof Error && error.message ? error.message : 'learning_run_failed'
+    await markLearningRunFailed({ runId: input.runId, error: message }).catch(() => undefined)
+    return { ok: false, error: message }
+  }
+}
+
+export function dispatchLearningRunExecution(input: LearningRunExecutionInput): void {
+  void executeLearningRun(input).catch((error) => {
+    console.error('[learning/run-executor] Unexpected learning run failure', {
+      runId: input.runId,
+      error,
+    })
+  })
+}

--- a/apps/web/src/lib/learning/run-lifecycle.ts
+++ b/apps/web/src/lib/learning/run-lifecycle.ts
@@ -16,13 +16,12 @@ const STALE_PENDING_RUN_MS = 6 * 60 * 60 * 1000
 /*
  * Learning run lifecycle owner.
  *
- * `pending` currently means the learning run is queued but curator-agent execution is
- * not wired yet. The internal OpenCode session is created by the execution path (not
- * here), so queued runs do not accumulate orphaned sessions. Pending runs older than
- * STALE_PENDING_RUN_MS no longer count as active, so a stuck run cannot block
- * auto-learning indefinitely. Keep run status mutations in this module so the future
- * execution path has one place to own pending -> running -> succeeded/failed
- * transitions.
+ * Runs are created as `pending`; callers dispatch them to the curator executor
+ * (`@/lib/learning/run-executor`), which claims the run (pending/failed ->
+ * running), creates the internal OpenCode session, and finishes it as
+ * succeeded/failed. Pending runs older than STALE_PENDING_RUN_MS no longer
+ * count as active, so a stuck run cannot block auto-learning indefinitely and
+ * can be retried from the curator panel.
  */
 
 export async function createLearningRun(args: {
@@ -61,10 +60,10 @@ export async function maybeQueueAutoLearningRun(args: {
   sessionId: string
   sessionTitle: string
   messageCount: number
-}): Promise<void> {
-  if (args.messageCount < AUTO_LEARNING_MIN_MESSAGES) return
+}): Promise<LearningRun | null> {
+  if (args.messageCount < AUTO_LEARNING_MIN_MESSAGES) return null
 
-  if (!(await canQueueAutoLearningRun({ userId: args.userId, sessionId: args.sessionId }))) return
+  if (!(await canQueueAutoLearningRun({ userId: args.userId, sessionId: args.sessionId }))) return null
 
   const run = await createLearningRun({
     userId: args.userId,
@@ -73,9 +72,10 @@ export async function maybeQueueAutoLearningRun(args: {
     title: args.sessionTitle,
     trigger: 'auto',
   })
-  if (run.ok) {
-    await setLearningRunMessageCount({ runId: run.run.id, messageCount: args.messageCount })
-  }
+  if (!run.ok) return null
+
+  await setLearningRunMessageCount({ runId: run.run.id, messageCount: args.messageCount })
+  return run.run
 }
 
 export async function canQueueAutoLearningRun(args: { userId: string; sessionId: string }): Promise<boolean> {

--- a/apps/web/src/lib/learning/service.ts
+++ b/apps/web/src/lib/learning/service.ts
@@ -4,10 +4,15 @@ export {
 } from '@/lib/learning/proposal-application'
 export {
   createLearningProposal,
+  findLearningRunForUser,
   learningRunBelongsToUser,
   listLearningProposals,
   listLearningRuns,
 } from '@/lib/learning/repository'
+export {
+  dispatchLearningRunExecution,
+  executeLearningRun,
+} from '@/lib/learning/run-executor'
 export {
   AUTO_LEARNING_MIN_MESSAGES,
   canQueueAutoLearningRun,


### PR DESCRIPTION
> Stacked on #377 (uses its panel redesign and real-error surfacing). Retarget to `main` after #377 merges.

## Summary

Finishes the two unwired learning paths. Until now, the manual **Learn** action and **auto-learning** only created a `knowledge_learning_runs` row that stayed `pending` forever (`run-lifecycle.ts` documented executor wiring as a TODO). Only the agent-triggered path (`learning_propose` from a chat session) actually produced proposals.

### Changes

**Run executor** (`lib/learning/run-executor.ts`)
- Claims the run via an atomic `pending/failed -> running` transition so concurrent dispatches (create + retry) cannot double-execute.
- Ensures the workspace instance is running, creates a hidden `Learning | <title>` session (already excluded from the sessions list by `isLearningSessionTitle`), persists `internalSessionId`.
- Prompts the curator to gather evidence with `session_history_query` (scoped to the source session when there is one) and file proposals with `learning_propose` carrying the `runId`/`trigger`; never writes KB files directly.
- Tracks execution as a message run (`source: learning`) for usage accounting — which also makes the provider-sync deferral from #377 protect learning runs from instance disposes.
- Marks the run `succeeded`/`failed` with the real session error (surfaced by #377).

**Dispatch wiring**
- Manual: the learning API route dispatches right after creating the run.
- Auto: `maybeQueueAutoLearningRun` now returns the created run and the chat stream hook dispatches it (still best-effort, ≥12 messages, 24h cooldown).
- Retry: `POST /api/u/[slug]/learning` with `{ runId }` re-dispatches `pending` runs that lost their executor (created before this change, or across a server restart) and `failed` runs. This unblocks the stuck production run.

**Curator panel**
- Polls every 5s while any run is pending/running.
- "Retry" on failed runs and "Run now" on pending runs older than 2 minutes.

## Test plan
- [x] New executor unit tests: success path, real-error failure path, claim contention, instance unavailable, workspace start failure, prompt content with/without source session
- [x] Learning route tests: dispatch on create, retry semantics (failed → ok, running → 400, unknown → 404)
- [x] Full `apps/web` suite: 4772 passed, 15 skipped
- [x] ESLint clean; `tsc` clean on changed files after `prisma generate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)