### PR TITLE
fix(workspace): recover pending tool permissions

### DIFF
--- a/apps/web/src/actions/__tests__/opencode.test.ts
+++ b/apps/web/src/actions/__tests__/opencode.test.ts
@@ -136,6 +136,7 @@ const mockSessionAbort = vi.fn()
 const mockSessionStatus = vi.fn()
 const mockSessionDiff = vi.fn()
 const mockAppAgents = vi.fn()
+const mockPermissionList = vi.fn()
 
 function makeClient() {
   return {
@@ -151,6 +152,7 @@ function makeClient() {
       status: mockSessionStatus,
       diff: mockSessionDiff,
     },
+    permission: { list: mockPermissionList },
     config: { providers: vi.fn() },
     app: { agents: mockAppAgents },
   } as never
@@ -162,6 +164,7 @@ beforeEach(() => {
   mockCreateInstanceClient.mockResolvedValue(makeClient())
   mockAbortSessionFamilyAndConfirmIdle.mockResolvedValue(true)
   mockSessionStatus.mockResolvedValue({ data: {} })
+  mockPermissionList.mockResolvedValue({ data: [] })
   mockMessageRunService.abortActiveRun.mockResolvedValue(undefined)
   mockSlackService.deleteSessionBindingsByOpenCodeSessionId.mockResolvedValue({ dm: 0, thread: 0 })
   // Mock global fetch
@@ -709,6 +712,91 @@ describe('listMessagesAction', () => {
     mockSessionStatus.mockRejectedValue(new Error('status fail'))
     const result = await listMessagesAction('alice', 'sess-1')
     expect(result.ok).toBe(true)
+  })
+
+  it('hydrates pending permissions onto their assistant message', async () => {
+    mockSessionMessages.mockResolvedValue({
+      data: [
+        {
+          info: { id: 'msg-1', role: 'assistant', time: { created: Date.now() } },
+          parts: [{ type: 'tool', id: 'tool-1', tool: 'deploy', state: { status: 'pending', input: {} } }],
+        },
+      ],
+    })
+    mockPermissionList.mockResolvedValue({
+      data: [
+        {
+          always: ['*'],
+          id: 'permission-1',
+          metadata: { tool: 'deploy' },
+          patterns: ['*'],
+          permission: 'deploy',
+          sessionID: 'sess-1',
+          tool: { callID: 'tool-1', messageID: 'msg-1' },
+        },
+      ],
+    })
+
+    const result = await listMessagesAction('alice', 'sess-1')
+
+    expect(result.messages![0]).toMatchObject({
+      pending: false,
+      parts: [
+        { type: 'tool', id: 'tool-1' },
+        {
+          type: 'permission',
+          id: 'permission:permission-1',
+          permissionId: 'permission-1',
+          sessionId: 'sess-1',
+          state: 'pending',
+        },
+      ],
+    })
+  })
+
+  it('continues loading messages when pending permissions cannot be listed', async () => {
+    mockSessionMessages.mockResolvedValue({
+      data: [
+        {
+          info: { id: 'msg-1', role: 'assistant', time: { created: Date.now() } },
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+    })
+    mockPermissionList.mockRejectedValue(new Error('permission list failed'))
+
+    const result = await listMessagesAction('alice', 'sess-1')
+
+    expect(result.ok).toBe(true)
+    expect(result.messages![0].parts).toEqual([{ type: 'text', text: 'Hello' }])
+  })
+
+  it('does not restore permissions for completed messages', async () => {
+    mockSessionMessages.mockResolvedValue({
+      data: [
+        {
+          info: { id: 'msg-1', role: 'assistant', time: { created: Date.now(), completed: Date.now() } },
+          parts: [{ type: 'text', text: 'Done' }],
+        },
+      ],
+    })
+    mockPermissionList.mockResolvedValue({
+      data: [
+        {
+          always: ['*'],
+          id: 'permission-1',
+          metadata: { tool: 'deploy' },
+          patterns: ['*'],
+          permission: 'deploy',
+          sessionID: 'sess-1',
+          tool: { callID: 'tool-1', messageID: 'msg-1' },
+        },
+      ],
+    })
+
+    const result = await listMessagesAction('alice', 'sess-1')
+
+    expect(result.messages![0].parts).toEqual([{ type: 'text', text: 'Done' }])
   })
 
   it('handles exceptions', async () => {

--- a/apps/web/src/actions/__tests__/opencode.test.ts
+++ b/apps/web/src/actions/__tests__/opencode.test.ts
@@ -26,13 +26,6 @@ vi.mock('@/lib/opencode/transform', () => ({
   transformParts: vi.fn((parts: unknown[]) => parts),
 }))
 
-vi.mock('@/lib/workspace-message-state', () => ({
-  deriveWorkspaceMessageRuntimeState: vi.fn(() => ({
-    pending: false,
-    statusInfo: undefined,
-  })),
-}))
-
 vi.mock('@/lib/providers/catalog', () => ({
   getCanonicalProviderId: vi.fn((id: string) => id),
   getProviderLabel: vi.fn((id: string) => id),
@@ -714,7 +707,7 @@ describe('listMessagesAction', () => {
     expect(result.ok).toBe(true)
   })
 
-  it('hydrates pending permissions onto their assistant message', async () => {
+  it('hydrates pending permissions onto their assistant message and keeps it pending', async () => {
     mockSessionMessages.mockResolvedValue({
       data: [
         {
@@ -740,7 +733,11 @@ describe('listMessagesAction', () => {
     const result = await listMessagesAction('alice', 'sess-1')
 
     expect(result.messages![0]).toMatchObject({
-      pending: false,
+      pending: true,
+      statusInfo: {
+        status: 'tool-calling',
+        detail: 'permission_required',
+      },
       parts: [
         { type: 'tool', id: 'tool-1' },
         {
@@ -751,6 +748,80 @@ describe('listMessagesAction', () => {
           state: 'pending',
         },
       ],
+    })
+  })
+
+  it('does not hydrate foreign-session or unlinked permissions', async () => {
+    mockSessionMessages.mockResolvedValue({
+      data: [
+        {
+          info: { id: 'msg-1', role: 'assistant', time: { created: Date.now() } },
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+    })
+    mockPermissionList.mockResolvedValue({
+      data: [
+        {
+          id: 'foreign-permission',
+          metadata: { tool: 'deploy' },
+          patterns: ['*'],
+          permission: 'deploy',
+          sessionID: 'other-session',
+          tool: { callID: 'tool-1', messageID: 'msg-1' },
+        },
+        {
+          id: 'unlinked-permission',
+          metadata: { tool: 'deploy' },
+          patterns: ['*'],
+          permission: 'deploy',
+          sessionID: 'sess-1',
+          tool: { callID: 'tool-2', messageID: '' },
+        },
+      ],
+    })
+
+    const result = await listMessagesAction('alice', 'sess-1')
+
+    expect(result).toMatchObject({
+      ok: true,
+      messages: [
+        {
+          id: 'msg-1',
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+    })
+  })
+
+  it.each([
+    ['a non-array result', { id: 'permission-1' }],
+    ['a permission with non-array patterns', [
+      {
+        id: 'permission-1',
+        metadata: { tool: 'deploy' },
+        patterns: '*',
+        permission: 'deploy',
+        sessionID: 'sess-1',
+        tool: { callID: 'tool-1', messageID: 'msg-1' },
+      },
+    ]],
+  ])('continues loading messages when permission.list returns %s', async (_description, data) => {
+    mockSessionMessages.mockResolvedValue({
+      data: [
+        {
+          info: { id: 'msg-1', role: 'assistant', time: { created: Date.now() } },
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+    })
+    mockPermissionList.mockResolvedValue({ data })
+
+    const result = await listMessagesAction('alice', 'sess-1')
+
+    expect(result).toMatchObject({
+      ok: true,
+      messages: [{ id: 'msg-1', parts: [{ type: 'text', text: 'Hello' }] }],
     })
   })
 

--- a/apps/web/src/actions/opencode.ts
+++ b/apps/web/src/actions/opencode.ts
@@ -66,6 +66,47 @@ function extractUserTextContent(parts: ReturnType<typeof transformParts>): strin
   return firstText ? firstText.text : "";
 }
 
+type PendingPermission = {
+  always: string[];
+  id: string;
+  metadata: Record<string, unknown>;
+  patterns: string[];
+  permission: string;
+  sessionID: string;
+  tool?: {
+    callID: string;
+    messageID: string;
+  };
+};
+
+function getPendingPermissionPartsByMessageId(
+  permissions: PendingPermission[],
+  sessionId: string
+) {
+  const partsByMessageId = new Map<string, ReturnType<typeof transformParts>>();
+
+  for (const permission of permissions) {
+    if (permission.sessionID !== sessionId || !permission.tool?.messageID) continue;
+
+    const parts = partsByMessageId.get(permission.tool.messageID) ?? [];
+    parts.push({
+      type: "permission",
+      id: `permission:${permission.id}`,
+      permissionId: permission.id,
+      sessionId,
+      title: permission.permission,
+      state: "pending",
+      callId: permission.tool.callID,
+      pattern: permission.patterns.join(", "),
+      permissionType: "tool",
+      metadata: permission.metadata,
+    });
+    partsByMessageId.set(permission.tool.messageID, parts);
+  }
+
+  return partsByMessageId;
+}
+
 async function getAuthorizedClientContext(slug: string) {
   const session = await getSession();
   if (!session) return { error: "unauthorized" as const, client: null };
@@ -761,15 +802,28 @@ export async function listMessagesAction(
       // Keep unknown status when status endpoint fails.
     }
 
+    const pendingPermissions = await client!.permission.list()
+      .then((result) => result.data ?? [])
+      .catch(() => []);
+    const pendingPermissionPartsByMessageId = getPendingPermissionPartsByMessageId(
+      pendingPermissions,
+      sessionId
+    );
+
     const transformed: WorkspaceMessage[] = [];
     for (const m of messages) {
       const role = normalizeMessageRole(m.info.role);
       if (!role) continue;
 
-      const parts = transformParts(m.parts ?? []);
       const rawTimestamp = m.info.time?.created;
       const completedAt = (m.info.time as { completed?: number } | undefined)
         ?.completed;
+      const parts = [
+        ...transformParts(m.parts ?? []),
+        ...(typeof completedAt === "number" && completedAt > 0
+          ? []
+          : pendingPermissionPartsByMessageId.get(m.info.id) ?? []),
+      ];
       const runtimeState = deriveWorkspaceMessageRuntimeState({
         role,
         completedAt,

--- a/apps/web/src/actions/opencode.ts
+++ b/apps/web/src/actions/opencode.ts
@@ -67,26 +67,45 @@ function extractUserTextContent(parts: ReturnType<typeof transformParts>): strin
 }
 
 type PendingPermission = {
-  always: string[];
   id: string;
-  metadata: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
   patterns: string[];
   permission: string;
   sessionID: string;
-  tool?: {
-    callID: string;
+  tool: {
+    callID?: string;
     messageID: string;
   };
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isPendingPermission(value: unknown): value is PendingPermission {
+  if (!isRecord(value) || !isRecord(value.tool)) return false;
+
+  return (
+    typeof value.id === "string" &&
+    typeof value.permission === "string" &&
+    typeof value.sessionID === "string" &&
+    typeof value.tool.messageID === "string" &&
+    (value.tool.callID === undefined || typeof value.tool.callID === "string") &&
+    Array.isArray(value.patterns) &&
+    value.patterns.every((pattern) => typeof pattern === "string") &&
+    (value.metadata === undefined || isRecord(value.metadata))
+  );
+}
+
 function getPendingPermissionPartsByMessageId(
-  permissions: PendingPermission[],
+  permissions: unknown,
   sessionId: string
 ) {
   const partsByMessageId = new Map<string, ReturnType<typeof transformParts>>();
+  if (!Array.isArray(permissions)) return partsByMessageId;
 
   for (const permission of permissions) {
-    if (permission.sessionID !== sessionId || !permission.tool?.messageID) continue;
+    if (!isPendingPermission(permission) || permission.sessionID !== sessionId) continue;
 
     const parts = partsByMessageId.get(permission.tool.messageID) ?? [];
     parts.push({
@@ -96,10 +115,10 @@ function getPendingPermissionPartsByMessageId(
       sessionId,
       title: permission.permission,
       state: "pending",
-      callId: permission.tool.callID,
+      ...(permission.tool.callID && { callId: permission.tool.callID }),
       pattern: permission.patterns.join(", "),
       permissionType: "tool",
-      metadata: permission.metadata,
+      ...(permission.metadata && { metadata: permission.metadata }),
     });
     partsByMessageId.set(permission.tool.messageID, parts);
   }
@@ -803,7 +822,7 @@ export async function listMessagesAction(
     }
 
     const pendingPermissions = await client!.permission.list()
-      .then((result) => result.data ?? [])
+      .then((result) => result.data)
       .catch(() => []);
     const pendingPermissionPartsByMessageId = getPendingPermissionPartsByMessageId(
       pendingPermissions,

--- a/apps/web/src/app/api/w/[slug]/chat/permissions/[permissionId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/permissions/[permissionId]/__tests__/route.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   validateSameOrigin: vi.fn(() => ({ ok: true })),
   validateDesktopToken: vi.fn(() => true),
   instanceService: { findCredentialsBySlug: vi.fn() },
+  auditEvent: vi.fn(),
   decryptPassword: vi.fn(() => 'secret'),
   getInstanceUrl: vi.fn(() => 'http://test-slug:3000'),
 }))
@@ -20,6 +21,7 @@ vi.mock('@/lib/runtime/desktop/token', () => ({
   DESKTOP_TOKEN_HEADER: 'x-arche-desktop-token',
   validateDesktopToken: mocks.validateDesktopToken,
 }))
+vi.mock('@/lib/auth', () => ({ auditEvent: mocks.auditEvent }))
 vi.mock('@/lib/services', () => ({ instanceService: mocks.instanceService }))
 vi.mock('@/lib/spawner/crypto', () => ({ decryptPassword: mocks.decryptPassword }))
 vi.mock('@/lib/opencode/client', () => ({ getInstanceUrl: mocks.getInstanceUrl }))
@@ -59,6 +61,7 @@ describe('POST /api/w/[slug]/chat/permissions/[permissionId]', () => {
     })
     mocks.decryptPassword.mockReturnValue('secret')
     mocks.getInstanceUrl.mockReturnValue('http://test-slug:3000')
+    mocks.auditEvent.mockResolvedValue(undefined)
   })
 
   it('forwards permission response to OpenCode', async () => {
@@ -77,6 +80,27 @@ describe('POST /api/w/[slug]/chat/permissions/[permissionId]', () => {
         body: JSON.stringify({ response: 'always' }),
       }),
     )
+  })
+
+  it('audits an administrator response for another workspace', async () => {
+    mocks.getSession.mockResolvedValue({
+      user: { id: 'admin-1', email: 'admin@test.com', slug: 'admin', role: 'ADMIN' },
+      sessionId: 'admin-session',
+    })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 200 })))
+
+    const res = await POST(makeRequest({ sessionId: 's1', response: 'always' }), params())
+
+    expect(res.status).toBe(200)
+    expect(mocks.auditEvent).toHaveBeenCalledWith(expect.objectContaining({
+      actorUserId: 'admin-1',
+      metadata: {
+        permissionId: 'perm-1',
+        response: 'always',
+        sessionId: 's1',
+        slug: 'alice',
+      },
+    }))
   })
 
   it('returns 400 when required fields are missing', async () => {

--- a/apps/web/src/app/api/w/[slug]/chat/permissions/[permissionId]/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/permissions/[permissionId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { auditEvent } from '@/lib/auth'
 import { getInstanceUrl } from '@/lib/opencode/client'
 import { withAuth } from '@/lib/runtime/with-auth'
 import { instanceService } from '@/lib/services'
@@ -23,7 +24,7 @@ function jsonErrorResponse(status: number, error: string) {
 export const POST = withAuth<
   { ok: true } | { error: string },
   { slug: string; permissionId: string }
->({ csrf: true }, async (request: NextRequest, { slug, params: { permissionId } }) => {
+>({ csrf: true }, async (request: NextRequest, { slug, params: { permissionId }, user }) => {
   const instance = await instanceService.findCredentialsBySlug(slug)
 
   if (!instance || !instance.serverPassword || instance.status !== 'running') {
@@ -63,6 +64,12 @@ export const POST = withAuth<
   if (!response.ok) {
     return jsonErrorResponse(response.status >= 400 && response.status < 500 ? response.status : 502, 'permission_reply_failed')
   }
+
+  await auditEvent({
+    actorUserId: user.id,
+    action: 'workspace.permission_replied',
+    metadata: { permissionId, response: body.response, sessionId, slug },
+  })
 
   return NextResponse.json({ ok: true })
 })

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/route.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/route.test.ts
@@ -826,6 +826,62 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     expect(text).toContain('"response":"always"')
   })
 
+  it('waits for a permission that existed before a resume subscription', async () => {
+    const listPermissions = vi.fn().mockResolvedValue({
+      data: [
+        { id: 'perm-1', sessionID: 's1' },
+        { id: 'foreign-permission', sessionID: 'other-session' },
+      ],
+    })
+    mocks.createConfiguredOpencodeClient.mockResolvedValue({
+      permission: { list: listPermissions },
+    })
+    mocks.getIdleFinalizationOutcome.mockImplementation(({
+      assistantPartSeen,
+      resume,
+    }: {
+      assistantPartSeen: boolean
+      resume: boolean
+    }) => resume && !assistantPartSeen ? 'resume_incomplete' : 'complete')
+    vi.stubGlobal('fetch', mockOpenCodeFetch([
+      { type: 'session.idle', properties: { info: { sessionID: 's1' } } },
+      {
+        type: 'permission.replied',
+        properties: {
+          permission: { id: 'perm-1', sessionID: 's1' },
+          response: 'once',
+        },
+      },
+      {
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            id: 'part-1',
+            messageID: 'assistant-1',
+            sessionID: 's1',
+            text: 'Resumed response',
+            type: 'text',
+          },
+        },
+      },
+      { type: 'session.idle', properties: { info: { sessionID: 's1' } } },
+    ]))
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({
+      sessionId: 's1',
+      resume: true,
+      messageId: 'assistant-1',
+    }), params())
+
+    const text = await res.text()
+
+    expect(listPermissions).toHaveBeenCalledOnce()
+    expect(text).toContain('event: permission-replied')
+    expect(text).toContain('event: done')
+    expect(text).not.toContain('resume_incomplete')
+  })
+
   it('streams an error when the upstream event subscription fails', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 500 })))
 

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -566,6 +566,22 @@ export const POST = withAuth(
           ? RESUME_STREAM_RELEVANT_EVENT_TIMEOUT_MS
           : SEND_STREAM_RELEVANT_EVENT_TIMEOUT_MS
 
+        if (resume) {
+          try {
+            const client = await createConfiguredOpencodeClient({ authHeader, baseUrl })
+            const result = await client.permission.list()
+            const permissions = Array.isArray(result.data) ? result.data : []
+            for (const permission of permissions) {
+              if (!isRecord(permission) || getString(permission.sessionID) !== sessionId) continue
+
+              const permissionId = getString(permission.id)
+              if (permissionId) pendingPermissionIds.add(permissionId)
+            }
+          } catch (error) {
+            console.warn('[chat/stream] Failed to list pending resume permissions', { error, sessionId })
+          }
+        }
+
         const markRelevantEvent = () => {
           const now = Date.now()
           lastRelevantEventAt = now

--- a/apps/web/src/lib/__tests__/workspace-message-state.test.ts
+++ b/apps/web/src/lib/__tests__/workspace-message-state.test.ts
@@ -59,6 +59,34 @@ describe('deriveWorkspaceMessageRuntimeState', () => {
     expect(result.statusInfo?.toolName).toBe('read_file')
   })
 
+  it('keeps pending permission requests pending', () => {
+    const parts: MessagePart[] = [
+      {
+        type: 'permission',
+        id: 'permission:permission-1',
+        permissionId: 'permission-1',
+        sessionId: 'session-1',
+        title: 'Deploy application',
+        pattern: 'deploy',
+        state: 'pending',
+      },
+    ]
+
+    const result = deriveWorkspaceMessageRuntimeState({
+      role: 'assistant',
+      parts,
+    })
+
+    expect(result).toEqual({
+      pending: true,
+      statusInfo: {
+        status: 'tool-calling',
+        toolName: 'deploy',
+        detail: 'permission_required',
+      },
+    })
+  })
+
   it('does not keep plain text assistants pending without completedAt', () => {
     const parts: MessagePart[] = [{ type: 'text', text: 'done' }]
 

--- a/apps/web/src/lib/__tests__/workspace-message-state.test.ts
+++ b/apps/web/src/lib/__tests__/workspace-message-state.test.ts
@@ -67,8 +67,9 @@ describe('deriveWorkspaceMessageRuntimeState', () => {
         permissionId: 'permission-1',
         sessionId: 'session-1',
         title: 'Deploy application',
-        pattern: 'deploy',
+        pattern: '*',
         state: 'pending',
+        metadata: { tool: 'deploy' },
       },
     ]
 

--- a/apps/web/src/lib/workspace-message-state.ts
+++ b/apps/web/src/lib/workspace-message-state.ts
@@ -65,11 +65,17 @@ export function deriveWorkspaceMessageRuntimeState({
   }
 
   if (lastPart.type === 'permission' && lastPart.state === 'pending') {
+    const metadataTool = lastPart.metadata?.tool
+    const metadataToolName = lastPart.metadata?.toolName
     return {
       pending: true,
       statusInfo: {
         status: 'tool-calling',
-        toolName: lastPart.pattern,
+        toolName: typeof metadataTool === 'string' && metadataTool.trim()
+          ? metadataTool
+          : typeof metadataToolName === 'string' && metadataToolName.trim()
+            ? metadataToolName
+            : lastPart.pattern,
         detail: 'permission_required',
       },
     }

--- a/apps/web/src/lib/workspace-message-state.ts
+++ b/apps/web/src/lib/workspace-message-state.ts
@@ -64,6 +64,17 @@ export function deriveWorkspaceMessageRuntimeState({
     return { pending: true, statusInfo: { status: 'thinking', detail: lastPart.error } }
   }
 
+  if (lastPart.type === 'permission' && lastPart.state === 'pending') {
+    return {
+      pending: true,
+      statusInfo: {
+        status: 'tool-calling',
+        toolName: lastPart.pattern,
+        detail: 'permission_required',
+      },
+    }
+  }
+
   if (typeof completedAt === 'number' && completedAt > 0) {
     return { pending: false }
   }


### PR DESCRIPTION
## Summary
- restore pending OpenCode tool permissions when a workspace conversation reloads
- keep the assistant message pending while it awaits an approval
- avoid rendering obsolete approvals for completed messages

## Verification
- pnpm test
- pnpm lint
- bash scripts/check-podman-images.sh