### PR TITLE
refactor(workspace): redesign chat permission approval card

### DIFF
--- a/apps/web/src/components/workspace/__tests__/chat-panel-interactions.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/chat-panel-interactions.test.tsx
@@ -159,7 +159,7 @@ describe("ChatPanel interactions", () => {
       onAnswerPermission,
     });
 
-    const allowButton = screen.getByRole("button", { name: "Allow" }) as HTMLButtonElement;
+    const allowButton = screen.getByRole("button", { name: "Allow once" }) as HTMLButtonElement;
 
     expect(allowButton.disabled).toBe(true);
     fireEvent.click(allowButton);

--- a/apps/web/src/components/workspace/chat-panel/__tests__/messages.test.tsx
+++ b/apps/web/src/components/workspace/chat-panel/__tests__/messages.test.tsx
@@ -283,13 +283,13 @@ describe("ChatPanelMessages", () => {
       ],
     });
 
-    expect(screen.getByText("Tool approval required")).toBeTruthy();
+    expect(screen.getByText("Approval required")).toBeTruthy();
     expect(screen.getByText("Create Linear issue")).toBeTruthy();
 
     expect(screen.getByRole("button", { name: "Reject" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Always allow for this session" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Allow for this session" })).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Allow" }));
+    fireEvent.click(screen.getByRole("button", { name: "Allow once" }));
 
     await waitFor(() => {
       expect(onAnswerPermission).toHaveBeenCalledWith("s1", "perm-1", "once");

--- a/apps/web/src/components/workspace/chat-panel/__tests__/permission-card.test.tsx
+++ b/apps/web/src/components/workspace/chat-panel/__tests__/permission-card.test.tsx
@@ -1,0 +1,141 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { PermissionCard } from '@/components/workspace/chat-panel/permission-card'
+import type { MessagePart, PermissionResponse, PermissionState } from '@/lib/opencode/types'
+
+type PermissionPart = Extract<MessagePart, { type: 'permission' }>
+
+function createPart(state: PermissionState): PermissionPart {
+  return {
+    type: 'permission',
+    id: 'part-1',
+    permissionId: 'perm-1',
+    sessionId: 's1',
+    title: 'Run command: pnpm test',
+    state,
+    pattern: 'bash(pnpm test)',
+    metadata: { tool: 'bash' },
+  }
+}
+
+describe('PermissionCard', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the pending state with a warning surface', () => {
+    const { container } = render(<PermissionCard part={createPart('pending')} />)
+
+    const card = container.firstElementChild
+    expect(card?.className).toContain('border-warning/25')
+    expect(card?.className).toContain('bg-warning/5')
+    expect(screen.getByText('Approval required')).toBeTruthy()
+
+    const actionLine = screen.getByText(/Run command: pnpm test/)
+    expect(actionLine.className).toContain('truncate')
+    expect(actionLine.textContent).toContain('bash:')
+    expect(actionLine.textContent).toContain('Run command: pnpm test')
+
+    const metadata = screen.getByText('bash:')
+    expect(metadata.className).toContain('font-mono')
+    expect(metadata.className).toContain('chat-text-micro')
+    expect(metadata.className).toContain('text-muted-foreground')
+  })
+
+  it('renders the approved state with a primary surface and no actions', () => {
+    const { container } = render(<PermissionCard part={createPart('approved')} />)
+
+    const card = container.firstElementChild
+    expect(card?.className).toContain('border-primary/25')
+    expect(card?.className).toContain('bg-primary/5')
+    expect(card?.className).not.toContain('warning')
+    expect(screen.getByText('Permission granted')).toBeTruthy()
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('renders the rejected state with a destructive surface and no actions', () => {
+    const { container } = render(<PermissionCard part={createPart('rejected')} />)
+
+    const card = container.firstElementChild
+    expect(card?.className).toContain('border-destructive/25')
+    expect(card?.className).toContain('bg-destructive/5')
+    expect(screen.getByText('Permission rejected')).toBeTruthy()
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('renders explicit action labels with a homogeneous solid hierarchy', () => {
+    render(<PermissionCard part={createPart('pending')} onAnswerPermission={vi.fn()} />)
+
+    const allowOnce = screen.getByRole('button', { name: 'Allow once' })
+    expect(allowOnce.className).toContain('bg-warning')
+    expect(allowOnce.className).toContain('text-foreground')
+
+    const session = screen.getByRole('button', { name: 'Allow for this session' })
+    expect(session.className).toContain('bg-primary-foreground/60')
+    expect(session.className).toContain('dark:bg-foreground/5')
+
+    const reject = screen.getByRole('button', { name: 'Reject' })
+    expect(reject.className).toContain('bg-destructive')
+    expect(reject.className).toContain('dark:bg-destructive/15')
+    expect(reject.className).toContain('dark:text-destructive')
+  })
+
+  it.each([
+    ['Allow once', 'once'],
+    ['Reject', 'reject'],
+    ['Allow for this session', 'always'],
+  ] as const)('sends %s as %s', async (label, expected) => {
+    const onAnswerPermission = vi.fn(async () => true)
+    render(<PermissionCard part={createPart('pending')} onAnswerPermission={onAnswerPermission} />)
+
+    fireEvent.click(screen.getByRole('button', { name: label }))
+
+    await waitFor(() => {
+      expect(onAnswerPermission).toHaveBeenCalledWith('s1', 'perm-1', expected satisfies PermissionResponse)
+    })
+  })
+
+  it('announces submission failures with an alert', async () => {
+    const onAnswerPermission = vi.fn(async () => false)
+    render(<PermissionCard part={createPart('pending')} onAnswerPermission={onAnswerPermission} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allow once' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('Could not send permission response.')
+  })
+
+  it('shows an unambiguous sending state and disables all actions while submitting', async () => {
+    let resolveAnswer: (value: boolean) => void = () => undefined
+    const onAnswerPermission = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveAnswer = resolve
+        }),
+    )
+    render(<PermissionCard part={createPart('pending')} onAnswerPermission={onAnswerPermission} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allow once' }))
+
+    const sending = await screen.findByRole('button', { name: 'Sending...' })
+    expect(sending).toBeTruthy()
+    for (const button of screen.getAllByRole('button')) {
+      expect((button as HTMLButtonElement).disabled).toBe(true)
+    }
+
+    resolveAnswer(true)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Allow once' })).toBeTruthy()
+    })
+  })
+
+  it('keeps actions disabled without a handler (read-only conversation)', () => {
+    render(<PermissionCard part={createPart('pending')} />)
+
+    for (const button of screen.getAllByRole('button')) {
+      expect((button as HTMLButtonElement).disabled).toBe(true)
+    }
+  })
+})

--- a/apps/web/src/components/workspace/chat-panel/permission-card.tsx
+++ b/apps/web/src/components/workspace/chat-panel/permission-card.tsx
@@ -2,9 +2,11 @@
 
 import { useCallback, useState } from 'react'
 
-import { CheckCircle, Info, XCircle } from '@phosphor-icons/react'
+import { CheckCircle, Warning, XCircle } from '@phosphor-icons/react'
 
-import type { MessagePart, PermissionResponse } from '@/lib/opencode/types'
+import { Button } from '@/components/ui/button'
+import type { MessagePart, PermissionResponse, PermissionState } from '@/lib/opencode/types'
+import { cn } from '@/lib/utils'
 
 type PermissionPart = Extract<MessagePart, { type: 'permission' }>
 
@@ -17,6 +19,24 @@ type PermissionCardProps = {
   part: PermissionPart
 }
 
+const STATE_STYLES: Record<PermissionState, { container: string; chip: string; title: string }> = {
+  pending: {
+    container: 'border-warning/25 bg-warning/5',
+    chip: 'bg-warning/15 text-warning',
+    title: 'Approval required',
+  },
+  approved: {
+    container: 'border-primary/25 bg-primary/5',
+    chip: 'bg-primary/15 text-primary',
+    title: 'Permission granted',
+  },
+  rejected: {
+    container: 'border-destructive/25 bg-destructive/5',
+    chip: 'bg-destructive/15 text-destructive',
+    title: 'Permission rejected',
+  },
+}
+
 const getString = (value: unknown) => (typeof value === 'string' && value.trim() ? value : undefined)
 
 export function PermissionCard({ onAnswerPermission, part }: PermissionCardProps) {
@@ -25,6 +45,8 @@ export function PermissionCard({ onAnswerPermission, part }: PermissionCardProps
   const toolName = getString(part.metadata?.tool) ?? getString(part.metadata?.toolName) ?? part.pattern
   const isPending = part.state === 'pending'
   const isSubmitting = Boolean(submittingResponse)
+  const styles = STATE_STYLES[part.state]
+  const StateIcon = part.state === 'pending' ? Warning : part.state === 'approved' ? CheckCircle : XCircle
 
   const handleAnswer = useCallback(
     async (response: PermissionResponse) => {
@@ -42,55 +64,65 @@ export function PermissionCard({ onAnswerPermission, part }: PermissionCardProps
   )
 
   return (
-    <div className="my-2 rounded-xl border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm">
-      <div className="flex items-start gap-3">
-        {isPending ? (
-          <Info size={16} weight="fill" className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-300" />
-        ) : part.state === 'approved' ? (
-          <CheckCircle size={16} weight="fill" className="mt-0.5 shrink-0 text-primary" />
-        ) : (
-          <XCircle size={16} weight="fill" className="mt-0.5 shrink-0 text-destructive" />
-        )}
-
-        <div className="min-w-0 flex-1 space-y-1">
-          <p className="font-medium text-foreground">
-            {isPending ? 'Tool approval required' : part.state === 'approved' ? 'Tool approved' : 'Tool rejected'}
-          </p>
-          <p className="text-xs text-muted-foreground">{part.title}</p>
-          {toolName ? <p className="break-all text-xs text-muted-foreground">{toolName}</p> : null}
-        </div>
+    <div className={cn('@container my-2 rounded-xl border px-4 py-3 text-sm', styles.container)}>
+      <div className="flex items-center gap-2.5">
+        <span className={cn('flex h-6 w-6 shrink-0 items-center justify-center rounded-full', styles.chip)}>
+          <StateIcon size={13} weight="fill" aria-hidden />
+        </span>
+        <p className="font-medium text-foreground">{styles.title}</p>
       </div>
 
+      <p
+        className="mt-2 truncate text-xs text-foreground/80"
+        title={toolName ? `${toolName}: ${part.title}` : part.title}
+      >
+        {toolName ? (
+          <span className="chat-text-micro font-mono text-muted-foreground">{`${toolName}: `}</span>
+        ) : null}
+        {part.title}
+      </p>
+
       {isPending ? (
-        <div className="mt-3 flex flex-wrap gap-2 pl-7">
-          <button
-            type="button"
-            disabled={!onAnswerPermission || isSubmitting}
-            onClick={() => void handleAnswer('once')}
-            className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-opacity disabled:opacity-50"
-          >
-            {submittingResponse === 'once' ? 'Sending...' : 'Allow'}
-          </button>
-          <button
-            type="button"
-            disabled={!onAnswerPermission || isSubmitting}
-            onClick={() => void handleAnswer('reject')}
-            className="rounded-md border border-destructive/30 px-3 py-1.5 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10 disabled:opacity-50"
-          >
-            {submittingResponse === 'reject' ? 'Sending...' : 'Reject'}
-          </button>
-          <button
-            type="button"
-            disabled={!onAnswerPermission || isSubmitting}
-            onClick={() => void handleAnswer('always')}
-            className="rounded-md border border-border/60 px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-50"
-          >
-            {submittingResponse === 'always' ? 'Sending...' : 'Always allow for this session'}
-          </button>
+        <div className="mt-3" aria-busy={isSubmitting}>
+          <div className="flex flex-col gap-2 @md:flex-row @md:items-center">
+            <Button
+              type="button"
+              size="sm"
+              className="w-full bg-warning text-foreground hover:bg-warning/90 active:bg-warning/85 @md:w-auto dark:bg-[hsl(38_92%_50%)] dark:text-background"
+              disabled={!onAnswerPermission || isSubmitting}
+              onClick={() => void handleAnswer('once')}
+            >
+              {submittingResponse === 'once' ? 'Sending...' : 'Allow once'}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="w-full bg-primary-foreground/60 hover:bg-primary-foreground/80 active:bg-primary-foreground/90 @md:w-auto dark:bg-foreground/5 dark:hover:bg-foreground/10 dark:active:bg-foreground/15"
+              disabled={!onAnswerPermission || isSubmitting}
+              onClick={() => void handleAnswer('always')}
+            >
+              {submittingResponse === 'always' ? 'Sending...' : 'Allow for this session'}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="destructive"
+              className="w-full @md:ml-auto @md:w-auto dark:bg-destructive/15 dark:text-destructive dark:hover:bg-destructive/20 dark:active:bg-destructive/25"
+              disabled={!onAnswerPermission || isSubmitting}
+              onClick={() => void handleAnswer('reject')}
+            >
+              {submittingResponse === 'reject' ? 'Sending...' : 'Reject'}
+            </Button>
+          </div>
         </div>
       ) : null}
 
-      {error ? <p className="mt-2 pl-7 text-xs text-destructive">{error}</p> : null}
+      {error ? (
+        <p role="alert" className="mt-2 text-xs text-destructive">
+          {error}
+        </p>
+      ) : null}
     </div>
   )
 }

--- a/apps/web/src/hooks/__tests__/use-workspace.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-workspace.test.tsx
@@ -2059,11 +2059,11 @@ describe("useWorkspace", () => {
 
     let accepted = false;
     await act(async () => {
-      accepted = await result.current.answerPermission("s1", "perm-1", "approve");
+      accepted = await result.current.answerPermission("s1", "perm-1", "once");
     });
 
     expect(accepted).toBe(true);
-    expect(permissionBody).toEqual({ sessionId: "s1", response: "approve" });
+    expect(permissionBody).toEqual({ sessionId: "s1", response: "once" });
     expect(result.current.messages[0]?.parts[0]).toMatchObject({
       type: "permission",
       state: "approved",


### PR DESCRIPTION
## Summary

Redesign of the chat permission card (`permission-card.tsx`) to make the approval decision clear, theme-coherent, accessible, and usable in narrow panels.

### Appearance by state (theme tokens, no hardcoded `amber-*`)
- **Pending:** warning surface (`border-warning/25 bg-warning/5`) + warning chip icon
- **Approved:** primary surface — no longer perceived as an alert
- **Rejected:** destructive surface

### Information structure
- Header: state chip icon + title, vertically centered (`Approval required` / `Permission granted` / `Permission rejected`)
- Tool/pattern as inline metadata on the **same line** as the requested action: `bash: pnpm test …` (mono, `chat-text-micro`, truncated with tooltip)

### Actions (shared `Button`, homogeneous solid hierarchy)
- **Allow once** — warning yellow (`bg-warning`, more saturated in dark mode)
- **Allow for this session** — translucent (`bg-primary-foreground/60` light, `bg-foreground/5` dark)
- **Reject** — solid destructive in light (fixes poor contrast of previous outline), soft destructive in dark (`bg-destructive/15` + deep red text)
- Single row ordered Allow once → Allow for this session → Reject (destructive pushed right with `@md:ml-auto`)
- Redundant session explanation text removed; double-submit guard kept

### Responsive
- **Container queries** (`@container` + `@md:`) so layout responds to the card's real width, not the viewport: single row on wide cards, deliberate full-width column in narrow chat panels — no `flex-wrap` accidents, no fragile `pl-7` alignment

### Accessibility
- Focus/active/disabled states inherited from `Button`
- Submission failure announced with `role=alert`; `aria-busy` while submitting
- Controls stay disabled in read-only conversations with consistent `Button` styling

### Tests
- New `permission-card.test.tsx`: three states (surface classes), labels/variants, valid values `once`/`always`/`reject` (table-driven), error alert, loading state, read-only without handler
- Fixed `use-workspace` test that used invalid `approve` value (real contract: `once`/`always`/`reject`)
- Updated `messages.test.tsx` and `chat-panel-interactions.test.tsx` to new labels

## Validation
- `pnpm test` — 5073 passed
- `pnpm lint` — 0 errors
- `scripts/check-podman-images.sh` — passed
- Visual review in light/dark themes and 320px narrow panel