### PR TITLE
feat(learning): add ability to cancel learning runs

### DIFF
--- a/apps/web/prisma/migrations/20260612104700_add_cancelled_learning_run_status/migration.sql
+++ b/apps/web/prisma/migrations/20260612104700_add_cancelled_learning_run_status/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "KnowledgeLearningRunStatus" ADD VALUE IF NOT EXISTS 'cancelled';

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -72,6 +72,7 @@ enum KnowledgeLearningRunStatus {
   running
   succeeded
   failed
+  cancelled
 }
 
 enum KnowledgeLearningTrigger {

--- a/apps/web/src/app/api/u/[slug]/learning/runs/[runId]/cancel/__tests__/route.test.ts
+++ b/apps/web/src/app/api/u/[slug]/learning/runs/[runId]/cancel/__tests__/route.test.ts
@@ -2,11 +2,15 @@ import { NextRequest } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  auditCreateEvent: vi.fn(),
   abortActiveRun: vi.fn(),
+  auditEvent: vi.fn(),
   cancelLearningRun: vi.fn(),
   createInstanceClient: vi.fn(),
   findLearningRunForUser: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  auditEvent: mocks.auditEvent,
 }))
 
 vi.mock('@/lib/learning/service', () => ({
@@ -19,9 +23,6 @@ vi.mock('@/lib/opencode/client', () => ({
 }))
 
 vi.mock('@/lib/services', () => ({
-  auditService: {
-    createEvent: mocks.auditCreateEvent,
-  },
   messageRunService: {
     abortActiveRun: mocks.abortActiveRun,
   },
@@ -72,7 +73,7 @@ describe('/api/u/[slug]/learning/runs/[runId]/cancel', () => {
     vi.clearAllMocks()
     mocks.findLearningRunForUser.mockResolvedValue(runningRun)
     mocks.cancelLearningRun.mockResolvedValue({ ...runningRun, status: 'cancelled' })
-    mocks.auditCreateEvent.mockResolvedValue(undefined)
+    mocks.auditEvent.mockResolvedValue(undefined)
     mocks.abortActiveRun.mockResolvedValue(undefined)
     mocks.createInstanceClient.mockResolvedValue({
       session: {
@@ -92,7 +93,7 @@ describe('/api/u/[slug]/learning/runs/[runId]/cancel', () => {
     const client = await mocks.createInstanceClient.mock.results[0].value
     expect(client.session.abort).toHaveBeenCalledWith({ sessionID: 'internal-session-1' })
     expect(mocks.abortActiveRun).toHaveBeenCalledWith('alice', 'internal-session-1')
-    expect(mocks.auditCreateEvent).toHaveBeenCalledWith({
+    expect(mocks.auditEvent).toHaveBeenCalledWith({
       actorUserId: 'user-1',
       action: 'learning.run_cancelled',
       metadata: {

--- a/apps/web/src/app/api/u/[slug]/learning/runs/[runId]/cancel/__tests__/route.test.ts
+++ b/apps/web/src/app/api/u/[slug]/learning/runs/[runId]/cancel/__tests__/route.test.ts
@@ -104,6 +104,53 @@ describe('/api/u/[slug]/learning/runs/[runId]/cancel', () => {
     })
   })
 
+  it('uses the persisted internal session id when cancellation wins a creation race', async () => {
+    mocks.findLearningRunForUser.mockResolvedValue({ ...runningRun, internalSessionId: null })
+    mocks.cancelLearningRun.mockResolvedValue({ ...runningRun, internalSessionId: 'late-session', status: 'cancelled' })
+
+    const response = await POST(makeRequest(), routeContext())
+
+    expect(response.status).toBe(200)
+    const client = await mocks.createInstanceClient.mock.results[0].value
+    expect(client.session.abort).toHaveBeenCalledWith({ sessionID: 'late-session' })
+    expect(mocks.abortActiveRun).toHaveBeenCalledWith('alice', 'late-session')
+  })
+
+  it('keeps cancellation successful when runtime aborts fail', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const client = {
+      session: {
+        abort: vi.fn().mockRejectedValue(new Error('abort failed')),
+      },
+    }
+    mocks.createInstanceClient.mockResolvedValue(client)
+    mocks.abortActiveRun.mockRejectedValue(new Error('message abort failed'))
+
+    try {
+      const response = await POST(makeRequest(), routeContext())
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({ run: { ...runningRun, status: 'cancelled' } })
+      expect(client.session.abort).toHaveBeenCalledWith({ sessionID: 'internal-session-1' })
+      expect(mocks.abortActiveRun).toHaveBeenCalledWith('alice', 'internal-session-1')
+      expect(mocks.auditEvent).toHaveBeenCalledWith(expect.objectContaining({ action: 'learning.run_cancelled' }))
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('returns not cancelable when the guarded cancel update loses a race', async () => {
+    mocks.cancelLearningRun.mockResolvedValue(null)
+
+    const response = await POST(makeRequest(), routeContext())
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'run_not_cancelable' })
+    expect(mocks.createInstanceClient).not.toHaveBeenCalled()
+    expect(mocks.abortActiveRun).not.toHaveBeenCalled()
+    expect(mocks.auditEvent).not.toHaveBeenCalled()
+  })
+
   it('returns not found for runs outside the user', async () => {
     mocks.findLearningRunForUser.mockResolvedValue(null)
 

--- a/apps/web/src/app/api/u/[slug]/learning/runs/[runId]/cancel/__tests__/route.test.ts
+++ b/apps/web/src/app/api/u/[slug]/learning/runs/[runId]/cancel/__tests__/route.test.ts
@@ -1,0 +1,125 @@
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  auditCreateEvent: vi.fn(),
+  abortActiveRun: vi.fn(),
+  cancelLearningRun: vi.fn(),
+  createInstanceClient: vi.fn(),
+  findLearningRunForUser: vi.fn(),
+}))
+
+vi.mock('@/lib/learning/service', () => ({
+  cancelLearningRun: mocks.cancelLearningRun,
+  findLearningRunForUser: mocks.findLearningRunForUser,
+}))
+
+vi.mock('@/lib/opencode/client', () => ({
+  createInstanceClient: mocks.createInstanceClient,
+}))
+
+vi.mock('@/lib/services', () => ({
+  auditService: {
+    createEvent: mocks.auditCreateEvent,
+  },
+  messageRunService: {
+    abortActiveRun: mocks.abortActiveRun,
+  },
+}))
+
+vi.mock('@/lib/runtime/with-auth', () => ({
+  withAuth: (
+    _options: unknown,
+    handler: (
+      request: NextRequest,
+      context: { slug: string; params: { slug: string; runId: string }; user: { id: string } }
+    ) => Promise<Response>
+  ) => {
+    return async (request: NextRequest, { params }: { params: Promise<{ slug: string; runId: string }> }) => {
+      const resolvedParams = await params
+      return handler(request, { slug: resolvedParams.slug, params: resolvedParams, user: { id: 'user-1' } })
+    }
+  },
+}))
+
+import { POST } from '../route'
+
+const runningRun = {
+  id: 'run-1',
+  sourceSessionId: 'session-1',
+  internalSessionId: 'internal-session-1',
+  title: 'Session',
+  trigger: 'manual',
+  status: 'running',
+  error: null,
+  messageCount: 10,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+function makeRequest(): NextRequest {
+  return new NextRequest('http://localhost/api/u/alice/learning/runs/run-1/cancel', {
+    method: 'POST',
+  })
+}
+
+function routeContext(runId = 'run-1') {
+  return { params: Promise.resolve({ slug: 'alice', runId }) }
+}
+
+describe('/api/u/[slug]/learning/runs/[runId]/cancel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.findLearningRunForUser.mockResolvedValue(runningRun)
+    mocks.cancelLearningRun.mockResolvedValue({ ...runningRun, status: 'cancelled' })
+    mocks.auditCreateEvent.mockResolvedValue(undefined)
+    mocks.abortActiveRun.mockResolvedValue(undefined)
+    mocks.createInstanceClient.mockResolvedValue({
+      session: {
+        abort: vi.fn().mockResolvedValue({ data: {} }),
+      },
+    })
+  })
+
+  it('cancels an active run and aborts its internal session best-effort', async () => {
+    const response = await POST(makeRequest(), routeContext())
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ run: { ...runningRun, status: 'cancelled' } })
+    expect(mocks.findLearningRunForUser).toHaveBeenCalledWith({ runId: 'run-1', userId: 'user-1' })
+    expect(mocks.cancelLearningRun).toHaveBeenCalledWith({ runId: 'run-1', userId: 'user-1' })
+    expect(mocks.createInstanceClient).toHaveBeenCalledWith('alice')
+    const client = await mocks.createInstanceClient.mock.results[0].value
+    expect(client.session.abort).toHaveBeenCalledWith({ sessionID: 'internal-session-1' })
+    expect(mocks.abortActiveRun).toHaveBeenCalledWith('alice', 'internal-session-1')
+    expect(mocks.auditCreateEvent).toHaveBeenCalledWith({
+      actorUserId: 'user-1',
+      action: 'learning.run_cancelled',
+      metadata: {
+        internalSessionId: 'internal-session-1',
+        runId: 'run-1',
+        sourceSessionId: 'session-1',
+      },
+    })
+  })
+
+  it('returns not found for runs outside the user', async () => {
+    mocks.findLearningRunForUser.mockResolvedValue(null)
+
+    const response = await POST(makeRequest(), routeContext('run-missing'))
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({ error: 'not_found' })
+    expect(mocks.cancelLearningRun).not.toHaveBeenCalled()
+  })
+
+  it('rejects cancelling completed runs', async () => {
+    mocks.findLearningRunForUser.mockResolvedValue({ ...runningRun, status: 'succeeded' })
+
+    const response = await POST(makeRequest(), routeContext())
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'run_not_cancelable' })
+    expect(mocks.cancelLearningRun).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/app/api/u/[slug]/learning/runs/[runId]/cancel/route.ts
+++ b/apps/web/src/app/api/u/[slug]/learning/runs/[runId]/cancel/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server'
 
+import { auditEvent } from '@/lib/auth'
 import { cancelLearningRun, findLearningRunForUser } from '@/lib/learning/service'
 import { createInstanceClient } from '@/lib/opencode/client'
 import { withAuth } from '@/lib/runtime/with-auth'
-import { auditService, messageRunService } from '@/lib/services'
+import { messageRunService } from '@/lib/services'
 import type { LearningRun } from '@/types/learning'
 
 type CancelRunParams = {
@@ -49,7 +50,7 @@ export const POST = withAuth<{ run: LearningRun } | { error: string }, CancelRun
       await abortInternalSessionBestEffort(context.slug, run.id, run.internalSessionId)
     }
 
-    await auditService.createEvent({
+    await auditEvent({
       actorUserId: context.user.id,
       action: 'learning.run_cancelled',
       metadata: {

--- a/apps/web/src/app/api/u/[slug]/learning/runs/[runId]/cancel/route.ts
+++ b/apps/web/src/app/api/u/[slug]/learning/runs/[runId]/cancel/route.ts
@@ -12,20 +12,24 @@ type CancelRunParams = {
   runId: string
 }
 
+function cancellationLogError(error: unknown): string {
+  return error instanceof Error && error.name ? error.name : 'unknown_error'
+}
+
 async function abortInternalSessionBestEffort(slug: string, runId: string, sessionId: string): Promise<void> {
   const client = await createInstanceClient(slug).catch((error) => {
-    console.warn('[learning/cancel] Failed to create OpenCode client', { error, runId, sessionId })
+    console.warn('[learning/cancel] Failed to create OpenCode client', { error: cancellationLogError(error), runId })
     return null
   })
 
   if (client) {
     await Promise.resolve(client.session.abort({ sessionID: sessionId })).catch((error) => {
-      console.warn('[learning/cancel] Failed to abort OpenCode session', { error, runId, sessionId })
+      console.warn('[learning/cancel] Failed to abort OpenCode session', { error: cancellationLogError(error), runId })
     })
   }
 
   await messageRunService.abortActiveRun(slug, sessionId).catch((error) => {
-    console.warn('[learning/cancel] Failed to abort active message run', { error, runId, sessionId })
+    console.warn('[learning/cancel] Failed to abort active message run', { error: cancellationLogError(error), runId })
   })
 }
 
@@ -46,15 +50,17 @@ export const POST = withAuth<{ run: LearningRun } | { error: string }, CancelRun
       return NextResponse.json({ error: 'run_not_cancelable' }, { status: 400 })
     }
 
-    if (run.internalSessionId) {
-      await abortInternalSessionBestEffort(context.slug, run.id, run.internalSessionId)
+    const internalSessionId = cancelledRun.internalSessionId ?? run.internalSessionId
+
+    if (internalSessionId) {
+      await abortInternalSessionBestEffort(context.slug, run.id, internalSessionId)
     }
 
     await auditEvent({
       actorUserId: context.user.id,
       action: 'learning.run_cancelled',
       metadata: {
-        internalSessionId: run.internalSessionId,
+        internalSessionId,
         runId: run.id,
         sourceSessionId: run.sourceSessionId,
       },

--- a/apps/web/src/app/api/u/[slug]/learning/runs/[runId]/cancel/route.ts
+++ b/apps/web/src/app/api/u/[slug]/learning/runs/[runId]/cancel/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server'
+
+import { cancelLearningRun, findLearningRunForUser } from '@/lib/learning/service'
+import { createInstanceClient } from '@/lib/opencode/client'
+import { withAuth } from '@/lib/runtime/with-auth'
+import { auditService, messageRunService } from '@/lib/services'
+import type { LearningRun } from '@/types/learning'
+
+type CancelRunParams = {
+  slug: string
+  runId: string
+}
+
+async function abortInternalSessionBestEffort(slug: string, runId: string, sessionId: string): Promise<void> {
+  const client = await createInstanceClient(slug).catch((error) => {
+    console.warn('[learning/cancel] Failed to create OpenCode client', { error, runId, sessionId })
+    return null
+  })
+
+  if (client) {
+    await Promise.resolve(client.session.abort({ sessionID: sessionId })).catch((error) => {
+      console.warn('[learning/cancel] Failed to abort OpenCode session', { error, runId, sessionId })
+    })
+  }
+
+  await messageRunService.abortActiveRun(slug, sessionId).catch((error) => {
+    console.warn('[learning/cancel] Failed to abort active message run', { error, runId, sessionId })
+  })
+}
+
+export const POST = withAuth<{ run: LearningRun } | { error: string }, CancelRunParams>(
+  { csrf: true },
+  async (_request, context) => {
+    const run = await findLearningRunForUser({ runId: context.params.runId, userId: context.user.id })
+    if (!run) {
+      return NextResponse.json({ error: 'not_found' }, { status: 404 })
+    }
+
+    if (run.status !== 'pending' && run.status !== 'running') {
+      return NextResponse.json({ error: 'run_not_cancelable' }, { status: 400 })
+    }
+
+    const cancelledRun = await cancelLearningRun({ runId: run.id, userId: context.user.id })
+    if (!cancelledRun) {
+      return NextResponse.json({ error: 'run_not_cancelable' }, { status: 400 })
+    }
+
+    if (run.internalSessionId) {
+      await abortInternalSessionBestEffort(context.slug, run.id, run.internalSessionId)
+    }
+
+    await auditService.createEvent({
+      actorUserId: context.user.id,
+      action: 'learning.run_cancelled',
+      metadata: {
+        internalSessionId: run.internalSessionId,
+        runId: run.id,
+        sourceSessionId: run.sourceSessionId,
+      },
+    })
+
+    return NextResponse.json({ run: cancelledRun })
+  }
+)

--- a/apps/web/src/components/workspace/__tests__/knowledge-curator-panel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/knowledge-curator-panel.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { KnowledgeCuratorPanel } from '@/components/workspace/knowledge-curator-panel'
@@ -58,6 +58,7 @@ describe('KnowledgeCuratorPanel', () => {
 
   afterEach(() => {
     cleanup()
+    vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
@@ -142,6 +143,52 @@ describe('KnowledgeCuratorPanel', () => {
     expect(await screen.findByText('99+')).toBeTruthy()
   })
 
+  it('refreshes the pending proposal badge while collapsed', async () => {
+    vi.useFakeTimers()
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ runs: [], proposals: [] }))
+      .mockResolvedValueOnce(jsonResponse(learningResponse))
+
+    render(<KnowledgeCuratorPanel slug="alice" collapsed />)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText('1')).toBeNull()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(45_000)
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(screen.getByText('1')).toBeTruthy()
+  })
+
+  it('keeps active learning runs polling while collapsed', async () => {
+    vi.useFakeTimers()
+    fetchMock.mockResolvedValue(jsonResponse({ runs: [runningRun], proposals: [] }))
+
+    render(<KnowledgeCuratorPanel slug="alice" collapsed />)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_999)
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
   it('opens a learning run internal session', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ runs: [runningRun], proposals: [] }))
     const onOpenSession = vi.fn()
@@ -171,6 +218,20 @@ describe('KnowledgeCuratorPanel', () => {
       })
     })
     expect(await screen.findByText('Cancelled')).toBeTruthy()
+  })
+
+  it('shows a readable error when cancelling a run is rejected', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ runs: [runningRun], proposals: [] }))
+      .mockResolvedValueOnce(jsonResponse({ error: 'run_not_cancelable' }, { status: 400 }))
+      .mockResolvedValueOnce(jsonResponse({ runs: [runningRun], proposals: [] }))
+
+    render(<KnowledgeCuratorPanel slug="alice" />)
+
+    expect(await screen.findByText('Learning from session')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(await screen.findByText('This run cannot be cancelled.')).toBeTruthy()
   })
 
   it('uses the simplified header with the standard collapse button', async () => {

--- a/apps/web/src/components/workspace/__tests__/knowledge-curator-panel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/knowledge-curator-panel.test.tsx
@@ -37,6 +37,19 @@ const learningResponse = {
   ],
 }
 
+const runningRun = {
+  id: 'run-1',
+  sourceSessionId: 'session-1',
+  internalSessionId: 'internal-session-1',
+  title: 'Learning from session',
+  trigger: 'manual',
+  status: 'running',
+  error: null,
+  messageCount: 10,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
 describe('KnowledgeCuratorPanel', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', fetchMock)
@@ -110,7 +123,63 @@ describe('KnowledgeCuratorPanel', () => {
     render(<KnowledgeCuratorPanel slug="alice" collapsed onToggleCollapse={onToggleCollapse} />)
 
     expect(screen.queryByText('Knowledge Curator')).toBeNull()
+    expect(await screen.findByText('1')).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Expand curator panel' }))
     expect(onToggleCollapse).toHaveBeenCalledTimes(1)
+  })
+
+  it('caps the collapsed pending proposal badge at 99+', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({
+      runs: [],
+      proposals: Array.from({ length: 100 }, (_, index) => ({
+        ...learningResponse.proposals[0],
+        id: `proposal-${index}`,
+      })),
+    }))
+
+    render(<KnowledgeCuratorPanel slug="alice" collapsed />)
+
+    expect(await screen.findByText('99+')).toBeTruthy()
+  })
+
+  it('opens a learning run internal session', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ runs: [runningRun], proposals: [] }))
+    const onOpenSession = vi.fn()
+
+    render(<KnowledgeCuratorPanel slug="alice" onOpenSession={onOpenSession} />)
+
+    expect(await screen.findByText('Learning from session')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Open session' }))
+
+    expect(onOpenSession).toHaveBeenCalledWith('internal-session-1')
+  })
+
+  it('cancels an active learning run and refreshes the list', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ runs: [runningRun], proposals: [] }))
+      .mockResolvedValueOnce(jsonResponse({ run: { ...runningRun, status: 'cancelled' } }))
+      .mockResolvedValueOnce(jsonResponse({ runs: [{ ...runningRun, status: 'cancelled' }], proposals: [] }))
+
+    render(<KnowledgeCuratorPanel slug="alice" />)
+
+    expect(await screen.findByText('Learning from session')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/u/alice/learning/runs/run-1/cancel', {
+        method: 'POST',
+      })
+    })
+    expect(await screen.findByText('Cancelled')).toBeTruthy()
+  })
+
+  it('uses the simplified header with the standard collapse button', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(learningResponse))
+
+    render(<KnowledgeCuratorPanel slug="alice" onToggleCollapse={vi.fn()} />)
+
+    expect(await screen.findByText('Knowledge Curator')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Collapse panel' })).toBeTruthy()
+    expect(screen.queryByText('Review learning runs and pending KB proposals.')).toBeNull()
   })
 })

--- a/apps/web/src/components/workspace/__tests__/workspace-shell.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/workspace-shell.test.tsx
@@ -27,9 +27,11 @@ const readFileMock = vi.fn();
 const refreshDiffsMock = vi.fn();
 const refreshFilesMock = vi.fn();
 const refreshMessagesMock = vi.fn();
+const selectSessionMock = vi.fn();
 const sendMessageMock = vi.fn().mockResolvedValue(true);
 const writeFileMock = vi.fn();
 let workspaceMockOverrides: Record<string, unknown> = {};
+let learningApiResponse: unknown = { runs: [], proposals: [] };
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -89,7 +91,7 @@ vi.mock("@/hooks/use-workspace", () => ({
     deleteSession: vi.fn(),
     markFlowRunSeen: vi.fn(),
     renameSession: vi.fn(),
-    selectSession: vi.fn(),
+    selectSession: selectSessionMock,
     agentCatalog: [
       { id: "assistant", displayName: "Assistant", isPrimary: true },
       { id: "ads-scripts", displayName: "Ads Scripts", isPrimary: false },
@@ -305,7 +307,9 @@ describe("WorkspaceShell", () => {
     refreshMessagesMock.mockResolvedValue(undefined);
     sendMessageMock.mockClear();
     sendMessageMock.mockResolvedValue(true);
+    selectSessionMock.mockClear();
     workspaceMockOverrides = {};
+    learningApiResponse = { runs: [], proposals: [] };
     writeFileMock.mockReset();
     writeFileMock.mockResolvedValue({ ok: true, hash: "hash-updated" });
     desktopBridgeMocks.listRecentVaults.mockReset();
@@ -369,7 +373,7 @@ describe("WorkspaceShell", () => {
       }
 
       if (url.endsWith("/learning")) {
-        return jsonResponse({ runs: [], proposals: [] });
+        return jsonResponse(learningApiResponse);
       }
 
       return jsonResponse({ ok: true });
@@ -1225,6 +1229,34 @@ describe("WorkspaceShell", () => {
 
     expect(await screen.findByText("Knowledge Curator")).toBeTruthy();
     expect(await screen.findByText("No pending proposals.")).toBeTruthy();
+  });
+
+  it("opens a curator learning run in the workspace session", async () => {
+    learningApiResponse = {
+      runs: [
+        {
+          id: "run-1",
+          sourceSessionId: "root-session",
+          internalSessionId: "internal-session-1",
+          title: "Learning from session",
+          trigger: "manual",
+          status: "running",
+          error: null,
+          messageCount: 10,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      proposals: [],
+    };
+
+    render(<WorkspaceShell slug="alice" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Expand curator panel" }));
+    expect(await screen.findByText("Learning from session")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Open session" }));
+
+    expect(selectSessionMock).toHaveBeenCalledWith("internal-session-1");
   });
 
   it("shows chat as default view in compact layout", async () => {

--- a/apps/web/src/components/workspace/knowledge-curator-panel.tsx
+++ b/apps/web/src/components/workspace/knowledge-curator-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+
 import { ArrowLineRight } from "@phosphor-icons/react";
 
 import { Button } from "@/components/ui/button";
@@ -311,7 +312,7 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
                   <RunStatusBadge status={run.status} />
                 </div>
                 <div className="flex items-center justify-between gap-2">
-                  <p className="text-muted-foreground">{run.trigger}</p>
+                  <p className="min-w-0 truncate text-muted-foreground">{run.trigger}</p>
                   <div className="flex shrink-0 items-center gap-1.5">
                     {internalSessionId && onOpenSession ? (
                       <Button

--- a/apps/web/src/components/workspace/knowledge-curator-panel.tsx
+++ b/apps/web/src/components/workspace/knowledge-curator-panel.tsx
@@ -162,7 +162,9 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
         });
         const json = (await response.json().catch(() => null)) as { error?: string } | null;
         if (!response.ok) {
+          await refresh();
           setError(json?.error ?? "cancel_failed");
+          return;
         } else {
           setError(null);
         }

--- a/apps/web/src/components/workspace/knowledge-curator-panel.tsx
+++ b/apps/web/src/components/workspace/knowledge-curator-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { ArrowLineRight } from "@phosphor-icons/react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -10,6 +11,7 @@ type KnowledgeCuratorPanelProps = {
   slug: string;
   collapsed?: boolean;
   onToggleCollapse?: () => void;
+  onOpenSession?: (sessionId: string) => void;
   refreshKey?: number;
 }
 
@@ -27,11 +29,15 @@ const ERROR_LABELS: Record<string, string> = {
   invalid_request: "The request was invalid.",
   learning_load_failed: "Could not load learning data.",
   learning_action_failed: "The action failed. Try again.",
+  learning_run_cancelled: "The learning run was cancelled.",
+  run_not_cancelable: "This run cannot be cancelled.",
   run_not_retryable: "This run is already executing.",
+  cancel_failed: "Could not cancel the learning run. Try again.",
   instance_unavailable: "The workspace instance is unavailable. Try again later.",
 };
 
 const ACTIVE_RUN_POLL_INTERVAL_MS = 5_000;
+const COLLAPSED_IDLE_POLL_INTERVAL_MS = 45_000;
 // Dispatch happens right after a run is created, so a run still pending after
 // this window lost its executor (e.g. a server restart) and can be retried.
 const STALE_PENDING_RUN_MS = 2 * 60 * 1000;
@@ -45,6 +51,7 @@ const RUN_STATUS_LABELS: Record<LearningRunStatus, string> = {
   running: "Running",
   succeeded: "Succeeded",
   failed: "Failed",
+  cancelled: "Cancelled",
 };
 
 const RUN_STATUS_CLASSES: Record<LearningRunStatus, string> = {
@@ -52,6 +59,7 @@ const RUN_STATUS_CLASSES: Record<LearningRunStatus, string> = {
   running: "bg-primary/15 text-primary",
   succeeded: "bg-emerald-500/15 text-emerald-500",
   failed: "bg-destructive/15 text-destructive",
+  cancelled: "bg-muted/60 text-muted-foreground",
 };
 
 function RunStatusBadge({ status }: { status: LearningRunStatus }) {
@@ -67,7 +75,7 @@ function RunStatusBadge({ status }: { status: LearningRunStatus }) {
   );
 }
 
-export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollapse, refreshKey = 0 }: KnowledgeCuratorPanelProps) {
+export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollapse, onOpenSession, refreshKey = 0 }: KnowledgeCuratorPanelProps) {
   const [data, setData] = useState<LearningResponse>({ proposals: [], runs: [] });
   const [edits, setEdits] = useState<Record<string, string>>({});
   const [error, setError] = useState<string | null>(null);
@@ -101,13 +109,20 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
   }, [refresh, refreshKey]);
 
   const hasActiveRun = data.runs.some((run) => run.status === "pending" || run.status === "running");
+  const pendingProposalCount = data.proposals.filter((proposal) => proposal.status === "pending").length;
+  const pendingProposalBadge = pendingProposalCount > 99 ? "99+" : String(pendingProposalCount);
 
   useEffect(() => {
-    if (collapsed || !hasActiveRun) return;
+    const pollIntervalMs = hasActiveRun
+      ? ACTIVE_RUN_POLL_INTERVAL_MS
+      : collapsed
+        ? COLLAPSED_IDLE_POLL_INTERVAL_MS
+        : null;
+    if (!pollIntervalMs) return;
 
     const interval = window.setInterval(() => {
       void refresh();
-    }, ACTIVE_RUN_POLL_INTERVAL_MS);
+    }, pollIntervalMs);
 
     return () => window.clearInterval(interval);
   }, [collapsed, hasActiveRun, refresh]);
@@ -130,6 +145,29 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
         await refresh();
       } catch {
         setError("learning_action_failed");
+      } finally {
+        setBusyRunId(null);
+      }
+    },
+    [refresh, slug]
+  );
+
+  const cancelRun = useCallback(
+    async (runId: string) => {
+      setBusyRunId(runId);
+      try {
+        const response = await fetch(`/api/u/${slug}/learning/runs/${runId}/cancel`, {
+          method: "POST",
+        });
+        const json = (await response.json().catch(() => null)) as { error?: string } | null;
+        if (!response.ok) {
+          setError(json?.error ?? "cancel_failed");
+        } else {
+          setError(null);
+        }
+        await refresh();
+      } catch {
+        setError("cancel_failed");
       } finally {
         setBusyRunId(null);
       }
@@ -177,6 +215,13 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
         aria-label="Expand curator panel"
         className="group flex h-full w-full cursor-pointer flex-col items-center gap-3 py-4 text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"
       >
+        {pendingProposalCount > 0 ? (
+          <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-[10px] font-semibold leading-none text-primary-foreground">
+            {pendingProposalBadge}
+          </span>
+        ) : (
+          <span className="h-5" aria-hidden />
+        )}
         <span
           className="text-[11px] font-medium uppercase tracking-[0.22em] text-muted-foreground/80 transition-colors group-hover:text-foreground"
           style={{ writingMode: "vertical-rl" }}
@@ -189,21 +234,23 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
 
   return (
     <aside className="flex h-full min-h-0 flex-col text-card-foreground">
-      <div className="flex items-start justify-between border-b border-border/30 px-4 py-3">
-        <div>
-          <h2 className="text-sm font-semibold">Knowledge Curator</h2>
-          <p className="text-xs text-muted-foreground">Review learning runs and pending KB proposals.</p>
-        </div>
+      <div className="flex shrink-0 items-center gap-2 pl-2 pr-3 py-2">
         {onToggleCollapse ? (
           <button
             type="button"
             onClick={onToggleCollapse}
-            aria-label="Collapse curator panel"
-            className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"
+            aria-label="Collapse panel"
+            title="Collapse panel"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground/80 transition-colors hover:bg-foreground/5 hover:text-foreground"
           >
-            <span aria-hidden>»</span>
+            <ArrowLineRight size={13} weight="bold" />
           </button>
         ) : null}
+        <div className="flex h-8 min-w-0 flex-1 items-center">
+          <h2 className="truncate text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Knowledge Curator
+          </h2>
+        </div>
       </div>
       <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
         {error ? <p className="text-xs text-destructive">{errorLabel(error)}</p> : null}
@@ -245,7 +292,7 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
               </div>
             </article>
           ))}
-          {data.proposals.every((proposal) => proposal.status !== "pending") ? (
+          {pendingProposalCount === 0 ? (
             <p className="text-xs text-muted-foreground">No pending proposals.</p>
           ) : null}
         </section>
@@ -255,6 +302,8 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
             const isStalePending =
               run.status === "pending" && refreshedAt - Date.parse(run.createdAt) > STALE_PENDING_RUN_MS;
             const isRetryable = run.status === "failed" || isStalePending;
+            const isCancelable = run.status === "pending" || run.status === "running";
+            const internalSessionId = run.internalSessionId;
             return (
               <div key={run.id} className="space-y-1 rounded-md border border-border/60 p-2 text-xs">
                 <div className="flex items-center justify-between gap-2">
@@ -263,17 +312,40 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
                 </div>
                 <div className="flex items-center justify-between gap-2">
                   <p className="text-muted-foreground">{run.trigger}</p>
-                  {isRetryable ? (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="h-6 px-2 text-[11px]"
-                      disabled={busyRunId !== null}
-                      onClick={() => void retryRun(run.id)}
-                    >
-                      {run.status === "failed" ? "Retry" : "Run now"}
-                    </Button>
-                  ) : null}
+                  <div className="flex shrink-0 items-center gap-1.5">
+                    {internalSessionId && onOpenSession ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-6 px-2 text-[11px]"
+                        onClick={() => onOpenSession(internalSessionId)}
+                      >
+                        Open session
+                      </Button>
+                    ) : null}
+                    {isCancelable ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-6 px-2 text-[11px]"
+                        disabled={busyRunId !== null}
+                        onClick={() => void cancelRun(run.id)}
+                      >
+                        Cancel
+                      </Button>
+                    ) : null}
+                    {isRetryable ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-6 px-2 text-[11px]"
+                        disabled={busyRunId !== null}
+                        onClick={() => void retryRun(run.id)}
+                      >
+                        {run.status === "failed" ? "Retry" : "Run now"}
+                      </Button>
+                    ) : null}
+                  </div>
                 </div>
                 {run.status === "failed" && run.error ? (
                   <p className="text-destructive">{errorLabel(run.error)}</p>

--- a/apps/web/src/components/workspace/workspace-shell.tsx
+++ b/apps/web/src/components/workspace/workspace-shell.tsx
@@ -1894,6 +1894,7 @@ export function WorkspaceShell({
             slug={slug}
             collapsed={isCompactLayout ? false : rightCollapsed}
             onToggleCollapse={isCompactLayout ? handleShowChat : handleToggleRight}
+            onOpenSession={handleSelectSession}
             refreshKey={learningRefreshKey}
           />
         );

--- a/apps/web/src/lib/learning/__tests__/repository.test.ts
+++ b/apps/web/src/lib/learning/__tests__/repository.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
       findFirst: vi.fn(),
       findMany: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
     },
   },
 }))
@@ -151,6 +152,37 @@ describe('learning repository', () => {
     expect(mocks.prisma.knowledgeLearningRun.findFirst).toHaveBeenCalledWith({
       where: { id: 'run-other', userId: 'user-1' },
       select: { id: true },
+    })
+  })
+
+  it('cancels only active learning runs for the owning user', async () => {
+    const { cancelLearningRun } = await import('@/lib/learning/repository')
+    mocks.prisma.knowledgeLearningRun.updateMany.mockResolvedValue({ count: 1 })
+    mocks.prisma.knowledgeLearningRun.findFirst.mockResolvedValue({ ...runRecord, status: 'cancelled' })
+
+    await expect(cancelLearningRun({ runId: 'run-1', userId: 'user-1' })).resolves.toEqual(
+      expect.objectContaining({ id: 'run-1', status: 'cancelled' }),
+    )
+
+    expect(mocks.prisma.knowledgeLearningRun.updateMany).toHaveBeenCalledWith({
+      where: { id: 'run-1', userId: 'user-1', status: { in: ['pending', 'running'] } },
+      data: { error: null, finishedAt: expect.any(Date), status: 'cancelled' },
+    })
+  })
+
+  it('guards terminal learning run transitions from overwriting cancellations', async () => {
+    const { markLearningRunFailed, markLearningRunSucceeded } = await import('@/lib/learning/repository')
+
+    await markLearningRunSucceeded('run-1')
+    await markLearningRunFailed({ runId: 'run-1', error: 'provider_failed' })
+
+    expect(mocks.prisma.knowledgeLearningRun.updateMany).toHaveBeenCalledWith({
+      where: { id: 'run-1', status: 'running' },
+      data: { finishedAt: expect.any(Date), status: 'succeeded' },
+    })
+    expect(mocks.prisma.knowledgeLearningRun.updateMany).toHaveBeenCalledWith({
+      where: { id: 'run-1', status: 'running' },
+      data: { error: 'provider_failed', finishedAt: expect.any(Date), status: 'failed' },
     })
   })
 })

--- a/apps/web/src/lib/learning/__tests__/repository.test.ts
+++ b/apps/web/src/lib/learning/__tests__/repository.test.ts
@@ -170,6 +170,15 @@ describe('learning repository', () => {
     })
   })
 
+  it('returns null when no active learning run is cancelled', async () => {
+    const { cancelLearningRun } = await import('@/lib/learning/repository')
+    mocks.prisma.knowledgeLearningRun.updateMany.mockResolvedValue({ count: 0 })
+
+    await expect(cancelLearningRun({ runId: 'run-1', userId: 'user-1' })).resolves.toBeNull()
+
+    expect(mocks.prisma.knowledgeLearningRun.findFirst).not.toHaveBeenCalled()
+  })
+
   it('guards terminal learning run transitions from overwriting cancellations', async () => {
     const { markLearningRunFailed, markLearningRunSucceeded } = await import('@/lib/learning/repository')
 

--- a/apps/web/src/lib/learning/__tests__/run-executor.test.ts
+++ b/apps/web/src/lib/learning/__tests__/run-executor.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   claimLearningRunForExecution: vi.fn(),
+  findLearningRunForUser: vi.fn(),
   markLearningRunFailed: vi.fn(),
   markLearningRunSucceeded: vi.fn(),
   setLearningRunInternalSessionId: vi.fn(),
@@ -11,11 +12,13 @@ const mocks = vi.hoisted(() => ({
   captureSessionMessageCursor: vi.fn(),
   waitForSessionToComplete: vi.fn(),
   markRunFailed: vi.fn(),
+  markRunAborted: vi.fn(),
   markRunSucceeded: vi.fn(),
 }))
 
 vi.mock('@/lib/learning/repository', () => ({
   claimLearningRunForExecution: mocks.claimLearningRunForExecution,
+  findLearningRunForUser: mocks.findLearningRunForUser,
   markLearningRunFailed: mocks.markLearningRunFailed,
   markLearningRunSucceeded: mocks.markLearningRunSucceeded,
   setLearningRunInternalSessionId: mocks.setLearningRunInternalSessionId,
@@ -34,6 +37,7 @@ vi.mock('@/lib/opencode/session-execution', () => ({
 
 vi.mock('@/lib/services', () => ({
   messageRunService: {
+    markRunAborted: mocks.markRunAborted,
     markRunFailed: mocks.markRunFailed,
     markRunSucceeded: mocks.markRunSucceeded,
   },
@@ -53,6 +57,7 @@ const baseInput = {
 function makeClient() {
   return {
     session: {
+      abort: vi.fn().mockResolvedValue({ data: {} }),
       create: vi.fn().mockResolvedValue({ data: { id: 'internal-session-1' } }),
       promptAsync: vi.fn().mockResolvedValue({ data: {} }),
     },
@@ -66,6 +71,8 @@ describe('executeLearningRun', () => {
     mocks.markLearningRunFailed.mockResolvedValue(undefined)
     mocks.markLearningRunSucceeded.mockResolvedValue(undefined)
     mocks.setLearningRunInternalSessionId.mockResolvedValue(undefined)
+    mocks.findLearningRunForUser.mockResolvedValue(null)
+    mocks.markRunAborted.mockResolvedValue(undefined)
     mocks.markRunFailed.mockResolvedValue(undefined)
     mocks.markRunSucceeded.mockResolvedValue(undefined)
     mocks.ensureWorkspaceRunningForExecution.mockResolvedValue(undefined)
@@ -147,6 +154,31 @@ describe('executeLearningRun', () => {
     await expect(executeLearningRun(baseInput)).resolves.toEqual({ ok: false, error: 'instance_start_timeout' })
 
     expect(mocks.markLearningRunFailed).toHaveBeenCalledWith({ runId: 'run-1', error: 'instance_start_timeout' })
+  })
+
+  it('aborts the internal session and does not overwrite a cancelled run during polling', async () => {
+    const client = makeClient()
+    mocks.createInstanceClient.mockResolvedValue(client)
+    mocks.findLearningRunForUser.mockResolvedValue({
+      ...baseInput,
+      error: null,
+      internalSessionId: 'internal-session-1',
+      messageCount: 10,
+      status: 'cancelled',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    })
+    mocks.waitForSessionToComplete.mockImplementationOnce(
+      async (params: { onPulse?: () => Promise<string | null | void> }) => (await params.onPulse?.()) ?? null,
+    )
+
+    await expect(executeLearningRun(baseInput)).resolves.toEqual({ ok: false, error: 'learning_run_cancelled' })
+
+    expect(mocks.findLearningRunForUser).toHaveBeenCalledWith({ runId: 'run-1', userId: 'user-1' })
+    expect(client.session.abort).toHaveBeenCalledWith({ sessionID: 'internal-session-1' })
+    expect(mocks.markRunAborted).toHaveBeenCalledWith('message-run-1')
+    expect(mocks.markLearningRunFailed).not.toHaveBeenCalled()
+    expect(mocks.markLearningRunSucceeded).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/web/src/lib/learning/repository.ts
+++ b/apps/web/src/lib/learning/repository.ts
@@ -184,9 +184,25 @@ export async function claimLearningRunForExecution(runId: string): Promise<boole
   // (create + manual retry) cannot execute the same run twice.
   const result = await prisma.knowledgeLearningRun.updateMany({
     where: { id: runId, status: { in: ['pending', 'failed'] } },
-    data: { status: 'running', error: null },
+    data: { status: 'running', error: null, finishedAt: null, startedAt: new Date() },
   })
   return result.count === 1
+}
+
+export async function cancelLearningRun(args: {
+  runId: string
+  userId: string
+}): Promise<LearningRun | null> {
+  const result = await prisma.knowledgeLearningRun.updateMany({
+    where: { id: args.runId, userId: args.userId, status: { in: ['pending', 'running'] } },
+    data: { error: null, finishedAt: new Date(), status: 'cancelled' },
+  })
+  if (result.count !== 1) return null
+
+  const updated = await prisma.knowledgeLearningRun.findFirst({
+    where: { id: args.runId, userId: args.userId },
+  })
+  return updated ? mapRun(updated) : null
 }
 
 export async function hasActiveLearningRun(args: {
@@ -291,13 +307,22 @@ export async function createLearningProposal(userId: string, input: ProposalInpu
 }
 
 export async function markLearningRunRunning(runId: string): Promise<void> {
-  await prisma.knowledgeLearningRun.update({ where: { id: runId }, data: { status: 'running' } })
+  await prisma.knowledgeLearningRun.update({
+    where: { id: runId },
+    data: { error: null, finishedAt: null, startedAt: new Date(), status: 'running' },
+  })
 }
 
 export async function markLearningRunSucceeded(runId: string): Promise<void> {
-  await prisma.knowledgeLearningRun.update({ where: { id: runId }, data: { status: 'succeeded' } })
+  await prisma.knowledgeLearningRun.updateMany({
+    where: { id: runId, status: 'running' },
+    data: { finishedAt: new Date(), status: 'succeeded' },
+  })
 }
 
 export async function markLearningRunFailed(args: { runId: string; error: string }): Promise<void> {
-  await prisma.knowledgeLearningRun.update({ where: { id: args.runId }, data: { status: 'failed', error: args.error } })
+  await prisma.knowledgeLearningRun.updateMany({
+    where: { id: args.runId, status: 'running' },
+    data: { error: args.error, finishedAt: new Date(), status: 'failed' },
+  })
 }

--- a/apps/web/src/lib/learning/run-executor.ts
+++ b/apps/web/src/lib/learning/run-executor.ts
@@ -1,8 +1,9 @@
 import {
   claimLearningRunForExecution,
+  findLearningRunForUser,
   markLearningRunFailed,
-  setLearningRunInternalSessionId,
   markLearningRunSucceeded,
+  setLearningRunInternalSessionId,
 } from '@/lib/learning/repository'
 import { createInstanceClient } from '@/lib/opencode/client'
 import {
@@ -15,6 +16,7 @@ import { messageRunService } from '@/lib/services'
 import type { LearningTrigger } from '@/types/learning'
 
 const LEARNING_SESSION_TITLE_MAX_LENGTH = 160
+const LEARNING_RUN_CANCELLED_ERROR = 'learning_run_cancelled'
 
 export type LearningRunExecutionInput = {
   runId: string
@@ -88,6 +90,20 @@ export async function executeLearningRun(input: LearningRunExecutionInput): Prom
 
     await setLearningRunInternalSessionId({ runId: input.runId, internalSessionId: sessionId })
 
+    const abortIfCancelled = async (): Promise<string | null> => {
+      const run = await findLearningRunForUser({ runId: input.runId, userId: input.userId })
+      if (run?.status !== 'cancelled') return null
+
+      await Promise.resolve(client.session.abort({ sessionID: sessionId })).catch((error) => {
+        console.warn('[learning/run-executor] Failed to abort cancelled learning session', {
+          error,
+          runId: input.runId,
+          sessionId,
+        })
+      })
+      return LEARNING_RUN_CANCELLED_ERROR
+    }
+
     const promptRun = await createSessionPromptRun({
       client,
       sessionId,
@@ -112,6 +128,7 @@ export async function executeLearningRun(input: LearningRunExecutionInput): Prom
       failure = await waitForSessionToComplete({
         client,
         cursor,
+        onPulse: abortIfCancelled,
         sessionId,
         slug: input.slug,
         usage: { messageRunId: promptRun.run.id, source: 'learning', userId: input.userId },
@@ -123,6 +140,11 @@ export async function executeLearningRun(input: LearningRunExecutionInput): Prom
     }
 
     if (failure) {
+      if (failure === LEARNING_RUN_CANCELLED_ERROR) {
+        await messageRunService.markRunAborted(promptRun.run.id).catch(() => undefined)
+        return { ok: false, error: failure }
+      }
+
       await messageRunService.markRunFailed(promptRun.run.id, failure).catch(() => undefined)
       await markLearningRunFailed({ runId: input.runId, error: failure })
       return { ok: false, error: failure }
@@ -133,7 +155,9 @@ export async function executeLearningRun(input: LearningRunExecutionInput): Prom
     return { ok: true }
   } catch (error) {
     const message = error instanceof Error && error.message ? error.message : 'learning_run_failed'
-    await markLearningRunFailed({ runId: input.runId, error: message }).catch(() => undefined)
+    if (message !== LEARNING_RUN_CANCELLED_ERROR) {
+      await markLearningRunFailed({ runId: input.runId, error: message }).catch(() => undefined)
+    }
     return { ok: false, error: message }
   }
 }

--- a/apps/web/src/lib/learning/run-executor.ts
+++ b/apps/web/src/lib/learning/run-executor.ts
@@ -18,6 +18,10 @@ import type { LearningTrigger } from '@/types/learning'
 const LEARNING_SESSION_TITLE_MAX_LENGTH = 160
 const LEARNING_RUN_CANCELLED_ERROR = 'learning_run_cancelled'
 
+function cancellationLogError(error: unknown): string {
+  return error instanceof Error && error.name ? error.name : 'unknown_error'
+}
+
 export type LearningRunExecutionInput = {
   runId: string
   slug: string
@@ -96,9 +100,8 @@ export async function executeLearningRun(input: LearningRunExecutionInput): Prom
 
       await Promise.resolve(client.session.abort({ sessionID: sessionId })).catch((error) => {
         console.warn('[learning/run-executor] Failed to abort cancelled learning session', {
-          error,
+          error: cancellationLogError(error),
           runId: input.runId,
-          sessionId,
         })
       })
       return LEARNING_RUN_CANCELLED_ERROR

--- a/apps/web/src/lib/learning/service.ts
+++ b/apps/web/src/lib/learning/service.ts
@@ -3,6 +3,7 @@ export {
   rejectLearningProposal,
 } from '@/lib/learning/proposal-application'
 export {
+  cancelLearningRun,
   createLearningProposal,
   findLearningRunForUser,
   learningRunBelongsToUser,

--- a/apps/web/src/types/learning.ts
+++ b/apps/web/src/types/learning.ts
@@ -9,7 +9,7 @@ export const LEARNING_EVIDENCE_QUOTE_MAX_LENGTH = 4_000
 export const LEARNING_EVIDENCE_SOURCE_MAX_LENGTH = 500
 
 export type LearningTrigger = (typeof LEARNING_TRIGGERS)[number]
-export type LearningRunStatus = 'pending' | 'running' | 'succeeded' | 'failed'
+export type LearningRunStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled'
 export type LearningProposalStatus = 'pending' | 'rejected' | 'applied'
 export type LearningProposalType = (typeof LEARNING_PROPOSAL_TYPES)[number]
 export type LearningProposalOperation = (typeof LEARNING_OPERATIONS)[number]


### PR DESCRIPTION
## Summary

- Add  status to  enum
- Implement  endpoint
- Add UI controls for cancelling pending/running learning runs in the knowledge curator panel
- Properly handle aborting internal OpenCode sessions and active message runs when cancelling
- Add audit logging for cancellation actions

## Changes

### Database
- Add  status to learning runs enum
- Add migration to update database schema

### API
- New cancel endpoint with proper authorization and validation
- Abort internal sessions and message runs on cancellation
- Audit event creation for cancellation tracking

### UI
- Cancel button in knowledge curator panel for active runs
- Error handling and user feedback for cancellation actions

### Tests
- Add comprehensive tests for cancel endpoint
- Add UI component tests for cancellation workflow
- Add repository tests for cancel operations

## Tests run

- `pnpm test` - All tests pass (4790 tests passed, 15 skipped)
- `pnpm lint` - No errors, only pre-existing warnings

## Review notes

- The cancellation logic uses best-effort approach for aborting internal sessions
- Only pending and running runs can be cancelled
- Proper authorization checks ensure users can only cancel their own runs
- Database updates use updateMany with proper WHERE clauses to prevent race conditions

## Checklist

- [x] Tests pass locally
- [x] Linter passes
- [x] No secrets committed
- [x] Conventional commit format followed
- [x] Database migration is additive (safe for zero-downtime deploy)
- [x] Authorization checks in place
- [x] Audit logging added for sensitive action