### PR TITLE
fix(workspace): improve knowledge mode file review

### DIFF
--- a/apps/web/src/actions/__tests__/opencode.test.ts
+++ b/apps/web/src/actions/__tests__/opencode.test.ts
@@ -359,7 +359,7 @@ describe('searchFilesAction', () => {
 
   it('filters out hidden paths', async () => {
     mockFindFiles.mockResolvedValue({
-      data: ['src/index.ts', '.arche/config.json', 'opencode.json'],
+      data: ['src/index.ts', '.arche/config.json', '.git/config', 'opencode.json'],
     })
 
     const result = await searchFilesAction('alice', 'json')
@@ -444,6 +444,7 @@ describe('loadFileTreeAction', () => {
       data: [
         { path: 'src', name: 'src', type: 'directory', ignored: false },
         { path: '.arche', name: '.arche', type: 'directory', ignored: false },
+        { path: '.git', name: '.git', type: 'directory', ignored: false },
         { path: 'ignored.ts', name: 'ignored.ts', type: 'file', ignored: true },
       ],
     }).mockResolvedValueOnce({ data: [] })

--- a/apps/web/src/components/workspace/__tests__/knowledge-curator-panel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/knowledge-curator-panel.test.tsx
@@ -73,7 +73,7 @@ describe('KnowledgeCuratorPanel', () => {
     expect(await screen.findByText('Remember preference')).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Send to review' }))
 
-    expect(await screen.findByText('The target file changed since this proposal was created. Review it before applying.')).toBeTruthy()
+    expect(await screen.findByText('The target file changed since this proposal was created. Review it before sending again.')).toBeTruthy()
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
   })
 
@@ -128,6 +128,17 @@ describe('KnowledgeCuratorPanel', () => {
     expect(await screen.findByText('Remember preference')).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Send to review' }))
 
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/u/alice/learning/proposals', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'apply',
+          proposalId: 'proposal-1',
+          content: '# Preference\n\nUse **concise** answers.',
+        }),
+      })
+    })
     await waitFor(() => expect(onProposalSentToReview).toHaveBeenCalledTimes(1))
   })
 

--- a/apps/web/src/components/workspace/__tests__/knowledge-curator-panel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/knowledge-curator-panel.test.tsx
@@ -27,7 +27,7 @@ const learningResponse = {
       evidence: { quote: 'Use concise answers' },
       kbPath: 'Preferences/Answers.md',
       operation: 'update',
-      proposedContent: 'Use concise answers.',
+      proposedContent: '# Preference\n\nUse **concise** answers.',
       currentFileHash: 'hash-old',
       internalSessionId: null,
       trigger: 'agent',
@@ -71,7 +71,7 @@ describe('KnowledgeCuratorPanel', () => {
     render(<KnowledgeCuratorPanel slug="alice" />)
 
     expect(await screen.findByText('Remember preference')).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Send to review' }))
 
     expect(await screen.findByText('The target file changed since this proposal was created. Review it before applying.')).toBeTruthy()
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
@@ -95,16 +95,40 @@ describe('KnowledgeCuratorPanel', () => {
     render(<KnowledgeCuratorPanel slug="alice" />)
 
     expect(await screen.findByText('Remember preference')).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Send to review' }))
 
     await waitFor(() => {
-      expect((screen.getByRole('button', { name: 'Apply' }) as HTMLButtonElement).disabled).toBe(true)
+      expect((screen.getByRole('button', { name: 'Send to review' }) as HTMLButtonElement).disabled).toBe(true)
       expect((screen.getByRole('button', { name: 'Reject' }) as HTMLButtonElement).disabled).toBe(true)
     })
 
     resolveAction?.(jsonResponse({ proposal: { id: 'proposal-1' } }))
 
     expect(await screen.findByText('No pending proposals.')).toBeTruthy()
+  })
+
+  it('renders proposal content as a markdown preview', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(learningResponse))
+
+    render(<KnowledgeCuratorPanel slug="alice" />)
+
+    expect(await screen.findByRole('heading', { name: 'Preference' })).toBeTruthy()
+    expect(screen.getByText('concise')).toBeTruthy()
+  })
+
+  it('notifies the workspace after a proposal is sent to review', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(learningResponse))
+      .mockResolvedValueOnce(jsonResponse({ proposal: { id: 'proposal-1' } }))
+      .mockResolvedValueOnce(jsonResponse({ runs: [], proposals: [] }))
+    const onProposalSentToReview = vi.fn()
+
+    render(<KnowledgeCuratorPanel slug="alice" onProposalSentToReview={onProposalSentToReview} />)
+
+    expect(await screen.findByText('Remember preference')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Send to review' }))
+
+    await waitFor(() => expect(onProposalSentToReview).toHaveBeenCalledTimes(1))
   })
 
   it('refetches when refreshKey changes', async () => {

--- a/apps/web/src/components/workspace/__tests__/workspace-command-palette.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/workspace-command-palette.test.tsx
@@ -4,9 +4,10 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { WorkspaceCommandPalette } from "@/components/workspace/workspace-command-palette"
-import type { WorkspaceSession } from "@/lib/opencode/types"
+import type { WorkspaceFileNode, WorkspaceSession } from "@/lib/opencode/types"
 
 const listSessionsActionMock = vi.fn()
+const searchFilesActionMock = vi.fn()
 const loadFlowsMock = vi.fn()
 const runFlowMock = vi.fn()
 const setThemeIdMock = vi.fn()
@@ -14,6 +15,7 @@ const toggleDarkMock = vi.fn()
 
 vi.mock("@/actions/opencode", () => ({
   listSessionsAction: (...args: unknown[]) => listSessionsActionMock(...args),
+  searchFilesAction: (...args: unknown[]) => searchFilesActionMock(...args),
 }))
 
 vi.mock("@/contexts/workspace-theme-context", () => ({
@@ -49,6 +51,7 @@ vi.mock("@/hooks/use-flow-runner", () => ({
 type PaletteHandlers = {
   onCreateSession: ReturnType<typeof vi.fn>
   onModeChange: ReturnType<typeof vi.fn>
+  onOpenFile: ReturnType<typeof vi.fn>
   onNavigateConnectors: ReturnType<typeof vi.fn>
   onNavigateProviders: ReturnType<typeof vi.fn>
   onNavigateSettings: ReturnType<typeof vi.fn>
@@ -63,6 +66,7 @@ function makeHandlers(): PaletteHandlers {
   return {
     onCreateSession: vi.fn().mockResolvedValue(undefined),
     onModeChange: vi.fn(),
+    onOpenFile: vi.fn().mockResolvedValue(undefined),
     onNavigateConnectors: vi.fn(),
     onNavigateProviders: vi.fn(),
     onNavigateSettings: vi.fn(),
@@ -74,10 +78,36 @@ function makeHandlers(): PaletteHandlers {
   }
 }
 
-function renderPalette(options?: { hideFlows?: boolean; handlers?: PaletteHandlers }) {
+const fileNodes: WorkspaceFileNode[] = [
+  {
+    id: "Company",
+    name: "Company",
+    path: "Company",
+    type: "directory",
+    children: [
+      {
+        id: "Company/Product Strategy.md",
+        name: "Product Strategy.md",
+        path: "Company/Product Strategy.md",
+        type: "file",
+      },
+      {
+        id: "Company/Research/Customer Interviews.md",
+        name: "Customer Interviews.md",
+        path: "Company/Research/Customer Interviews.md",
+        type: "file",
+      },
+    ],
+  },
+]
+
+const palettePlaceholder = "Search commands, files, chats, flows..."
+
+function renderPalette(options?: { fileNodes?: WorkspaceFileNode[]; hideFlows?: boolean; handlers?: PaletteHandlers }) {
   const handlers = options?.handlers ?? makeHandlers()
   render(
     <WorkspaceCommandPalette
+      fileNodes={options?.fileNodes ?? fileNodes}
       slug="alice"
       open
       hideFlows={options?.hideFlows ?? false}
@@ -91,6 +121,7 @@ describe("WorkspaceCommandPalette", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     listSessionsActionMock.mockResolvedValue({ ok: true, sessions: [] })
+    searchFilesActionMock.mockResolvedValue({ ok: true, files: [] })
     runFlowMock.mockResolvedValue(undefined)
     window.HTMLElement.prototype.scrollIntoView = vi.fn()
     window.requestAnimationFrame = (callback: FrameRequestCallback) => {
@@ -109,10 +140,10 @@ describe("WorkspaceCommandPalette", () => {
     expect(loadFlowsMock).toHaveBeenCalledTimes(1)
     expect(screen.getByText("Go to Flows mode")).not.toBeNull()
 
-    fireEvent.change(screen.getByPlaceholderText("Search commands, chats, flows..."), {
+    fireEvent.change(screen.getByPlaceholderText(palettePlaceholder), {
       target: { value: "new chat" },
     })
-    fireEvent.keyDown(screen.getByPlaceholderText("Search commands, chats, flows..."), {
+    fireEvent.keyDown(screen.getByPlaceholderText(palettePlaceholder), {
       key: "Enter",
     })
 
@@ -142,7 +173,7 @@ describe("WorkspaceCommandPalette", () => {
     listSessionsActionMock.mockResolvedValue({ ok: true, sessions })
     const handlers = renderPalette()
 
-    fireEvent.change(screen.getByPlaceholderText("Search commands, chats, flows..."), {
+    fireEvent.change(screen.getByPlaceholderText(palettePlaceholder), {
       target: { value: "weekly" },
     })
 
@@ -192,7 +223,7 @@ describe("WorkspaceCommandPalette", () => {
     expect(loadFlowsMock).not.toHaveBeenCalled()
     expect(screen.queryByText("Go to Flows mode")).toBeNull()
 
-    fireEvent.change(screen.getByPlaceholderText("Search commands, chats, flows..."), {
+    fireEvent.change(screen.getByPlaceholderText(palettePlaceholder), {
       target: { value: "run" },
     })
 
@@ -202,7 +233,7 @@ describe("WorkspaceCommandPalette", () => {
 
   it("runs theme, layout, navigation, and flow commands", async () => {
     const handlers = renderPalette()
-    const input = screen.getByPlaceholderText("Search commands, chats, flows...")
+    const input = screen.getByPlaceholderText(palettePlaceholder)
 
     fireEvent.change(input, { target: { value: "slate" } })
     fireEvent.keyDown(input, { key: "Enter" })
@@ -222,10 +253,39 @@ describe("WorkspaceCommandPalette", () => {
     expect(handlers.onModeChange).toHaveBeenCalledWith("flows")
   })
 
+  it("finds files by fuzzy name and opens them in knowledge mode", async () => {
+    searchFilesActionMock.mockResolvedValue({ ok: true, files: ["Company/Research/Customer Interviews.md"] })
+    const handlers = renderPalette()
+    const input = screen.getByPlaceholderText(palettePlaceholder)
+
+    fireEvent.change(input, { target: { value: "prd strat" } })
+
+    expect(await screen.findByText("Product Strategy.md")).not.toBeNull()
+    fireEvent.click(screen.getByText("Product Strategy.md"))
+
+    await waitFor(() => expect(handlers.onOpenChange).toHaveBeenCalledWith(false))
+    expect(handlers.onModeChange).toHaveBeenCalledWith("knowledge")
+    expect(handlers.onOpenFile).toHaveBeenCalledWith("Company/Product Strategy.md")
+  })
+
+  it("includes file results returned by workspace search", async () => {
+    searchFilesActionMock.mockResolvedValue({ ok: true, files: ["Deep/Vault/Roadmap.md"] })
+    renderPalette({ fileNodes: [] })
+    const input = screen.getByPlaceholderText(palettePlaceholder)
+
+    fireEvent.change(input, { target: { value: "road" } })
+
+    await waitFor(() => {
+      expect(searchFilesActionMock).toHaveBeenCalledWith("alice", "road")
+    })
+    expect(await screen.findByText("Roadmap.md")).not.toBeNull()
+  })
+
   it("supports keyboard navigation, hover selection, empty results, and dark mode", async () => {
     listSessionsActionMock.mockResolvedValue({ ok: false })
+    searchFilesActionMock.mockResolvedValue({ ok: false })
     const handlers = renderPalette()
-    const input = screen.getByPlaceholderText("Search commands, chats, flows...")
+    const input = screen.getByPlaceholderText(palettePlaceholder)
 
     fireEvent.keyDown(input, { key: "ArrowDown" })
     fireEvent.keyDown(input, { key: "ArrowUp" })
@@ -238,6 +298,6 @@ describe("WorkspaceCommandPalette", () => {
     await waitFor(() => expect(toggleDarkMock).toHaveBeenCalledTimes(1))
 
     fireEvent.change(input, { target: { value: "does-not-exist" } })
-    await waitFor(() => expect(screen.getByText("No commands or sessions found.")).not.toBeNull())
+    await waitFor(() => expect(screen.getByText("No commands, files, or sessions found.")).not.toBeNull())
   })
 })

--- a/apps/web/src/components/workspace/__tests__/workspace-command-palette.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/workspace-command-palette.test.tsx
@@ -281,6 +281,25 @@ describe("WorkspaceCommandPalette", () => {
     expect(await screen.findByText("Roadmap.md")).not.toBeNull()
   })
 
+  it("clears search loading state when search actions reject", async () => {
+    listSessionsActionMock.mockRejectedValue(new Error("session unavailable"))
+    searchFilesActionMock.mockRejectedValue(new Error("file search unavailable"))
+    renderPalette()
+    const input = screen.getByPlaceholderText(palettePlaceholder)
+
+    fireEvent.change(input, { target: { value: "does-not-exist" } })
+
+    await waitFor(() => {
+      expect(listSessionsActionMock).toHaveBeenCalledWith("alice", {
+        limit: 100,
+        query: "does-not-exist",
+        rootsOnly: true,
+      })
+    })
+    await waitFor(() => expect(screen.getByText("No commands, files, or sessions found.")).not.toBeNull())
+    expect(screen.queryByText("Searching...")).toBeNull()
+  })
+
   it("supports keyboard navigation, hover selection, empty results, and dark mode", async () => {
     listSessionsActionMock.mockResolvedValue({ ok: false })
     searchFilesActionMock.mockResolvedValue({ ok: false })

--- a/apps/web/src/components/workspace/file-tree-panel.tsx
+++ b/apps/web/src/components/workspace/file-tree-panel.tsx
@@ -4,8 +4,9 @@ import { useCallback, useMemo, useState, type MouseEvent } from "react";
 import { File, Plus } from "@phosphor-icons/react";
 
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 import type { WorkspaceFileNode } from "@/lib/opencode/types";
+import { cn } from "@/lib/utils";
+import { flattenWorkspaceFileNodes, type WorkspaceFileSearchCandidate } from "@/lib/workspace-file-search";
 
 import { FileTreeContextMenu } from "./file-tree-context-menu";
 import { FileTree } from "./file-tree";
@@ -19,20 +20,7 @@ type FileTreePanelProps = {
   query?: string;
 };
 
-type FlatFile = { name: string; path: string };
-type FileContextMenuState = FlatFile & { x: number; y: number };
-
-function flattenFiles(nodes: WorkspaceFileNode[]): FlatFile[] {
-  const result: FlatFile[] = [];
-  nodes.forEach((node) => {
-    if (node.type === "file") {
-      result.push({ name: node.name, path: node.path });
-    } else if (node.children) {
-      result.push(...flattenFiles(node.children));
-    }
-  });
-  return result;
-}
+type FileContextMenuState = WorkspaceFileSearchCandidate & { x: number; y: number };
 
 export function FileTreePanel({
   nodes,
@@ -43,7 +31,7 @@ export function FileTreePanel({
   query = "",
 }: FileTreePanelProps) {
   const normalizedQuery = query.trim().toLowerCase();
-  const files = useMemo(() => flattenFiles(nodes), [nodes]);
+  const files = useMemo(() => flattenWorkspaceFileNodes(nodes), [nodes]);
   const [contextMenu, setContextMenu] = useState<FileContextMenuState | null>(null);
   const matches = useMemo(() => {
     if (!normalizedQuery) return [];
@@ -51,7 +39,7 @@ export function FileTreePanel({
   }, [files, normalizedQuery]);
 
   const handleFileContextMenu = useCallback(
-    (file: FlatFile, event: MouseEvent<HTMLButtonElement>) => {
+    (file: WorkspaceFileSearchCandidate, event: MouseEvent<HTMLButtonElement>) => {
       if (!onDownloadFile) return;
 
       event.preventDefault();

--- a/apps/web/src/components/workspace/knowledge-curator-panel.tsx
+++ b/apps/web/src/components/workspace/knowledge-curator-panel.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState } from "react";
 import { ArrowLineRight } from "@phosphor-icons/react";
 
 import { Button } from "@/components/ui/button";
+import { MarkdownPreview } from "@/components/workspace/markdown-preview";
 import { cn } from "@/lib/utils";
 import type { LearningProposal, LearningRun, LearningRunStatus } from "@/types/learning";
 
@@ -13,6 +14,7 @@ type KnowledgeCuratorPanelProps = {
   collapsed?: boolean;
   onToggleCollapse?: () => void;
   onOpenSession?: (sessionId: string) => void;
+  onProposalSentToReview?: () => Promise<void> | void;
   refreshKey?: number;
 }
 
@@ -76,7 +78,15 @@ function RunStatusBadge({ status }: { status: LearningRunStatus }) {
   );
 }
 
-export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollapse, onOpenSession, refreshKey = 0 }: KnowledgeCuratorPanelProps) {
+function formatTrigger(trigger: LearningRun["trigger"]): string {
+  return trigger.charAt(0).toUpperCase() + trigger.slice(1);
+}
+
+function formatMessageCount(count: number): string {
+  return `${count} ${count === 1 ? "message" : "messages"}`;
+}
+
+export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollapse, onOpenSession, onProposalSentToReview, refreshKey = 0 }: KnowledgeCuratorPanelProps) {
   const [data, setData] = useState<LearningResponse>({ proposals: [], runs: [] });
   const [edits, setEdits] = useState<Record<string, string>>({});
   const [error, setError] = useState<string | null>(null);
@@ -196,6 +206,9 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
 
         setError(null);
         await refresh();
+        if (action === "apply") {
+          void onProposalSentToReview?.();
+        }
         setEdits((current) => {
           const next = { ...current };
           delete next[proposalId];
@@ -207,7 +220,7 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
         setBusyProposalId(null);
       }
     },
-    [refresh, slug]
+    [onProposalSentToReview, refresh, slug]
   );
 
   if (collapsed) {
@@ -259,42 +272,59 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
         {error ? <p className="text-xs text-destructive">{errorLabel(error)}</p> : null}
         <section className="space-y-2">
           <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Pending proposals</h3>
-          {data.proposals.filter((proposal) => proposal.status === "pending").map((proposal) => (
-            <article key={proposal.id} className="space-y-2 rounded-lg border border-border/60 bg-background/60 p-3">
-              <div>
-                <p className="text-sm font-medium">{proposal.title}</p>
-                <p className="text-xs text-muted-foreground">{proposal.operation} {proposal.kbPath} · {Math.round(proposal.confidence * 100)}%</p>
-              </div>
-              {proposal.evidence.quote ? (
-                <blockquote className="rounded bg-muted/40 p-2 text-xs text-muted-foreground">{proposal.evidence.quote}</blockquote>
-              ) : null}
-              <textarea
-                className="h-28 w-full rounded-md border border-border bg-background p-2 text-xs outline-none"
-                value={edits[proposal.id] ?? proposal.proposedContent}
-                disabled={busyProposalId === proposal.id}
-                onChange={(event) => {
-                  setEdits((current) => ({ ...current, [proposal.id]: event.currentTarget.value }));
-                }}
-              />
-              <div className="flex justify-end gap-2">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={busyProposalId !== null}
-                  onClick={() => void actOnProposal(proposal.id, "reject")}
-                >
-                  Reject
-                </Button>
-                <Button
-                  size="sm"
-                  disabled={busyProposalId !== null}
-                  onClick={() => void actOnProposal(proposal.id, "apply", edits[proposal.id] ?? proposal.proposedContent)}
-                >
-                  Apply
-                </Button>
-              </div>
-            </article>
-          ))}
+          {data.proposals.filter((proposal) => proposal.status === "pending").map((proposal) => {
+            const proposalContent = edits[proposal.id] ?? proposal.proposedContent;
+
+            return (
+              <article key={proposal.id} className="space-y-3 rounded-xl border border-border/60 bg-background/70 p-3 shadow-sm">
+                <div>
+                  <p className="text-sm font-medium">{proposal.title}</p>
+                  <p className="text-xs text-muted-foreground">{proposal.operation} {proposal.kbPath} · {Math.round(proposal.confidence * 100)}%</p>
+                </div>
+                {proposal.evidence.quote ? (
+                  <blockquote className="rounded-lg border border-border/40 bg-muted/30 p-2 text-xs leading-relaxed text-muted-foreground">{proposal.evidence.quote}</blockquote>
+                ) : null}
+                <div className="overflow-hidden rounded-lg border border-border/60 bg-background">
+                  <div className="border-b border-border/50 bg-muted/30 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Markdown preview
+                  </div>
+                  <div className="max-h-72 overflow-y-auto scrollbar-none">
+                    <MarkdownPreview content={proposalContent} />
+                  </div>
+                </div>
+                <details className="rounded-lg border border-border/50 bg-muted/20 p-2">
+                  <summary className="cursor-pointer text-xs font-medium text-muted-foreground">
+                    Edit markdown before review
+                  </summary>
+                  <textarea
+                    className="mt-2 h-28 w-full rounded-md border border-border bg-background p-2 font-mono text-xs outline-none"
+                    value={proposalContent}
+                    disabled={busyProposalId === proposal.id}
+                    onChange={(event) => {
+                      setEdits((current) => ({ ...current, [proposal.id]: event.currentTarget.value }));
+                    }}
+                  />
+                </details>
+                <div className="flex justify-end gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={busyProposalId !== null}
+                    onClick={() => void actOnProposal(proposal.id, "reject")}
+                  >
+                    Reject
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={busyProposalId !== null}
+                    onClick={() => void actOnProposal(proposal.id, "apply", proposalContent)}
+                  >
+                    Send to review
+                  </Button>
+                </div>
+              </article>
+            );
+          })}
           {pendingProposalCount === 0 ? (
             <p className="text-xs text-muted-foreground">No pending proposals.</p>
           ) : null}
@@ -308,14 +338,19 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
             const isCancelable = run.status === "pending" || run.status === "running";
             const internalSessionId = run.internalSessionId;
             return (
-              <div key={run.id} className="space-y-1 rounded-md border border-border/60 p-2 text-xs">
-                <div className="flex items-center justify-between gap-2">
-                  <p className="min-w-0 truncate font-medium">{run.title}</p>
+              <article key={run.id} className="rounded-xl border border-border/60 bg-background/70 p-3 text-xs shadow-sm">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 space-y-1">
+                    <p className="truncate text-sm font-medium">{run.title}</p>
+                    <div className="flex flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
+                      <span className="rounded-full bg-muted/50 px-2 py-0.5">{formatTrigger(run.trigger)}</span>
+                      <span className="rounded-full bg-muted/50 px-2 py-0.5">{formatMessageCount(run.messageCount)}</span>
+                    </div>
+                  </div>
                   <RunStatusBadge status={run.status} />
                 </div>
-                <div className="flex items-center justify-between gap-2">
-                  <p className="min-w-0 truncate text-muted-foreground">{run.trigger}</p>
-                  <div className="flex shrink-0 items-center gap-1.5">
+                <div className="mt-3 flex items-center justify-end gap-2">
+                  <div className="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
                     {internalSessionId && onOpenSession ? (
                       <Button
                         size="sm"
@@ -351,9 +386,9 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
                   </div>
                 </div>
                 {run.status === "failed" && run.error ? (
-                  <p className="text-destructive">{errorLabel(run.error)}</p>
+                  <p className="mt-2 rounded-lg bg-destructive/10 px-2 py-1 text-destructive">{errorLabel(run.error)}</p>
                 ) : null}
-              </div>
+              </article>
             );
           })}
           {data.runs.length === 0 ? (

--- a/apps/web/src/components/workspace/knowledge-curator-panel.tsx
+++ b/apps/web/src/components/workspace/knowledge-curator-panel.tsx
@@ -23,8 +23,15 @@ type LearningResponse = {
   runs: LearningRun[];
 }
 
+type ProposalDecision = "send_to_review" | "reject";
+
+const PROPOSAL_API_ACTION_BY_DECISION: Record<ProposalDecision, "apply" | "reject"> = {
+  send_to_review: "apply",
+  reject: "reject",
+};
+
 const ERROR_LABELS: Record<string, string> = {
-  hash_conflict: "The target file changed since this proposal was created. Review it before applying.",
+  hash_conflict: "The target file changed since this proposal was created. Review it before sending again.",
   not_pending: "This proposal was already resolved.",
   not_found: "Proposal not found.",
   file_exists: "The target file already exists.",
@@ -188,10 +195,11 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
     [refresh, slug]
   );
 
-  const actOnProposal = useCallback(
-    async (proposalId: string, action: "apply" | "reject", content?: string) => {
+  const resolveProposal = useCallback(
+    async (proposalId: string, decision: ProposalDecision, content?: string) => {
       setBusyProposalId(proposalId);
       try {
+        const action = PROPOSAL_API_ACTION_BY_DECISION[decision];
         const response = await fetch(`/api/u/${slug}/learning/proposals`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -206,7 +214,7 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
 
         setError(null);
         await refresh();
-        if (action === "apply") {
+        if (decision === "send_to_review") {
           void onProposalSentToReview?.();
         }
         setEdits((current) => {
@@ -310,14 +318,14 @@ export function KnowledgeCuratorPanel({ slug, collapsed = false, onToggleCollaps
                     size="sm"
                     variant="outline"
                     disabled={busyProposalId !== null}
-                    onClick={() => void actOnProposal(proposal.id, "reject")}
+                    onClick={() => void resolveProposal(proposal.id, "reject")}
                   >
                     Reject
                   </Button>
                   <Button
                     size="sm"
                     disabled={busyProposalId !== null}
-                    onClick={() => void actOnProposal(proposal.id, "apply", proposalContent)}
+                    onClick={() => void resolveProposal(proposal.id, "send_to_review", proposalContent)}
                   >
                     Send to review
                   </Button>

--- a/apps/web/src/components/workspace/workspace-command-palette.tsx
+++ b/apps/web/src/components/workspace/workspace-command-palette.tsx
@@ -15,25 +15,27 @@ import {
   Sparkle,
 } from "@phosphor-icons/react";
 
-import { listSessionsAction } from "@/actions/opencode";
+import { listSessionsAction, searchFilesAction } from "@/actions/opencode";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { useWorkspaceTheme } from "@/contexts/workspace-theme-context";
 import { useFlowRunner } from "@/hooks/use-flow-runner";
-import type { WorkspaceSession } from "@/lib/opencode/types";
+import type { WorkspaceFileNode, WorkspaceSession } from "@/lib/opencode/types";
+import { cn } from "@/lib/utils";
 import { isFlowSession } from "@/lib/workspace-session-utils";
 import type { WorkspaceThemeId } from "@/lib/workspace-theme";
-import { cn } from "@/lib/utils";
 
 import type { WorkspaceMode } from "./workspace-mode-toggle";
 
 type WorkspaceCommandPaletteProps = {
+  fileNodes?: WorkspaceFileNode[];
   slug: string;
   open: boolean;
   hideFlows: boolean;
   onOpenChange: (open: boolean) => void;
   onCreateSession: () => Promise<void> | void;
   onModeChange: (mode: WorkspaceMode) => void;
+  onOpenFile?: (path: string) => Promise<void> | void;
   onNavigateConnectors: () => void;
   onNavigateProviders: () => void;
   onNavigateSettings: () => void;
@@ -55,6 +57,79 @@ type PaletteItem = {
 
 const SESSION_SEARCH_SCAN_LIMIT = 100;
 const SESSION_SEARCH_RESULT_LIMIT = 20;
+const FILE_SEARCH_RESULT_LIMIT = 15;
+
+type FileSearchCandidate = {
+  name: string;
+  path: string;
+};
+
+function flattenFileNodes(nodes: WorkspaceFileNode[]): FileSearchCandidate[] {
+  const result: FileSearchCandidate[] = [];
+
+  for (const node of nodes) {
+    if (node.type === "file") {
+      result.push({ name: node.name, path: node.path });
+      continue;
+    }
+
+    if (node.children && node.children.length > 0) {
+      result.push(...flattenFileNodes(node.children));
+    }
+  }
+
+  return result;
+}
+
+function basename(path: string): string {
+  return path.split("/").pop() ?? path;
+}
+
+function fuzzyScore(value: string, token: string): number | null {
+  const exactIndex = value.indexOf(token);
+  if (exactIndex >= 0) return exactIndex;
+
+  let valueIndex = 0;
+  let previousMatchIndex = -1;
+  let score = 50;
+
+  for (const character of token) {
+    const matchIndex = value.indexOf(character, valueIndex);
+    if (matchIndex === -1) return null;
+
+    score += matchIndex;
+    if (previousMatchIndex >= 0 && matchIndex !== previousMatchIndex + 1) {
+      score += 8;
+    }
+
+    previousMatchIndex = matchIndex;
+    valueIndex = matchIndex + 1;
+  }
+
+  return score;
+}
+
+function scoreFileMatch(file: FileSearchCandidate, query: string): number | null {
+  const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return null;
+
+  const name = file.name.toLowerCase();
+  const path = file.path.toLowerCase();
+  let score = 0;
+
+  for (const token of tokens) {
+    const nameScore = fuzzyScore(name, token);
+    const pathScore = fuzzyScore(path, token);
+    if (nameScore === null && pathScore === null) return null;
+
+    score += Math.min(
+      nameScore ?? Number.POSITIVE_INFINITY,
+      pathScore === null ? Number.POSITIVE_INFINITY : pathScore + 12
+    );
+  }
+
+  return score + file.path.length / 1000;
+}
 
 function matchesQuery(item: PaletteItem, query: string): boolean {
   if (!query) return true;
@@ -63,12 +138,14 @@ function matchesQuery(item: PaletteItem, query: string): boolean {
 }
 
 export function WorkspaceCommandPalette({
+  fileNodes = [],
   slug,
   open,
   hideFlows,
   onOpenChange,
   onCreateSession,
   onModeChange,
+  onOpenFile,
   onNavigateConnectors,
   onNavigateProviders,
   onNavigateSettings,
@@ -84,6 +161,8 @@ export function WorkspaceCommandPalette({
   const [isKeyboardNavigating, setIsKeyboardNavigating] = useState(false);
   const [sessionResults, setSessionResults] = useState<WorkspaceSession[]>([]);
   const [isSearchingSessions, setIsSearchingSessions] = useState(false);
+  const [fileResults, setFileResults] = useState<string[]>([]);
+  const [isSearchingFiles, setIsSearchingFiles] = useState(false);
   const { themes, themeId, setThemeId, toggleDark } = useWorkspaceTheme();
   const {
     flows,
@@ -103,6 +182,8 @@ export function WorkspaceCommandPalette({
       setIsKeyboardNavigating(false);
       setSessionResults([]);
       setIsSearchingSessions(false);
+      setFileResults([]);
+      setIsSearchingFiles(false);
     },
     [onOpenChange]
   );
@@ -113,10 +194,13 @@ export function WorkspaceCommandPalette({
     requestAnimationFrame(() => itemRefs.current[0]?.scrollIntoView({ block: "nearest" }));
     if (value.trim()) {
       setIsSearchingSessions(true);
+      setIsSearchingFiles(Boolean(onOpenFile));
       return;
     }
     setSessionResults([]);
     setIsSearchingSessions(false);
+    setFileResults([]);
+    setIsSearchingFiles(false);
   };
 
   useEffect(() => {
@@ -136,14 +220,21 @@ export function WorkspaceCommandPalette({
 
     let cancelled = false;
     const timeout = window.setTimeout(() => {
-      void listSessionsAction(slug, {
+      const sessionSearch = listSessionsAction(slug, {
         limit: SESSION_SEARCH_SCAN_LIMIT,
         query: trimmedQuery,
         rootsOnly: true,
-      }).then((result) => {
+      });
+      const fileSearch = onOpenFile
+        ? searchFilesAction(slug, trimmedQuery)
+        : Promise.resolve({ ok: true, files: [] as string[] });
+
+      void Promise.all([sessionSearch, fileSearch]).then(([sessionResult, fileResult]) => {
         if (cancelled) return;
-        setSessionResults(result.ok ? (result.sessions ?? []).slice(0, SESSION_SEARCH_RESULT_LIMIT) : []);
+        setSessionResults(sessionResult.ok ? (sessionResult.sessions ?? []).slice(0, SESSION_SEARCH_RESULT_LIMIT) : []);
+        setFileResults(fileResult.ok ? (fileResult.files ?? []) : []);
         setIsSearchingSessions(false);
+        setIsSearchingFiles(false);
       });
     }, 150);
 
@@ -151,7 +242,7 @@ export function WorkspaceCommandPalette({
       cancelled = true;
       window.clearTimeout(timeout);
     };
-  }, [open, query, slug]);
+  }, [onOpenFile, open, query, slug]);
 
   const closeAndRun = useCallback(
     async (run: () => Promise<void> | void) => {
@@ -308,10 +399,47 @@ export function WorkspaceCommandPalette({
       });
   }, [hideFlows, onSelectSession, sessionResults]);
 
+  const localFiles = useMemo(() => flattenFileNodes(fileNodes), [fileNodes]);
+
+  const fileItems = useMemo<PaletteItem[]>(() => {
+    const trimmedQuery = query.trim();
+    if (!onOpenFile || !trimmedQuery) return [];
+
+    const candidatesByPath = new Map<string, FileSearchCandidate>();
+    for (const file of localFiles) {
+      candidatesByPath.set(file.path, file);
+    }
+    for (const path of fileResults) {
+      if (!candidatesByPath.has(path)) {
+        candidatesByPath.set(path, { name: basename(path), path });
+      }
+    }
+
+    return Array.from(candidatesByPath.values())
+      .map((file) => ({ file, score: scoreFileMatch(file, trimmedQuery) }))
+      .filter((candidate): candidate is { file: FileSearchCandidate; score: number } => candidate.score !== null)
+      .sort((a, b) => a.score - b.score || a.file.path.localeCompare(b.file.path))
+      .slice(0, FILE_SEARCH_RESULT_LIMIT)
+      .map(({ file }) => ({
+        id: `file-${file.path}`,
+        title: file.name,
+        subtitle: file.path,
+        section: "Files",
+        icon: File,
+        keywords: file.path,
+        run: async () => {
+          onModeChange("knowledge");
+          await onOpenFile(file.path);
+        },
+      }));
+  }, [fileResults, localFiles, onModeChange, onOpenFile, query]);
+
   const visibleItems = useMemo(() => {
     const trimmedQuery = query.trim();
-    return [...baseItems, ...flowItems].filter((item) => matchesQuery(item, trimmedQuery)).concat(sessionItems);
-  }, [baseItems, flowItems, query, sessionItems]);
+    return [...baseItems, ...flowItems]
+      .filter((item) => matchesQuery(item, trimmedQuery))
+      .concat(fileItems, sessionItems);
+  }, [baseItems, fileItems, flowItems, query, sessionItems]);
 
   const boundedActiveIndex = Math.min(activeIndex, Math.max(visibleItems.length - 1, 0));
   const activeItem = visibleItems[boundedActiveIndex] ?? null;
@@ -346,7 +474,7 @@ export function WorkspaceCommandPalette({
       <DialogContent className="top-4 max-w-[calc(100vw-1rem)] translate-y-0 gap-0 overflow-hidden p-0 sm:top-[12vh] sm:max-w-2xl" showCloseButton={false}>
         <DialogTitle className="sr-only">Workspace command palette</DialogTitle>
         <DialogDescription className="sr-only">
-          Search workspace commands, chats, flow runs, and settings.
+          Search workspace commands, files, chats, flow runs, and settings.
         </DialogDescription>
         <div className="border-b border-border/50 p-3">
           <Input
@@ -354,14 +482,14 @@ export function WorkspaceCommandPalette({
             value={query}
             onChange={(event) => handleQueryChange(event.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Search commands, chats, flows..."
+            placeholder="Search commands, files, chats, flows..."
             className="h-11 border-0 bg-muted/40 text-base focus-visible:ring-0 focus-visible:ring-offset-0"
           />
         </div>
         <div className="scrollbar-custom max-h-[min(28rem,60vh)] overflow-y-auto p-2">
           {visibleItems.length === 0 ? (
             <div className="px-4 py-8 text-center text-sm text-muted-foreground">
-              {isSearchingSessions ? "Searching sessions..." : "No commands or sessions found."}
+              {isSearchingSessions || isSearchingFiles ? "Searching..." : "No commands, files, or sessions found."}
             </div>
           ) : (
             <div className="space-y-1">
@@ -416,7 +544,7 @@ export function WorkspaceCommandPalette({
         <div className="flex items-center justify-between border-t border-border/50 px-4 py-2 text-[11px] text-muted-foreground">
           <span>Use arrows to navigate, Enter to run, Escape to close</span>
           <span>
-            {isLoadingFlows ? "Loading flows" : runningFlowId ? "Running flow" : runError ? runError : isSearchingSessions ? "Searching sessions" : null}
+            {isLoadingFlows ? "Loading flows" : runningFlowId ? "Running flow" : runError ? runError : isSearchingSessions || isSearchingFiles ? "Searching" : null}
           </span>
         </div>
       </DialogContent>

--- a/apps/web/src/components/workspace/workspace-command-palette.tsx
+++ b/apps/web/src/components/workspace/workspace-command-palette.tsx
@@ -22,7 +22,7 @@ import { useWorkspaceTheme } from "@/contexts/workspace-theme-context";
 import { useFlowRunner } from "@/hooks/use-flow-runner";
 import type { WorkspaceFileNode, WorkspaceSession } from "@/lib/opencode/types";
 import { cn } from "@/lib/utils";
-import { rankWorkspaceFileSearchResults } from "@/lib/workspace-file-search";
+import { flattenWorkspaceFileNodes, rankWorkspaceFileSearchCandidates } from "@/lib/workspace-file-search";
 import { isFlowSession } from "@/lib/workspace-session-utils";
 import type { WorkspaceThemeId } from "@/lib/workspace-theme";
 
@@ -101,6 +101,8 @@ export function WorkspaceCommandPalette({
     loadFlows,
     runFlow,
   } = useFlowRunner({ slug, onRunFlowComplete: onRefreshSessions });
+  const canSearchFiles = Boolean(onOpenFile);
+  const localFileCandidates = useMemo(() => flattenWorkspaceFileNodes(fileNodes), [fileNodes]);
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -123,7 +125,7 @@ export function WorkspaceCommandPalette({
     requestAnimationFrame(() => itemRefs.current[0]?.scrollIntoView({ block: "nearest" }));
     if (value.trim()) {
       setIsSearchingSessions(true);
-      setIsSearchingFiles(Boolean(onOpenFile));
+      setIsSearchingFiles(canSearchFiles);
       return;
     }
     setSessionResults([]);
@@ -149,29 +151,39 @@ export function WorkspaceCommandPalette({
 
     let cancelled = false;
     const timeout = window.setTimeout(() => {
-      const sessionSearch = listSessionsAction(slug, {
-        limit: SESSION_SEARCH_SCAN_LIMIT,
-        query: trimmedQuery,
-        rootsOnly: true,
-      });
-      const fileSearch = onOpenFile
-        ? searchFilesAction(slug, trimmedQuery)
-        : Promise.resolve({ ok: true, files: [] as string[] });
+      void (async () => {
+        try {
+          const [sessionResult, fileResult] = await Promise.all([
+            listSessionsAction(slug, {
+              limit: SESSION_SEARCH_SCAN_LIMIT,
+              query: trimmedQuery,
+              rootsOnly: true,
+            }),
+            canSearchFiles
+              ? searchFilesAction(slug, trimmedQuery)
+              : Promise.resolve({ ok: true, files: [] as string[] }),
+          ]);
 
-      void Promise.all([sessionSearch, fileSearch]).then(([sessionResult, fileResult]) => {
-        if (cancelled) return;
-        setSessionResults(sessionResult.ok ? (sessionResult.sessions ?? []).slice(0, SESSION_SEARCH_RESULT_LIMIT) : []);
-        setFileResults(fileResult.ok ? (fileResult.files ?? []) : []);
-        setIsSearchingSessions(false);
-        setIsSearchingFiles(false);
-      });
+          if (cancelled) return;
+          setSessionResults(sessionResult.ok ? (sessionResult.sessions ?? []).slice(0, SESSION_SEARCH_RESULT_LIMIT) : []);
+          setFileResults(fileResult.ok ? (fileResult.files ?? []) : []);
+        } catch {
+          if (cancelled) return;
+          setSessionResults([]);
+          setFileResults([]);
+        } finally {
+          if (cancelled) return;
+          setIsSearchingSessions(false);
+          setIsSearchingFiles(false);
+        }
+      })();
     }, 150);
 
     return () => {
       cancelled = true;
       window.clearTimeout(timeout);
     };
-  }, [onOpenFile, open, query, slug]);
+  }, [canSearchFiles, open, query, slug]);
 
   const closeAndRun = useCallback(
     async (run: () => Promise<void> | void) => {
@@ -332,8 +344,8 @@ export function WorkspaceCommandPalette({
     const trimmedQuery = query.trim();
     if (!onOpenFile || !trimmedQuery) return [];
 
-    return rankWorkspaceFileSearchResults({
-      fileNodes,
+    return rankWorkspaceFileSearchCandidates({
+      files: localFileCandidates,
       limit: FILE_SEARCH_RESULT_LIMIT,
       query: trimmedQuery,
       remotePaths: fileResults,
@@ -349,7 +361,7 @@ export function WorkspaceCommandPalette({
         await onOpenFile(file.path);
       },
     }));
-  }, [fileNodes, fileResults, onModeChange, onOpenFile, query]);
+  }, [fileResults, localFileCandidates, onModeChange, onOpenFile, query]);
 
   const visibleItems = useMemo(() => {
     const trimmedQuery = query.trim();

--- a/apps/web/src/components/workspace/workspace-command-palette.tsx
+++ b/apps/web/src/components/workspace/workspace-command-palette.tsx
@@ -22,6 +22,7 @@ import { useWorkspaceTheme } from "@/contexts/workspace-theme-context";
 import { useFlowRunner } from "@/hooks/use-flow-runner";
 import type { WorkspaceFileNode, WorkspaceSession } from "@/lib/opencode/types";
 import { cn } from "@/lib/utils";
+import { rankWorkspaceFileSearchResults } from "@/lib/workspace-file-search";
 import { isFlowSession } from "@/lib/workspace-session-utils";
 import type { WorkspaceThemeId } from "@/lib/workspace-theme";
 
@@ -58,78 +59,6 @@ type PaletteItem = {
 const SESSION_SEARCH_SCAN_LIMIT = 100;
 const SESSION_SEARCH_RESULT_LIMIT = 20;
 const FILE_SEARCH_RESULT_LIMIT = 15;
-
-type FileSearchCandidate = {
-  name: string;
-  path: string;
-};
-
-function flattenFileNodes(nodes: WorkspaceFileNode[]): FileSearchCandidate[] {
-  const result: FileSearchCandidate[] = [];
-
-  for (const node of nodes) {
-    if (node.type === "file") {
-      result.push({ name: node.name, path: node.path });
-      continue;
-    }
-
-    if (node.children && node.children.length > 0) {
-      result.push(...flattenFileNodes(node.children));
-    }
-  }
-
-  return result;
-}
-
-function basename(path: string): string {
-  return path.split("/").pop() ?? path;
-}
-
-function fuzzyScore(value: string, token: string): number | null {
-  const exactIndex = value.indexOf(token);
-  if (exactIndex >= 0) return exactIndex;
-
-  let valueIndex = 0;
-  let previousMatchIndex = -1;
-  let score = 50;
-
-  for (const character of token) {
-    const matchIndex = value.indexOf(character, valueIndex);
-    if (matchIndex === -1) return null;
-
-    score += matchIndex;
-    if (previousMatchIndex >= 0 && matchIndex !== previousMatchIndex + 1) {
-      score += 8;
-    }
-
-    previousMatchIndex = matchIndex;
-    valueIndex = matchIndex + 1;
-  }
-
-  return score;
-}
-
-function scoreFileMatch(file: FileSearchCandidate, query: string): number | null {
-  const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
-  if (tokens.length === 0) return null;
-
-  const name = file.name.toLowerCase();
-  const path = file.path.toLowerCase();
-  let score = 0;
-
-  for (const token of tokens) {
-    const nameScore = fuzzyScore(name, token);
-    const pathScore = fuzzyScore(path, token);
-    if (nameScore === null && pathScore === null) return null;
-
-    score += Math.min(
-      nameScore ?? Number.POSITIVE_INFINITY,
-      pathScore === null ? Number.POSITIVE_INFINITY : pathScore + 12
-    );
-  }
-
-  return score + file.path.length / 1000;
-}
 
 function matchesQuery(item: PaletteItem, query: string): boolean {
   if (!query) return true;
@@ -399,40 +328,28 @@ export function WorkspaceCommandPalette({
       });
   }, [hideFlows, onSelectSession, sessionResults]);
 
-  const localFiles = useMemo(() => flattenFileNodes(fileNodes), [fileNodes]);
-
   const fileItems = useMemo<PaletteItem[]>(() => {
     const trimmedQuery = query.trim();
     if (!onOpenFile || !trimmedQuery) return [];
 
-    const candidatesByPath = new Map<string, FileSearchCandidate>();
-    for (const file of localFiles) {
-      candidatesByPath.set(file.path, file);
-    }
-    for (const path of fileResults) {
-      if (!candidatesByPath.has(path)) {
-        candidatesByPath.set(path, { name: basename(path), path });
-      }
-    }
-
-    return Array.from(candidatesByPath.values())
-      .map((file) => ({ file, score: scoreFileMatch(file, trimmedQuery) }))
-      .filter((candidate): candidate is { file: FileSearchCandidate; score: number } => candidate.score !== null)
-      .sort((a, b) => a.score - b.score || a.file.path.localeCompare(b.file.path))
-      .slice(0, FILE_SEARCH_RESULT_LIMIT)
-      .map(({ file }) => ({
-        id: `file-${file.path}`,
-        title: file.name,
-        subtitle: file.path,
-        section: "Files",
-        icon: File,
-        keywords: file.path,
-        run: async () => {
-          onModeChange("knowledge");
-          await onOpenFile(file.path);
-        },
-      }));
-  }, [fileResults, localFiles, onModeChange, onOpenFile, query]);
+    return rankWorkspaceFileSearchResults({
+      fileNodes,
+      limit: FILE_SEARCH_RESULT_LIMIT,
+      query: trimmedQuery,
+      remotePaths: fileResults,
+    }).map((file) => ({
+      id: `file-${file.path}`,
+      title: file.name,
+      subtitle: file.path,
+      section: "Files",
+      icon: File,
+      keywords: file.path,
+      run: async () => {
+        onModeChange("knowledge");
+        await onOpenFile(file.path);
+      },
+    }));
+  }, [fileNodes, fileResults, onModeChange, onOpenFile, query]);
 
   const visibleItems = useMemo(() => {
     const trimmedQuery = query.trim();

--- a/apps/web/src/components/workspace/workspace-shell.tsx
+++ b/apps/web/src/components/workspace/workspace-shell.tsx
@@ -9,7 +9,7 @@ import type { SyncKbResult } from "@/app/api/instances/[slug]/sync-kb/route";
 import { useWorkspaceTheme } from "@/contexts/workspace-theme-context";
 import { useWorkspace } from "@/hooks/use-workspace";
 import type { KnowledgeGraphAgentSource } from "@/lib/kb-graph";
-import type { WorkspaceFileNode, WorkspaceSession } from "@/lib/opencode/types";
+import type { WorkspaceSession } from "@/lib/opencode/types";
 import { getDesktopFlowsHref, getDesktopWorkspaceHref } from "@/lib/runtime/desktop/current-vault";
 import {
   isProtectedWorkspacePath,
@@ -35,6 +35,7 @@ import {
   type WorkspaceStartPrompt,
 } from "@/lib/workspace-start-prompt";
 import { cn } from "@/lib/utils";
+import { flattenWorkspaceFileNodes } from "@/lib/workspace-file-search";
 
 import { useConfigStatus } from "@/hooks/use-config-status";
 import { useSkillsCatalog } from '@/hooks/use-skills-catalog'
@@ -353,6 +354,11 @@ export function WorkspaceShell({
   const reloadKnowledgeGraph = useCallback(() => {
     setKnowledgeGraphReloadKey((current) => current + 1);
   }, []);
+  const refreshKnowledgeReview = useCallback(() => {
+    workspace.refreshDiffs();
+    workspace.refreshFiles();
+    reloadKnowledgeGraph();
+  }, [reloadKnowledgeGraph, workspace]);
 
   const sessionsById = useMemo(() => {
     const map = new Map<string, WorkspaceSession>();
@@ -446,11 +452,9 @@ export function WorkspaceShell({
       } catch {
         // silent — auto-sync is best-effort
       }
-      workspace.refreshDiffs();
-      workspace.refreshFiles();
-      reloadKnowledgeGraph();
+      refreshKnowledgeReview();
     })();
-  }, [workspace, workspace.isConnected, slug, workspace.refreshDiffs, workspace.refreshFiles, reloadKnowledgeGraph]);
+  }, [refreshKnowledgeReview, slug, workspace.isConnected]);
 
   useEffect(() => {
     if (!workspace.isConnected || hasAutoStartedPrompt.current) return;
@@ -815,26 +819,20 @@ export function WorkspaceShell({
   }, [openFilePaths, workspace]);
 
   const handleSyncComplete = useCallback((status: SyncKbResult["status"]) => {
-    workspace.refreshDiffs();
-    workspace.refreshFiles();
-    reloadKnowledgeGraph();
+    refreshKnowledgeReview();
 
     if (status === "synced") {
       void refreshOpenFilesCache();
     }
-  }, [refreshOpenFilesCache, reloadKnowledgeGraph, workspace]);
+  }, [refreshKnowledgeReview, refreshOpenFilesCache]);
 
   const handlePublishComplete = useCallback(() => {
-    workspace.refreshDiffs();
-    workspace.refreshFiles();
-    reloadKnowledgeGraph();
-  }, [reloadKnowledgeGraph, workspace]);
+    refreshKnowledgeReview();
+  }, [refreshKnowledgeReview]);
 
   const handleResolveConflict = useCallback(
     async (path: string) => {
-      workspace.refreshDiffs();
-      workspace.refreshFiles();
-      reloadKnowledgeGraph();
+      refreshKnowledgeReview();
 
       if (!fileCacheRef.current[path]) return;
 
@@ -873,7 +871,7 @@ export function WorkspaceShell({
         });
       }
     },
-    [reloadKnowledgeGraph, workspace]
+    [refreshKnowledgeReview, workspace]
   );
 
   const handleSaveFile = useCallback(
@@ -900,13 +898,11 @@ export function WorkspaceShell({
         };
       });
 
-      workspace.refreshDiffs();
-      workspace.refreshFiles();
-      reloadKnowledgeGraph();
+      refreshKnowledgeReview();
 
       return { ok: true as const, hash: result.hash };
     },
-    [reloadKnowledgeGraph, workspace]
+    [refreshKnowledgeReview, workspace]
   );
 
   const handleReloadFile = useCallback(
@@ -973,25 +969,15 @@ export function WorkspaceShell({
         });
       }
 
-      workspace.refreshDiffs();
-      workspace.refreshFiles();
-      reloadKnowledgeGraph();
+      refreshKnowledgeReview();
 
       return { ok: true as const };
     },
-    [reloadKnowledgeGraph, workspace]
+    [refreshKnowledgeReview, workspace]
   );
 
   const flattenedFilePaths = useMemo(() => {
-    const paths: string[] = [];
-    const visit = (nodes: WorkspaceFileNode[]) => {
-      nodes.forEach((node) => {
-        if (node.type === "file") paths.push(node.path);
-        if (node.children && node.children.length > 0) visit(node.children);
-      });
-    };
-    visit(workspace.fileTree);
-    return paths;
+    return flattenWorkspaceFileNodes(workspace.fileTree).map((file) => file.path);
   }, [workspace.fileTree]);
 
   const filePathSet = useMemo(() => new Set(flattenedFilePaths), [flattenedFilePaths]);
@@ -1412,11 +1398,9 @@ export function WorkspaceShell({
   );
 
   const handleLearningProposalSentToReview = useCallback(() => {
-    void workspace.refreshDiffs();
-    void workspace.refreshFiles();
-    reloadKnowledgeGraph();
+    refreshKnowledgeReview();
     void refreshOpenFilesCache();
-  }, [refreshOpenFilesCache, reloadKnowledgeGraph, workspace]);
+  }, [refreshKnowledgeReview, refreshOpenFilesCache]);
 
   const handleFlowHumanResponseSubmitted = useCallback(async () => {
     await Promise.all([

--- a/apps/web/src/components/workspace/workspace-shell.tsx
+++ b/apps/web/src/components/workspace/workspace-shell.tsx
@@ -350,6 +350,11 @@ export function WorkspaceShell({
     reaperEnabled,
   });
   const skillsCatalog = useSkillsCatalog(slug)
+  const {
+    activeSessionId: workspaceActiveSessionId,
+    readFile: readWorkspaceFile,
+    selectSession: selectWorkspaceSession,
+  } = workspace;
   const [knowledgeGraphReloadKey, setKnowledgeGraphReloadKey] = useState(0);
   const reloadKnowledgeGraph = useCallback(() => {
     setKnowledgeGraphReloadKey((current) => current + 1);
@@ -673,7 +678,7 @@ export function WorkspaceShell({
       }
 
       if (prevMode !== resolvedNextMode) {
-        const currentActiveId = workspace.activeSessionId;
+        const currentActiveId = workspaceActiveSessionId;
         const currentSession = currentActiveId
           ? sessionsById.get(currentActiveId) ?? null
           : null;
@@ -682,7 +687,7 @@ export function WorkspaceShell({
         if (resolvedNextMode === "chat" && currentIsFlow) {
           const targetId = lastSessionByModeRef.current.chat;
           if (targetId !== currentActiveId) {
-            workspace.selectSession(targetId);
+            selectWorkspaceSession(targetId);
           }
         } else if (resolvedNextMode === "flows" && !currentIsFlow) {
           // Only switch the active session if we have a remembered flow to
@@ -690,7 +695,7 @@ export function WorkspaceShell({
           // does not auto-reselect a chat session in the background.
           const targetId = lastSessionByModeRef.current.flows;
           if (targetId && targetId !== currentActiveId) {
-            workspace.selectSession(targetId);
+            selectWorkspaceSession(targetId);
           }
         }
       }
@@ -713,7 +718,7 @@ export function WorkspaceShell({
       const query = params.toString();
       window.history.replaceState(window.history.state, "", query ? `/w/${slug}?${query}` : `/w/${slug}`);
     },
-    [isCompactLayout, sessionsById, slug, workspace, workspaceMode]
+    [isCompactLayout, selectWorkspaceSession, sessionsById, slug, workspaceActiveSessionId, workspaceMode]
   );
 
   const handleCreateSession = useCallback(async () => {
@@ -1215,76 +1220,92 @@ export function WorkspaceShell({
   }, [openFilePaths, fileCache]);
 
   // File handlers
-  async function handleOpenFile(path: string, options?: { forceKnowledgeMode?: boolean }) {
-    const resolvedPath = resolveFilePath(path);
-    const pathToOpen = resolvedPath || path;
-    const normalizedPath = normalizeWorkspacePath(pathToOpen);
+  const handleOpenFile = useCallback(
+    async (path: string, options?: { forceKnowledgeMode?: boolean }) => {
+      const resolvedPath = resolveFilePath(path);
+      const pathToOpen = resolvedPath || path;
+      const normalizedPath = normalizeWorkspacePath(pathToOpen);
 
-    if (!normalizedPath || isProtectedWorkspacePath(normalizedPath)) {
-      return;
-    }
+      if (!normalizedPath || isProtectedWorkspacePath(normalizedPath)) {
+        return;
+      }
 
-    const shouldOpenInKnowledge = options?.forceKnowledgeMode || isKnowledgeMode;
-    if (options?.forceKnowledgeMode && !isKnowledgeMode) {
-      handleWorkspaceModeChange("knowledge");
-    }
+      const shouldOpenInKnowledge = options?.forceKnowledgeMode || isKnowledgeMode;
+      if (options?.forceKnowledgeMode && !isKnowledgeMode) {
+        handleWorkspaceModeChange("knowledge");
+      }
 
-    if (shouldOpenInKnowledge) {
-      setOpenFilePaths(prev => prev.includes(normalizedPath) ? prev : [...prev, normalizedPath]);
-      setActiveFilePath(normalizedPath);
-      setRightTab("preview");
-      if (isCompactLayout) {
-        setMobileView("chat");
-      }
-    } else {
-      if (previewCloseTimerRef.current) {
-        clearTimeout(previewCloseTimerRef.current);
-        previewCloseTimerRef.current = null;
-      }
-      if (previewOpenFrameRef.current !== null) {
-        cancelAnimationFrame(previewOpenFrameRef.current);
-      }
-      setPreviewExpanded(false);
-      setPreviewFilePath(normalizedPath);
-      previewOpenFrameRef.current = requestAnimationFrame(() => {
-        setPreviewExpanded(true);
-        previewOpenFrameRef.current = null;
-      });
-      setRightCollapsedForMode(workspaceMode, false);
-      if (isCompactLayout) {
-        setMobileView("right");
-      }
-    }
-
-    // Load file content if not cached
-    if (!fileCacheRef.current[normalizedPath]) {
-      const result = await workspace.readFile(normalizedPath);
-      if (result) {
-        setFileCache(prev => ({
-          ...prev,
-           [normalizedPath]: {
-              content: result.content,
-              type: result.type,
-              title: normalizedPath.split('/').pop() ?? normalizedPath,
-              updatedAt: 'Just now',
-              size: `${(result.content.length / 1024).toFixed(1)} KB`,
-              hash: result.hash,
-            }
-         }));
-       } else {
-         setFileCache(prev => ({
-           ...prev,
-           [normalizedPath]: {
-              content: 'Unable to load file.',
-              type: 'raw',
-              title: normalizedPath.split('/').pop() ?? normalizedPath,
-              updatedAt: 'Error',
-              size: '0 KB',
-            }
-         }));
+      if (shouldOpenInKnowledge) {
+        setOpenFilePaths(prev => prev.includes(normalizedPath) ? prev : [...prev, normalizedPath]);
+        setActiveFilePath(normalizedPath);
+        setRightTab("preview");
+        if (isCompactLayout) {
+          setMobileView("chat");
+        }
+      } else {
+        if (previewCloseTimerRef.current) {
+          clearTimeout(previewCloseTimerRef.current);
+          previewCloseTimerRef.current = null;
+        }
+        if (previewOpenFrameRef.current !== null) {
+          cancelAnimationFrame(previewOpenFrameRef.current);
+        }
+        setPreviewExpanded(false);
+        setPreviewFilePath(normalizedPath);
+        previewOpenFrameRef.current = requestAnimationFrame(() => {
+          setPreviewExpanded(true);
+          previewOpenFrameRef.current = null;
+        });
+        setRightCollapsedForMode(workspaceMode, false);
+        if (isCompactLayout) {
+          setMobileView("right");
         }
       }
-    }
+
+      // Load file content if not cached
+      if (!fileCacheRef.current[normalizedPath]) {
+        const result = await readWorkspaceFile(normalizedPath);
+        if (result) {
+          setFileCache(prev => ({
+            ...prev,
+             [normalizedPath]: {
+                content: result.content,
+                type: result.type,
+                title: normalizedPath.split('/').pop() ?? normalizedPath,
+                updatedAt: 'Just now',
+                size: `${(result.content.length / 1024).toFixed(1)} KB`,
+                hash: result.hash,
+              }
+           }));
+         } else {
+           setFileCache(prev => ({
+             ...prev,
+             [normalizedPath]: {
+                content: 'Unable to load file.',
+                type: 'raw',
+                title: normalizedPath.split('/').pop() ?? normalizedPath,
+                updatedAt: 'Error',
+                size: '0 KB',
+              }
+           }));
+          }
+        }
+      },
+    [
+      handleWorkspaceModeChange,
+      isCompactLayout,
+      isKnowledgeMode,
+      resolveFilePath,
+      readWorkspaceFile,
+      setRightCollapsedForMode,
+      workspaceMode,
+    ]
+  );
+
+  const handleCommandPaletteOpenFile = useCallback(
+    (path: string) => handleOpenFile(path, { forceKnowledgeMode: true }),
+    [handleOpenFile]
+  );
 
   function handleClosePreview() {
     setPreviewExpanded(false);
@@ -1922,7 +1943,7 @@ export function WorkspaceShell({
         onOpenChange={setCommandPaletteOpen}
         onCreateSession={handleCreateSession}
         onModeChange={handleWorkspaceModeChange}
-        onOpenFile={(path) => handleOpenFile(path, { forceKnowledgeMode: true })}
+        onOpenFile={handleCommandPaletteOpenFile}
         onNavigateConnectors={navigateConnectors}
         onNavigateProviders={navigateProviders}
         onNavigateSettings={navigateSettings}

--- a/apps/web/src/components/workspace/workspace-shell.tsx
+++ b/apps/web/src/components/workspace/workspace-shell.tsx
@@ -1229,7 +1229,7 @@ export function WorkspaceShell({
   }, [openFilePaths, fileCache]);
 
   // File handlers
-  async function handleOpenFile(path: string) {
+  async function handleOpenFile(path: string, options?: { forceKnowledgeMode?: boolean }) {
     const resolvedPath = resolveFilePath(path);
     const pathToOpen = resolvedPath || path;
     const normalizedPath = normalizeWorkspacePath(pathToOpen);
@@ -1238,7 +1238,12 @@ export function WorkspaceShell({
       return;
     }
 
-    if (isKnowledgeMode) {
+    const shouldOpenInKnowledge = options?.forceKnowledgeMode || isKnowledgeMode;
+    if (options?.forceKnowledgeMode && !isKnowledgeMode) {
+      handleWorkspaceModeChange("knowledge");
+    }
+
+    if (shouldOpenInKnowledge) {
       setOpenFilePaths(prev => prev.includes(normalizedPath) ? prev : [...prev, normalizedPath]);
       setActiveFilePath(normalizedPath);
       setRightTab("preview");
@@ -1405,6 +1410,13 @@ export function WorkspaceShell({
     },
     [setRightCollapsedForMode, slug, workspaceMode]
   );
+
+  const handleLearningProposalSentToReview = useCallback(() => {
+    void workspace.refreshDiffs();
+    void workspace.refreshFiles();
+    reloadKnowledgeGraph();
+    void refreshOpenFilesCache();
+  }, [refreshOpenFilesCache, reloadKnowledgeGraph, workspace]);
 
   const handleFlowHumanResponseSubmitted = useCallback(async () => {
     await Promise.all([
@@ -1895,6 +1907,7 @@ export function WorkspaceShell({
             collapsed={isCompactLayout ? false : rightCollapsed}
             onToggleCollapse={isCompactLayout ? handleShowChat : handleToggleRight}
             onOpenSession={handleSelectSession}
+            onProposalSentToReview={handleLearningProposalSentToReview}
             refreshKey={learningRefreshKey}
           />
         );
@@ -1918,12 +1931,14 @@ export function WorkspaceShell({
       )}
     >
       <WorkspaceCommandPalette
+        fileNodes={workspace.fileTree}
         slug={slug}
         open={commandPaletteOpen}
         hideFlows={false}
         onOpenChange={setCommandPaletteOpen}
         onCreateSession={handleCreateSession}
         onModeChange={handleWorkspaceModeChange}
+        onOpenFile={(path) => handleOpenFile(path, { forceKnowledgeMode: true })}
         onNavigateConnectors={navigateConnectors}
         onNavigateProviders={navigateProviders}
         onNavigateSettings={navigateSettings}

--- a/apps/web/src/lib/__tests__/workspace-file-search.test.ts
+++ b/apps/web/src/lib/__tests__/workspace-file-search.test.ts
@@ -41,6 +41,7 @@ describe('workspace file search', () => {
   it('gets the basename for workspace paths', () => {
     expect(getWorkspacePathBasename('Deep/Vault/Roadmap.md')).toBe('Roadmap.md')
     expect(getWorkspacePathBasename('README.md')).toBe('README.md')
+    expect(getWorkspacePathBasename('Deep/Vault/')).toBe('Vault')
   })
 
   it('ranks fuzzy local and remote file matches', () => {

--- a/apps/web/src/lib/__tests__/workspace-file-search.test.ts
+++ b/apps/web/src/lib/__tests__/workspace-file-search.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import type { WorkspaceFileNode } from '@/lib/opencode/types'
+import {
+  flattenWorkspaceFileNodes,
+  getWorkspacePathBasename,
+  rankWorkspaceFileSearchResults,
+} from '@/lib/workspace-file-search'
+
+const fileNodes: WorkspaceFileNode[] = [
+  {
+    id: 'Company',
+    name: 'Company',
+    path: 'Company',
+    type: 'directory',
+    children: [
+      {
+        id: 'Company/Product Strategy.md',
+        name: 'Product Strategy.md',
+        path: 'Company/Product Strategy.md',
+        type: 'file',
+      },
+      {
+        id: 'Company/Research/Customer Interviews.md',
+        name: 'Customer Interviews.md',
+        path: 'Company/Research/Customer Interviews.md',
+        type: 'file',
+      },
+    ],
+  },
+]
+
+describe('workspace file search', () => {
+  it('flattens nested file nodes', () => {
+    expect(flattenWorkspaceFileNodes(fileNodes)).toEqual([
+      { name: 'Product Strategy.md', path: 'Company/Product Strategy.md' },
+      { name: 'Customer Interviews.md', path: 'Company/Research/Customer Interviews.md' },
+    ])
+  })
+
+  it('gets the basename for workspace paths', () => {
+    expect(getWorkspacePathBasename('Deep/Vault/Roadmap.md')).toBe('Roadmap.md')
+    expect(getWorkspacePathBasename('README.md')).toBe('README.md')
+  })
+
+  it('ranks fuzzy local and remote file matches', () => {
+    expect(rankWorkspaceFileSearchResults({
+      fileNodes,
+      limit: 10,
+      query: 'prd strat',
+      remotePaths: ['Deep/Vault/Roadmap.md'],
+    })).toEqual([
+      { name: 'Product Strategy.md', path: 'Company/Product Strategy.md' },
+    ])
+  })
+
+  it('deduplicates remote paths already present locally', () => {
+    expect(rankWorkspaceFileSearchResults({
+      fileNodes,
+      limit: 10,
+      query: 'customer',
+      remotePaths: ['Company/Research/Customer Interviews.md'],
+    })).toEqual([
+      { name: 'Customer Interviews.md', path: 'Company/Research/Customer Interviews.md' },
+    ])
+  })
+})

--- a/apps/web/src/lib/__tests__/workspace-paths.test.ts
+++ b/apps/web/src/lib/__tests__/workspace-paths.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  isGitWorkspacePath,
   isHiddenWorkspacePath,
   isInternalWorkspacePath,
   isNodeModulesWorkspacePath,
@@ -26,6 +27,8 @@ describe('workspace path normalization', () => {
   })
 
   it('detects protected workspace paths', () => {
+    expect(isProtectedWorkspacePath('.git')).toBe(true)
+    expect(isProtectedWorkspacePath('.git/config')).toBe(true)
     expect(isProtectedWorkspacePath('.gitignore')).toBe(true)
     expect(isProtectedWorkspacePath('.gitkeep')).toBe(true)
     expect(isProtectedWorkspacePath('Company/.gitkeep')).toBe(true)
@@ -41,7 +44,14 @@ describe('workspace path normalization', () => {
     expect(isNodeModulesWorkspacePath('packages/web/src/app/page.tsx')).toBe(false)
   })
 
+  it('detects git metadata paths', () => {
+    expect(isGitWorkspacePath('.git')).toBe(true)
+    expect(isGitWorkspacePath('.git/objects/pack')).toBe(true)
+    expect(isGitWorkspacePath('Company/.github/workflows/test.yml')).toBe(false)
+  })
+
   it('detects hidden workspace paths', () => {
+    expect(isHiddenWorkspacePath('.git/config')).toBe(true)
     expect(isHiddenWorkspacePath('.arche/attachments/a.txt')).toBe(true)
     expect(isHiddenWorkspacePath('node_modules/react/index.js')).toBe(true)
     expect(isHiddenWorkspacePath('Company/.gitkeep')).toBe(true)
@@ -52,6 +62,7 @@ describe('workspace path normalization', () => {
   it('validates context references', () => {
     expect(isValidContextReferencePath('')).toBe(false)
     expect(isValidContextReferencePath('.arche/secret.txt')).toBe(false)
+    expect(isValidContextReferencePath('.git/config')).toBe(false)
     expect(isValidContextReferencePath('AGENTS.md')).toBe(false)
     expect(isValidContextReferencePath('Company/.gitkeep')).toBe(false)
     expect(isValidContextReferencePath('node_modules/react/index.js')).toBe(false)

--- a/apps/web/src/lib/workspace-file-search.ts
+++ b/apps/web/src/lib/workspace-file-search.ts
@@ -1,0 +1,105 @@
+import type { WorkspaceFileNode } from '@/lib/opencode/types'
+
+export type WorkspaceFileSearchCandidate = {
+  name: string
+  path: string
+}
+
+export function getWorkspacePathBasename(path: string): string {
+  return path.split('/').pop() ?? path
+}
+
+export function flattenWorkspaceFileNodes(nodes: WorkspaceFileNode[]): WorkspaceFileSearchCandidate[] {
+  const result: WorkspaceFileSearchCandidate[] = []
+
+  for (const node of nodes) {
+    if (node.type === 'file') {
+      result.push({ name: node.name, path: node.path })
+      continue
+    }
+
+    if (node.children && node.children.length > 0) {
+      result.push(...flattenWorkspaceFileNodes(node.children))
+    }
+  }
+
+  return result
+}
+
+function fuzzyScore(value: string, token: string): number | null {
+  const exactIndex = value.indexOf(token)
+  if (exactIndex >= 0) return exactIndex
+
+  let valueIndex = 0
+  let previousMatchIndex = -1
+  let score = 50
+
+  for (const character of token) {
+    const matchIndex = value.indexOf(character, valueIndex)
+    if (matchIndex === -1) return null
+
+    score += matchIndex
+    if (previousMatchIndex >= 0 && matchIndex !== previousMatchIndex + 1) {
+      score += 8
+    }
+
+    previousMatchIndex = matchIndex
+    valueIndex = matchIndex + 1
+  }
+
+  return score
+}
+
+function scoreWorkspaceFileMatch(file: WorkspaceFileSearchCandidate, query: string): number | null {
+  const tokens = query.toLowerCase().split(/\s+/).filter(Boolean)
+  if (tokens.length === 0) return null
+
+  const name = file.name.toLowerCase()
+  const path = file.path.toLowerCase()
+  let score = 0
+
+  for (const token of tokens) {
+    const nameScore = fuzzyScore(name, token)
+    const pathScore = fuzzyScore(path, token)
+    if (nameScore === null && pathScore === null) return null
+
+    score += Math.min(
+      nameScore ?? Number.POSITIVE_INFINITY,
+      pathScore === null ? Number.POSITIVE_INFINITY : pathScore + 12
+    )
+  }
+
+  return score + file.path.length / 1000
+}
+
+export function rankWorkspaceFileSearchResults({
+  fileNodes,
+  limit,
+  query,
+  remotePaths,
+}: {
+  fileNodes: WorkspaceFileNode[]
+  limit: number
+  query: string
+  remotePaths: string[]
+}): WorkspaceFileSearchCandidate[] {
+  const trimmedQuery = query.trim()
+  if (!trimmedQuery) return []
+
+  const candidatesByPath = new Map<string, WorkspaceFileSearchCandidate>()
+  for (const file of flattenWorkspaceFileNodes(fileNodes)) {
+    candidatesByPath.set(file.path, file)
+  }
+  for (const path of remotePaths) {
+    if (!candidatesByPath.has(path)) {
+      candidatesByPath.set(path, { name: getWorkspacePathBasename(path), path })
+    }
+  }
+
+  return Array.from(candidatesByPath.values())
+    .map((file) => ({ file, score: scoreWorkspaceFileMatch(file, trimmedQuery) }))
+    .filter((candidate): candidate is { file: WorkspaceFileSearchCandidate; score: number } => candidate.score !== null)
+    .sort((a, b) => a.score - b.score || a.file.path.localeCompare(b.file.path))
+    .slice(0, limit)
+    .map(({ file }) => file)
+}

--- a/apps/web/src/lib/workspace-file-search.ts
+++ b/apps/web/src/lib/workspace-file-search.ts
@@ -6,7 +6,7 @@ export type WorkspaceFileSearchCandidate = {
 }
 
 export function getWorkspacePathBasename(path: string): string {
-  return path.split('/').pop() ?? path
+  return path.split('/').filter(Boolean).pop() ?? path
 }
 
 export function flattenWorkspaceFileNodes(nodes: WorkspaceFileNode[]): WorkspaceFileSearchCandidate[] {
@@ -72,13 +72,13 @@ function scoreWorkspaceFileMatch(file: WorkspaceFileSearchCandidate, query: stri
   return score + file.path.length / 1000
 }
 
-export function rankWorkspaceFileSearchResults({
-  fileNodes,
+export function rankWorkspaceFileSearchCandidates({
+  files,
   limit,
   query,
   remotePaths,
 }: {
-  fileNodes: WorkspaceFileNode[]
+  files: WorkspaceFileSearchCandidate[]
   limit: number
   query: string
   remotePaths: string[]
@@ -87,7 +87,7 @@ export function rankWorkspaceFileSearchResults({
   if (!trimmedQuery) return []
 
   const candidatesByPath = new Map<string, WorkspaceFileSearchCandidate>()
-  for (const file of flattenWorkspaceFileNodes(fileNodes)) {
+  for (const file of files) {
     candidatesByPath.set(file.path, file)
   }
   for (const path of remotePaths) {
@@ -102,4 +102,23 @@ export function rankWorkspaceFileSearchResults({
     .sort((a, b) => a.score - b.score || a.file.path.localeCompare(b.file.path))
     .slice(0, limit)
     .map(({ file }) => file)
+}
+
+export function rankWorkspaceFileSearchResults({
+  fileNodes,
+  limit,
+  query,
+  remotePaths,
+}: {
+  fileNodes: WorkspaceFileNode[]
+  limit: number
+  query: string
+  remotePaths: string[]
+}): WorkspaceFileSearchCandidate[] {
+  return rankWorkspaceFileSearchCandidates({
+    files: flattenWorkspaceFileNodes(fileNodes),
+    limit,
+    query,
+    remotePaths,
+  })
 }

--- a/apps/web/src/lib/workspace-paths.ts
+++ b/apps/web/src/lib/workspace-paths.ts
@@ -42,6 +42,11 @@ export function isNodeModulesWorkspacePath(path: string): boolean {
   return segments.some((segment) => segment.toLowerCase() === 'node_modules')
 }
 
+export function isGitWorkspacePath(path: string): boolean {
+  const segments = splitPathSegments(path)
+  return segments.some((segment) => segment.toLowerCase() === '.git')
+}
+
 function isGitkeepWorkspacePath(path: string): boolean {
   const segments = splitPathSegments(path)
   return segments.some((segment) => segment.toLowerCase() === '.gitkeep')
@@ -50,6 +55,7 @@ function isGitkeepWorkspacePath(path: string): boolean {
 export function isProtectedWorkspacePath(path: string): boolean {
   return (
     isRootProtectedWorkspaceFile(path) ||
+    isGitWorkspacePath(path) ||
     isNodeModulesWorkspacePath(path) ||
     isGitkeepWorkspacePath(path)
   )


### PR DESCRIPTION
Summary: Hide .git workspace paths, add fuzzy file results to the command palette, render Knowledge Curator proposals as Markdown, rename the proposal action to Send to review, refresh knowledge/review data after sending proposals, and polish Recent runs. Verification: pnpm test (passed); pnpm lint (passed with existing warnings only); bash scripts/check-podman-images.sh (passed); git diff --check (passed).