### PR TITLE
fix(workspace): stabilize stream recovery and connection resilience

### DIFF
--- a/apps/web/e2e/stream-stabilization.spec.ts
+++ b/apps/web/e2e/stream-stabilization.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test'
+
+import { adminSlug } from './support/test-data'
+
+// Covers the PRD "Estabilización de streams": verifies that a normal
+// text-only chat message flows through the stabilized SSE pipeline
+// (connect timeout, heartbeats, watchdog grace windows) without being
+// prematurely terminated. The fake runtime echoes `E2E_OK: <prompt>`,
+// so we assert on that deterministic reply.
+
+test.setTimeout(90_000)
+
+test('streams a text chat response through the stabilized SSE pipeline', async ({ page }) => {
+  await page.goto(`/w/${adminSlug}`)
+
+  // The chat composer only renders once the instance is started and connected.
+  await expect(page.getByPlaceholder('Type a message...')).toBeVisible({ timeout: 120_000 })
+
+  await page.getByPlaceholder('Type a message...').fill('Hello stream')
+  await page.getByLabel('Send message').click()
+
+  // The fake runtime replies with `E2E_OK: <prompt>`.
+  await expect(page.getByText('E2E_OK: Hello stream', { exact: true })).toBeVisible({ timeout: 30_000 })
+
+  // After the stream completes, the composer must be available again
+  // (no lingering "Reconnecting..." or error state from a healthy flow).
+  await expect(page.getByPlaceholder('Type a message...')).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByText('Reconnecting...')).toHaveCount(0)
+})

--- a/apps/web/src/actions/__tests__/opencode.test.ts
+++ b/apps/web/src/actions/__tests__/opencode.test.ts
@@ -210,6 +210,32 @@ describe('checkConnectionAction', () => {
     expect(result).toEqual({ status: 'error', error: 'unknown' })
   })
 
+  it('aborts and identifies a health check that exceeds its deadline', async () => {
+    const timeoutController = new AbortController()
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, 'timeout')
+      .mockReturnValue(timeoutController.signal)
+    mockHealthFn.mockImplementation(({ signal }: { signal: AbortSignal }) => (
+      new Promise((_, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+      })
+    ))
+
+    try {
+      const resultPromise = checkConnectionAction('alice')
+      await vi.waitFor(() => expect(mockHealthFn).toHaveBeenCalledOnce())
+      timeoutController.abort(new DOMException('Timed out', 'TimeoutError'))
+
+      await expect(resultPromise).resolves.toEqual({
+        status: 'error',
+        error: 'health_check_timeout',
+      })
+      expect(mockHealthFn).toHaveBeenCalledWith({ signal: timeoutController.signal })
+    } finally {
+      timeoutSpy.mockRestore()
+    }
+  })
+
   it('allows admin to check connection for another user', async () => {
     mockGetSession.mockResolvedValue(adminSession)
     mockHealthFn.mockResolvedValue({ data: { healthy: true, version: '2.0' } })

--- a/apps/web/src/actions/opencode.ts
+++ b/apps/web/src/actions/opencode.ts
@@ -35,6 +35,8 @@ import {
   isProtectedWorkspacePath,
 } from "@/lib/workspace-paths";
 
+const CONNECTION_HEALTH_TIMEOUT_MS = 5_000;
+
 function isFreeOpencodeModel(model: unknown): boolean {
   if (!model || typeof model !== "object" || Array.isArray(model)) {
     return false;
@@ -185,15 +187,21 @@ export async function checkConnectionAction(
   }
 
   try {
-    const health = await client!.global.health();
+    const health = await client!.global.health({
+      signal: AbortSignal.timeout(CONNECTION_HEALTH_TIMEOUT_MS),
+    });
     if (health.data?.healthy) {
       return { status: "connected", version: health.data.version };
     }
     return { status: "error", error: "unhealthy" };
   } catch (e) {
+    const timedOut = e instanceof Error && (
+      e.name === "TimeoutError" ||
+      (e.name === "AbortError" && e.message.toLowerCase().includes("timeout"))
+    );
     return {
       status: "error",
-      error: e instanceof Error ? e.message : "unknown",
+      error: timedOut ? "health_check_timeout" : e instanceof Error ? e.message : "unknown",
     };
   }
 }

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/route.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/route.test.ts
@@ -601,11 +601,47 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     const { POST } = await import('../route')
     const res = await POST(makeStartPostRequest({ sessionId: 's1', text: 'Hi' }), params())
 
-    await expect(res.text()).resolves.toContain('Failed to connect to event stream')
+    await expect(res.text()).resolves.toContain('event_stream_unavailable')
     expect(mocks.messageRunService.markRunFailed).toHaveBeenCalledWith(
       'run-started',
       'event_stream_unavailable',
     )
+  })
+
+  it('bounds a stalled upstream event subscription with a diagnostic timeout', async () => {
+    vi.useFakeTimers()
+    try {
+      const fetchMock = vi.fn((url: string | URL, init?: RequestInit) => {
+        if (String(url) !== 'http://test-slug:3000/event') {
+          return Promise.reject(new Error(`unexpected fetch ${String(url)}`))
+        }
+
+        return new Promise<Response>((_, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'))
+          }, { once: true })
+        })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const { POST } = await import('../route')
+      const res = await POST(makeStartPostRequest({ sessionId: 's1', text: 'Hi' }), params())
+      const textPromise = res.text()
+
+      await vi.advanceTimersByTimeAsync(8_001)
+
+      await expect(textPromise).resolves.toContain('event_stream_connect_timeout')
+      expect(mocks.messageRunService.markRunFailed).toHaveBeenCalledWith(
+        'run-started',
+        'event_stream_connect_timeout',
+      )
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        'http://test-slug:3000/session/s1/prompt_async',
+        expect.anything(),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('streams assistant status, parts, metadata, workspace updates, and completion', async () => {
@@ -888,7 +924,8 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     const { POST } = await import('../route')
     const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
 
-    await expect(res.text()).resolves.toContain('Failed to connect to event stream')
+    await expect(res.text()).resolves.toContain('event_stream_unavailable')
+    expect(mocks.messageRunService.markRunFailed).not.toHaveBeenCalled()
   })
 
   it('streams an error when subscribing to upstream events throws', async () => {
@@ -897,13 +934,96 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     const { POST } = await import('../route')
     const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
 
-    await expect(res.text()).resolves.toContain('stream down')
+    await expect(res.text()).resolves.toContain('event_stream_unavailable')
+    expect(mocks.messageRunService.markRunFailed).not.toHaveBeenCalled()
+  })
+
+  it('emits SSE heartbeat comments while the upstream stream is silent', async () => {
+    vi.useFakeTimers()
+    const clientAbortController = new AbortController()
+    try {
+      vi.stubGlobal('fetch', vi.fn((url: string | URL) => {
+        if (String(url) === 'http://test-slug:3000/event') {
+          return Promise.resolve(new Response(new ReadableStream<Uint8Array>(), { status: 200 }))
+        }
+
+        return Promise.reject(new Error(`unexpected fetch ${String(url)}`))
+      }))
+
+      const { POST } = await import('../route')
+      const res = await POST(makePostRequest(
+        { sessionId: 's1', runId: 'run-1' },
+        'alice',
+        clientAbortController.signal,
+      ), params())
+      const reader = res.body!.getReader()
+      const decoder = new TextDecoder()
+
+      await reader.read()
+      await reader.read()
+      const heartbeatRead = reader.read()
+      await vi.advanceTimersByTimeAsync(10_000)
+
+      const heartbeat = await heartbeatRead
+      expect(decoder.decode(heartbeat.value)).toMatch(/^: heartbeat \d+\n\n$/)
+      expect(mocks.messageRunService.markRunFailed).not.toHaveBeenCalled()
+    } finally {
+      clientAbortController.abort()
+      await vi.runAllTimersAsync()
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps an active run resumable when the upstream event stream ends', async () => {
+    mocks.createUpstreamSessionStatusReader.mockReturnValue(vi.fn().mockResolvedValue('busy'))
+    vi.stubGlobal('fetch', vi.fn((url: string | URL) => {
+      if (String(url) === 'http://test-slug:3000/event') {
+        return Promise.resolve(new Response(eventStream([]), { status: 200 }))
+      }
+
+      return Promise.reject(new Error(`unexpected fetch ${String(url)}`))
+    }))
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
+    const text = await res.text()
+
+    expect(text).toContain('"error":"upstream_eof"')
+    expect(text).toContain('"recoverable":true')
+    expect(mocks.messageRunService.markRunFailed).not.toHaveBeenCalled()
+    expect(mocks.abortSessionFamilyAndConfirmIdle).not.toHaveBeenCalled()
+  })
+
+  it('closes the observation recoverably when the upstream reader errors mid-stream', async () => {
+    mocks.createUpstreamSessionStatusReader.mockReturnValue(vi.fn().mockResolvedValue('busy'))
+    vi.stubGlobal('fetch', vi.fn((url: string | URL) => {
+      if (String(url) === 'http://test-slug:3000/event') {
+        return Promise.resolve(new Response(new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.error(new Error('upstream connection reset'))
+          },
+        }), { status: 200 }))
+      }
+
+      return Promise.reject(new Error(`unexpected fetch ${String(url)}`))
+    }))
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
+    const text = await res.text()
+
+    expect(text).toContain('"error":"upstream_stream_error"')
+    expect(text).toContain('"recoverable":true')
+    expect(text).toContain('"runId":"run-1"')
+    expect(mocks.messageRunService.markRunFailed).not.toHaveBeenCalled()
+    expect(mocks.abortSessionFamilyAndConfirmIdle).not.toHaveBeenCalled()
   })
 
   it('keeps waiting through delegated silence while upstream is busy and finalizes once idle', async () => {
     vi.useFakeTimers()
     try {
       const readStatus = vi.fn()
+        .mockResolvedValueOnce(null)
         .mockResolvedValueOnce('busy')
         .mockResolvedValueOnce('idle')
       mocks.createUpstreamSessionStatusReader.mockReturnValue(readStatus)
@@ -926,13 +1046,47 @@ describe('POST /api/w/[slug]/chat/stream', () => {
       expect(mocks.messageRunService.markRunFailed).not.toHaveBeenCalledWith('run-1', 'stream_timeout')
 
       await vi.advanceTimersByTimeAsync(21_000)
+      expect(mocks.messageRunService.markRunFailed).not.toHaveBeenCalledWith('run-1', 'stream_timeout')
+
+      await vi.advanceTimersByTimeAsync(21_000)
       const text = await textPromise
 
       expect(text).toContain('event: done')
       expect(text).not.toContain('stream_timeout')
-      expect(readStatus).toHaveBeenCalledTimes(2)
+      expect(readStatus).toHaveBeenCalledTimes(3)
       expect(mocks.messageRunService.markRunSucceeded).toHaveBeenCalledWith('run-1')
       expect(mocks.messageRunService.markRunFailed).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('closes only the observation after unknown status exhausts its grace window', async () => {
+    vi.useFakeTimers()
+    try {
+      mocks.createUpstreamSessionStatusReader.mockReturnValue(vi.fn().mockResolvedValue(null))
+      mocks.getSilentStreamOutcome
+        .mockReturnValueOnce('keep_waiting')
+        .mockReturnValueOnce('status_unknown_timeout')
+      vi.stubGlobal('fetch', vi.fn((url: string | URL) => {
+        if (String(url) === 'http://test-slug:3000/event') {
+          return Promise.resolve(new Response(new ReadableStream<Uint8Array>(), { status: 200 }))
+        }
+
+        return Promise.reject(new Error(`unexpected fetch ${String(url)}`))
+      }))
+
+      const { POST } = await import('../route')
+      const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
+      const textPromise = res.text()
+
+      await vi.advanceTimersByTimeAsync(42_000)
+      const text = await textPromise
+
+      expect(text).toContain('stream_status_unavailable')
+      expect(text).toContain('"recoverable":true')
+      expect(mocks.messageRunService.markRunFailed).not.toHaveBeenCalled()
+      expect(mocks.abortSessionFamilyAndConfirmIdle).not.toHaveBeenCalled()
     } finally {
       vi.useRealTimers()
     }
@@ -942,7 +1096,7 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     vi.useFakeTimers()
     try {
       mocks.createUpstreamSessionStatusReader.mockReturnValue(vi.fn().mockResolvedValue(null))
-      mocks.getSilentStreamOutcome.mockReturnValue('stream_timeout')
+      mocks.getSilentStreamOutcome.mockReturnValue('max_runtime_exceeded')
       const fetchMock = vi.fn((url: string | URL) => {
         if (String(url) === 'http://test-slug:3000/event') {
           return Promise.resolve(new Response(new ReadableStream<Uint8Array>(), { status: 200 }))
@@ -976,7 +1130,7 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     vi.useFakeTimers()
     try {
       mocks.createUpstreamSessionStatusReader.mockReturnValue(vi.fn().mockResolvedValue(null))
-      mocks.getSilentStreamOutcome.mockReturnValue('stream_timeout')
+      mocks.getSilentStreamOutcome.mockReturnValue('max_runtime_exceeded')
       mocks.abortSessionFamilyAndConfirmIdle.mockResolvedValue(false)
       vi.stubGlobal('fetch', vi.fn((url: string | URL) => {
         if (String(url) === 'http://test-slug:3000/event') {

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/status-reader.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/status-reader.test.ts
@@ -23,11 +23,13 @@ describe('createUpstreamSessionStatusReader', () => {
       ),
     )
     vi.stubGlobal('fetch', fetchMock)
+    const onRead = vi.fn()
 
     const readStatus = createUpstreamSessionStatusReader({
       baseUrl: 'http://127.0.0.1:4096',
       authHeader: 'Basic token',
       sessionId: 'session-1',
+      onRead,
     })
 
     await expect(readStatus()).resolves.toBe('busy')
@@ -35,6 +37,11 @@ describe('createUpstreamSessionStatusReader', () => {
     await expect(readStatus()).resolves.toBe('busy')
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(onRead).toHaveBeenCalledWith({
+      durationMs: 0,
+      outcome: 'success',
+      status: 'busy',
+    })
   })
 
   it('logs and returns null when the upstream status request fails', async () => {

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/watchdog.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/watchdog.test.ts
@@ -58,14 +58,22 @@ describe('chat stream watchdog helpers', () => {
   describe('getSilentStreamOutcome', () => {
     it('keeps waiting while upstream remains busy', () => {
       expect(getSilentStreamOutcome({
+        maxRuntimeMs: 35 * 60 * 1000,
+        runtimeMs: 19_999,
         upstreamStatus: 'busy',
         silentForMs: 19_999,
         relevantEventTimeoutMs: 20_000,
+        unknownStatusForMs: 0,
+        unknownStatusGraceMs: 45_000,
       })).toBe('keep_waiting')
       expect(getSilentStreamOutcome({
+        maxRuntimeMs: 35 * 60 * 1000,
+        runtimeMs: 35_999,
         upstreamStatus: 'retry',
         silentForMs: 35_999,
         relevantEventTimeoutMs: 12_000,
+        unknownStatusForMs: 0,
+        unknownStatusGraceMs: 45_000,
       })).toBe('keep_waiting')
     })
 
@@ -76,6 +84,8 @@ describe('chat stream watchdog helpers', () => {
         relevantEventTimeoutMs: 20_000,
         runtimeMs: 60_000,
         maxRuntimeMs: 35 * 60 * 1000,
+        unknownStatusForMs: 0,
+        unknownStatusGraceMs: 45_000,
       })).toBe('keep_waiting')
       expect(getSilentStreamOutcome({
         upstreamStatus: 'retry',
@@ -83,6 +93,8 @@ describe('chat stream watchdog helpers', () => {
         relevantEventTimeoutMs: 12_000,
         runtimeMs: 36_000,
         maxRuntimeMs: 35 * 60 * 1000,
+        unknownStatusForMs: 0,
+        unknownStatusGraceMs: 45_000,
       })).toBe('keep_waiting')
     })
 
@@ -93,7 +105,9 @@ describe('chat stream watchdog helpers', () => {
         relevantEventTimeoutMs: 20_000,
         runtimeMs: 35 * 60 * 1000,
         maxRuntimeMs: 35 * 60 * 1000,
-      })).toBe('stream_timeout')
+        unknownStatusForMs: 0,
+        unknownStatusGraceMs: 45_000,
+      })).toBe('max_runtime_exceeded')
     })
 
     it('finalizes when upstream has idled', () => {
@@ -103,24 +117,42 @@ describe('chat stream watchdog helpers', () => {
         relevantEventTimeoutMs: 20_000,
         runtimeMs: 20_000,
         maxRuntimeMs: 35 * 60 * 1000,
+        unknownStatusForMs: 0,
+        unknownStatusGraceMs: 45_000,
       })).toBe('finalize_idle')
     })
 
-    it('falls back to stream timeout for unknown or missing upstream status', () => {
+    it('keeps waiting for unknown status during the grace window', () => {
       expect(getSilentStreamOutcome({
         upstreamStatus: null,
         silentForMs: 20_000,
         relevantEventTimeoutMs: 20_000,
         runtimeMs: 20_000,
         maxRuntimeMs: 35 * 60 * 1000,
-      })).toBe('stream_timeout')
+        unknownStatusForMs: 30_000,
+        unknownStatusGraceMs: 45_000,
+      })).toBe('keep_waiting')
       expect(getSilentStreamOutcome({
         upstreamStatus: 'complete',
         silentForMs: 20_000,
         relevantEventTimeoutMs: 20_000,
         runtimeMs: 20_000,
         maxRuntimeMs: 35 * 60 * 1000,
-      })).toBe('stream_timeout')
+        unknownStatusForMs: 30_000,
+        unknownStatusGraceMs: 45_000,
+      })).toBe('keep_waiting')
+    })
+
+    it('ends observation only after unknown status exhausts its grace window', () => {
+      expect(getSilentStreamOutcome({
+        upstreamStatus: null,
+        silentForMs: 65_000,
+        relevantEventTimeoutMs: 20_000,
+        runtimeMs: 65_000,
+        maxRuntimeMs: 35 * 60 * 1000,
+        unknownStatusForMs: 45_000,
+        unknownStatusGraceMs: 45_000,
+      })).toBe('status_unknown_timeout')
     })
   })
 })

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto'
+
 import { NextRequest, NextResponse } from 'next/server'
 
 import { getIdleFinalizationOutcome, getSilentStreamOutcome } from '@/app/api/w/[slug]/chat/stream/watchdog'
@@ -33,6 +35,9 @@ export const dynamic = 'force-dynamic'
 const STREAM_RELEVANT_EVENT_TICK_MS = 1000
 const SEND_STREAM_RELEVANT_EVENT_TIMEOUT_MS = 20_000
 const RESUME_STREAM_RELEVANT_EVENT_TIMEOUT_MS = 12_000
+const EVENT_STREAM_CONNECT_TIMEOUT_MS = 8_000
+const SSE_HEARTBEAT_INTERVAL_MS = 10_000
+const STATUS_UNKNOWN_GRACE_MS = 45_000
 const PROMPT_START_TIMEOUT_MS = 60_000
 type StreamRequestBody = {
   attachments: MessageAttachmentInput[]
@@ -302,6 +307,7 @@ export const POST = withAuth(
     } = streamBody
     const startsPrompt = !resume && !runId
     const hasPromptInput = Boolean(text) || attachments.length > 0 || contextPaths.length > 0 || Boolean(model)
+    const observationId = randomUUID()
 
     if (!startsPrompt && hasPromptInput) {
       return jsonErrorResponse(400, 'invalid_stream_payload')
@@ -408,6 +414,10 @@ export const POST = withAuth(
         // Track whether the downstream client (browser) has disconnected.
         let clientGone = false
         let aborted = false
+        let firstDownstreamEventSeen = false
+        let firstUpstreamEventSeen = false
+        let terminalReason: string | null = null
+        let heartbeatCount = 0
         const upstreamEventsController = new AbortController()
 
         // Shared reference so the abort path and finally block can always
@@ -415,9 +425,28 @@ export const POST = withAuth(
         let eventReader: ReadableStreamDefaultReader<Uint8Array> | null = null
         let promptStarted = !startsPrompt
 
+        const logObservation = (event: string, details: Record<string, unknown> = {}) => {
+          console.log('[chat/stream]', {
+            activeRunId,
+            event,
+            observationId,
+            sessionId,
+            slug,
+            ...details,
+          })
+        }
+
+        const recordTerminalReason = (reason: string, details: Record<string, unknown> = {}) => {
+          if (terminalReason) return
+          terminalReason = reason
+          logObservation('stream_terminal', { reason, ...details })
+        }
+
         const handleAbort = () => {
           clientGone = true
           aborted = true
+          recordTerminalReason('client_abort')
+          logObservation('client_abort')
           upstreamEventsController.abort()
           void eventReader?.cancel().catch(() => undefined)
           if (startsPrompt && activeRunId && !promptStarted) {
@@ -436,10 +465,36 @@ export const POST = withAuth(
           if (clientGone) return
           try {
             controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`))
+            if (!firstDownstreamEventSeen) {
+              firstDownstreamEventSeen = true
+              logObservation('first_downstream_event', { eventType: event })
+            }
           } catch {
             clientGone = true
+            aborted = true
+            recordTerminalReason('downstream_write_error')
+            upstreamEventsController.abort()
+            void eventReader?.cancel().catch(() => undefined)
           }
         }
+
+        const sendHeartbeat = () => {
+          if (clientGone || aborted) return
+          try {
+            controller.enqueue(encoder.encode(`: heartbeat ${Date.now()}\n\n`))
+            heartbeatCount += 1
+            logObservation('heartbeat', { count: heartbeatCount })
+          } catch {
+            clientGone = true
+            aborted = true
+            recordTerminalReason('downstream_write_error')
+            upstreamEventsController.abort()
+            void eventReader?.cancel().catch(() => undefined)
+          }
+        }
+
+        const heartbeatInterval = setInterval(sendHeartbeat, SSE_HEARTBEAT_INTERVAL_MS)
+        logObservation('downstream_open')
 
         const markRunSucceeded = () => {
           if (!activeRunId) return
@@ -451,12 +506,42 @@ export const POST = withAuth(
           void messageRunService.markRunFailed(activeRunId, detail).catch(() => undefined)
         }
 
+        const closeForObservationInterruption = (detail: string, reason = detail) => {
+          sendEvent('error', {
+            error: detail,
+            recoverable: true,
+            ...(activeRunId ? { runId: activeRunId } : {}),
+          })
+          recordTerminalReason(reason, { detail, recoverable: true })
+          aborted = true
+        }
+
+        const failEventSubscription = (detail: string) => {
+          if (startsPrompt) {
+            markRunFailed(detail)
+            sendEvent('error', { error: detail })
+            recordTerminalReason(detail, { recoverable: false })
+            aborted = true
+            return
+          }
+
+          closeForObservationInterruption(detail)
+        }
+
         try {
           sendEvent('status', { status: 'connecting' })
           const readUpstreamSessionStatus = createUpstreamSessionStatusReader({
             baseUrl,
             authHeader,
             sessionId,
+            onRead: ({ durationMs, outcome, responseStatus, status }) => {
+              logObservation('upstream_status_read', {
+                durationMs,
+                outcome,
+                responseStatus,
+                status,
+              })
+            },
           })
 
           // Subscribe first so we don't miss fast session events.
@@ -464,6 +549,13 @@ export const POST = withAuth(
 
           let reader: ReadableStreamDefaultReader<Uint8Array> | null = null
           if (!clientGone) {
+            const connectStartedAt = Date.now()
+            let connectTimedOut = false
+            const connectTimeout = setTimeout(() => {
+              connectTimedOut = true
+              upstreamEventsController.abort()
+            }, EVENT_STREAM_CONNECT_TIMEOUT_MS)
+            logObservation('upstream_connect_start')
             try {
               const eventsResponse = await fetch(eventsUrl, {
                 method: 'GET',
@@ -476,21 +568,35 @@ export const POST = withAuth(
               })
 
               if (!eventsResponse.ok || !eventsResponse.body) {
-                markRunFailed('event_stream_unavailable')
-                sendEvent('error', { error: 'Failed to connect to event stream' })
+                logObservation('upstream_connect_failure', {
+                  durationMs: Date.now() - connectStartedAt,
+                  reason: 'event_stream_unavailable',
+                  responseStatus: eventsResponse.status,
+                })
+                failEventSubscription('event_stream_unavailable')
                 return
               }
 
+              logObservation('upstream_connect_success', {
+                durationMs: Date.now() - connectStartedAt,
+              })
               reader = eventsResponse.body.getReader()
               eventReader = reader
             } catch (error) {
-              if (!clientGone && !isAbortError(error)) {
-                markRunFailed(error instanceof Error ? error.message : 'event_stream_unavailable')
-                sendEvent('error', {
-                  error: error instanceof Error ? error.message : 'Unknown error'
+              if (!clientGone) {
+                const detail = connectTimedOut
+                  ? 'event_stream_connect_timeout'
+                  : 'event_stream_unavailable'
+                logObservation('upstream_connect_failure', {
+                  durationMs: Date.now() - connectStartedAt,
+                  error: error instanceof Error ? error.message : String(error),
+                  reason: detail,
                 })
-                return
+                failEventSubscription(detail)
               }
+              return
+            } finally {
+              clearTimeout(connectTimeout)
             }
           }
 
@@ -532,6 +638,9 @@ export const POST = withAuth(
                   : 'prompt_start_failed'
             markRunFailed(detail)
             sendEvent('error', { error: detail })
+            recordTerminalReason(
+              detail === 'prompt_start_timeout' ? detail : 'prompt_start_failed',
+            )
             await cancelReader()
             return
           }
@@ -541,9 +650,12 @@ export const POST = withAuth(
             const detail = `Failed to start message: ${errorText}`
             markRunFailed(detail)
             sendEvent('error', { error: detail })
+            recordTerminalReason('prompt_start_rejected', { responseStatus: promptResponse.status })
             await cancelReader()
             return
           }
+
+          logObservation('prompt_accepted')
         }
 
         // Track state for the assistant response
@@ -561,6 +673,7 @@ export const POST = withAuth(
         let runModelId = model?.modelId ?? null
         let lastRelevantEventAt = Date.now()
         let lastStreamActivityAt = lastRelevantEventAt
+        let unknownStatusSince: number | null = null
         const stepFinishUsageByPart = new Map<string, StepFinishUsage>()
         const relevantEventTimeoutMs = resume
           ? RESUME_STREAM_RELEVANT_EVENT_TIMEOUT_MS
@@ -661,6 +774,7 @@ export const POST = withAuth(
             sendEvent('error', { error: outcome })
             recordRunUsage()
             markRunFailed(outcome)
+            recordTerminalReason(`idle_${outcome}`)
             aborted = true
             return
           }
@@ -669,6 +783,7 @@ export const POST = withAuth(
           sendEvent('done', { refresh: true })
           recordRunUsage()
           markRunSucceeded()
+          recordTerminalReason('idle_confirmed_complete')
           void queueAutoLearningBestEffort({ authHeader, baseUrl, sessionId, slug, userId: user.id })
           aborted = true
         }
@@ -692,13 +807,25 @@ export const POST = withAuth(
                   continue
                 }
 
+                const upstreamStatus = await readUpstreamSessionStatus()
+                const statusReadAt = Date.now()
+                if (upstreamStatus === 'busy' || upstreamStatus === 'retry' || upstreamStatus === 'idle') {
+                  unknownStatusSince = null
+                } else if (unknownStatusSince === null) {
+                  unknownStatusSince = statusReadAt
+                }
+
                 const watchdogOutcome = getSilentStreamOutcome(
                   {
                     maxRuntimeMs: MESSAGE_RUN_TIMEOUT_MS,
-                    runtimeMs: Date.now() - runStartedAt,
-                    upstreamStatus: await readUpstreamSessionStatus(),
-                    silentForMs: Date.now() - lastStreamActivityAt,
+                    runtimeMs: statusReadAt - runStartedAt,
+                    upstreamStatus,
+                    silentForMs: statusReadAt - lastStreamActivityAt,
                     relevantEventTimeoutMs,
+                    unknownStatusForMs: unknownStatusSince === null
+                      ? 0
+                      : statusReadAt - unknownStatusSince,
+                    unknownStatusGraceMs: STATUS_UNKNOWN_GRACE_MS,
                   },
                 )
 
@@ -710,6 +837,15 @@ export const POST = withAuth(
                 if (watchdogOutcome === 'finalize_idle') {
                   markWatchdogCheck()
                   finalizeFromIdle()
+                  continue
+                }
+
+                if (watchdogOutcome === 'status_unknown_timeout') {
+                  recordRunUsage()
+                  closeForObservationInterruption(
+                    'stream_status_unavailable',
+                    'status_unknown_grace_exhausted',
+                  )
                   continue
                 }
 
@@ -726,6 +862,9 @@ export const POST = withAuth(
                 if (terminated) {
                   markRunFailed(failure)
                 }
+                recordTerminalReason('max_runtime_exceeded', {
+                  executionTerminationConfirmed: terminated,
+                })
                 aborted = true
               }
               continue
@@ -740,8 +879,11 @@ export const POST = withAuth(
 
           const { done, value } = streamReadResult
           if (done || !value) {
-            if (!resume && !aborted) {
+            logObservation('upstream_eof')
+            if (!aborted && await readUpstreamSessionStatus() === 'idle') {
               finalizeFromIdle()
+            } else if (!aborted) {
+              closeForObservationInterruption('upstream_eof')
             }
             break
           }
@@ -769,6 +911,10 @@ export const POST = withAuth(
                   event.properties?.part?.sessionID
 
                 const eventType = typeof event.type === 'string' ? event.type : ''
+                if (!firstUpstreamEventSeen) {
+                  firstUpstreamEventSeen = true
+                  logObservation('first_upstream_event', { eventType })
+                }
                 const isWorkspaceEvent =
                   eventType === 'file.edited' ||
                   eventType === 'file.created' ||
@@ -830,6 +976,7 @@ export const POST = withAuth(
                     sendEvent('error', { error: errorMessage })
                     recordRunUsage()
                     markRunFailed(errorMessage)
+                    recordTerminalReason('upstream_session_error')
                     aborted = true
                     break
                   }
@@ -1148,17 +1295,19 @@ export const POST = withAuth(
 
       } catch (error) {
         if (!aborted && !request.signal.aborted && !isAbortError(error)) {
-          markRunFailed(error instanceof Error ? error.message : 'stream_error')
-          sendEvent('error', {
-            error: error instanceof Error ? error.message : 'Unknown error'
+          logObservation('upstream_error', {
+            error: error instanceof Error ? error.message : String(error),
           })
+          closeForObservationInterruption('upstream_stream_error')
         }
       } finally {
+        clearInterval(heartbeatInterval)
         request.signal.removeEventListener('abort', handleAbort)
         upstreamEventsController.abort()
         if (eventReader) {
           await eventReader.cancel().catch(() => undefined)
         }
+        recordTerminalReason('stream_closed')
         try { controller.close() } catch { /* already closed/errored */ }
       }
       }
@@ -1169,7 +1318,8 @@ export const POST = withAuth(
         'Content-Type': 'text/event-stream',
         'Cache-Control': 'no-cache, no-transform',
         'Connection': 'keep-alive',
-        'X-Accel-Buffering': 'no'
+        'X-Accel-Buffering': 'no',
+        ...(activeRunId ? { 'X-Arche-Run-Id': activeRunId } : {}),
       }
     })
   },

--- a/apps/web/src/app/api/w/[slug]/chat/stream/status-reader.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/status-reader.ts
@@ -8,6 +8,14 @@ type UpstreamSessionStatusReaderOptions = {
   baseUrl: string
   authHeader: string
   sessionId: string
+  onRead?: (result: UpstreamSessionStatusReadResult) => void
+}
+
+export type UpstreamSessionStatusReadResult = {
+  durationMs: number
+  outcome: 'error' | 'http_error' | 'success'
+  responseStatus?: number
+  status: string | null
 }
 
 const UPSTREAM_STATUS_CACHE_WINDOW_MS = 2_000
@@ -17,6 +25,7 @@ export function createUpstreamSessionStatusReader({
   baseUrl,
   authHeader,
   sessionId,
+  onRead,
 }: UpstreamSessionStatusReaderOptions): () => Promise<string | null> {
   let cache: { expiresAt: number; status: string | null } | null = null
 
@@ -26,6 +35,7 @@ export function createUpstreamSessionStatusReader({
       return cache.status
     }
 
+    const startedAt = Date.now()
     try {
       const response = await fetch(`${baseUrl}/session/status`, {
         method: 'GET',
@@ -44,6 +54,12 @@ export function createUpstreamSessionStatusReader({
           status: response.status,
         })
         cache = { expiresAt: now + UPSTREAM_STATUS_CACHE_WINDOW_MS, status: null }
+        onRead?.({
+          durationMs: Date.now() - startedAt,
+          outcome: 'http_error',
+          responseStatus: response.status,
+          status: null,
+        })
         return null
       }
 
@@ -51,6 +67,7 @@ export function createUpstreamSessionStatusReader({
       const sessionStatus = data?.[sessionId]
       const status = typeof sessionStatus?.type === 'string' ? sessionStatus.type : null
       cache = { expiresAt: now + UPSTREAM_STATUS_CACHE_WINDOW_MS, status }
+      onRead?.({ durationMs: Date.now() - startedAt, outcome: 'success', status })
       return status
     } catch (error) {
       console.warn('[chat-stream] Failed to read upstream session status', {
@@ -59,6 +76,7 @@ export function createUpstreamSessionStatusReader({
         error: error instanceof Error ? error.message : String(error),
       })
       cache = { expiresAt: now + UPSTREAM_STATUS_CACHE_WINDOW_MS, status: null }
+      onRead?.({ durationMs: Date.now() - startedAt, outcome: 'error', status: null })
       return null
     }
   }

--- a/apps/web/src/app/api/w/[slug]/chat/stream/watchdog.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/watchdog.ts
@@ -4,7 +4,11 @@ export type IdleFinalizationOutcome =
   | 'stream_incomplete'
   | 'stream_no_assistant_message'
 
-export type SilentStreamOutcome = 'finalize_idle' | 'keep_waiting' | 'stream_timeout'
+export type SilentStreamOutcome =
+  | 'finalize_idle'
+  | 'keep_waiting'
+  | 'max_runtime_exceeded'
+  | 'status_unknown_timeout'
 
 type IdleFinalizationInput = {
   resume: boolean
@@ -18,6 +22,8 @@ type SilentStreamInput = {
   upstreamStatus: string | null
   silentForMs: number
   relevantEventTimeoutMs: number
+  unknownStatusForMs: number
+  unknownStatusGraceMs: number
 }
 
 export function getIdleFinalizationOutcome({
@@ -42,7 +48,7 @@ export function getIdleFinalizationOutcome({
 
 export function getSilentStreamOutcome(input: SilentStreamInput): SilentStreamOutcome {
   if (input.runtimeMs >= input.maxRuntimeMs) {
-    return 'stream_timeout'
+    return 'max_runtime_exceeded'
   }
 
   if (input.upstreamStatus === 'busy' || input.upstreamStatus === 'retry') {
@@ -53,5 +59,7 @@ export function getSilentStreamOutcome(input: SilentStreamInput): SilentStreamOu
     return 'finalize_idle'
   }
 
-  return 'stream_timeout'
+  return input.unknownStatusForMs >= input.unknownStatusGraceMs
+    ? 'status_unknown_timeout'
+    : 'keep_waiting'
 }

--- a/apps/web/src/components/workspace/__tests__/bitmap-status-indicator.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/bitmap-status-indicator.test.tsx
@@ -1,0 +1,66 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { StatusIndicator } from "@/components/workspace/bitmap-status-indicator";
+import type { MessageStatusInfo } from "@/lib/opencode/types";
+
+beforeEach(() => {
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const RECOVERY_DETAILS = [
+  "stream_interrupted",
+  "stream_status_unavailable",
+  "upstream_eof",
+  "upstream_stream_error",
+];
+
+describe("StatusIndicator", () => {
+  it("shows Reconnecting... while thinking with a stream recovery detail", () => {
+    for (const detail of RECOVERY_DETAILS) {
+      const { unmount } = render(
+        <StatusIndicator
+          currentStatus={{ status: "thinking", detail } as MessageStatusInfo}
+        />,
+      );
+      expect(screen.getByText("Reconnecting...")).toBeTruthy();
+      unmount();
+    }
+  });
+
+  it("shows Thinking... while thinking without a recovery detail", () => {
+    const { rerender } = render(
+      <StatusIndicator currentStatus={{ status: "thinking" } as MessageStatusInfo} />,
+    );
+    expect(screen.getByText("Thinking...")).toBeTruthy();
+
+    rerender(
+      <StatusIndicator
+        currentStatus={{ status: "thinking", detail: "file.ts" } as MessageStatusInfo}
+      />,
+    );
+    expect(screen.getByText("Thinking...")).toBeTruthy();
+    expect(screen.queryByText("Reconnecting...")).toBeNull();
+  });
+
+  it("returns null when no status is provided", () => {
+    const { container } = render(<StatusIndicator currentStatus={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/web/src/components/workspace/__tests__/workspace-shell.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/workspace-shell.test.tsx
@@ -447,6 +447,19 @@ describe("WorkspaceShell", () => {
     expect(screen.getByText("Error: socket down")).toBeTruthy();
   });
 
+  it("shows friendly copy for mapped connection errors", async () => {
+    workspaceMockOverrides = {
+      isConnected: false,
+      connection: { status: "error", error: "health_check_timeout" },
+    };
+
+    render(<WorkspaceShell slug="alice" />);
+
+    expect(await screen.findByText("Connecting to OpenCode")).toBeTruthy();
+    expect(screen.getByText("The workspace is taking too long to respond. Retrying...")).toBeTruthy();
+    expect(screen.queryByText("Error: health_check_timeout")).toBeNull();
+  });
+
   it("redirects to setup when the instance requires setup", async () => {
     ensureInstanceRunningActionMock.mockResolvedValueOnce({ status: "error", error: "setup_required" });
 

--- a/apps/web/src/components/workspace/bitmap-status-indicator.tsx
+++ b/apps/web/src/components/workspace/bitmap-status-indicator.tsx
@@ -16,6 +16,14 @@ type BitmapAnimationConfig = {
 const BITMAP_GRID_COLS = 6;
 const BITMAP_GRID_ROWS = 6;
 
+// Details set by the client while it reattaches to an interrupted stream.
+const STREAM_RECOVERY_DETAILS = new Set([
+  "stream_interrupted",
+  "stream_status_unavailable",
+  "upstream_eof",
+  "upstream_stream_error",
+]);
+
 function createFrame(cols: number, rows: number, activeDots: Array<[number, number]>): boolean[] {
   const frame = Array.from({ length: cols * rows }, () => false);
   for (const [x, y] of activeDots) {
@@ -229,7 +237,7 @@ export function StatusIndicator({
   const statusConfig: Record<string, { pattern: BitmapPattern; label: string; className: string }> = {
     thinking: {
       pattern: "orbit",
-      label: "Thinking...",
+      label: detail && STREAM_RECOVERY_DETAILS.has(detail) ? "Reconnecting..." : "Thinking...",
       className: "text-primary",
     },
     reasoning: {

--- a/apps/web/src/components/workspace/chat-panel/messages.tsx
+++ b/apps/web/src/components/workspace/chat-panel/messages.tsx
@@ -63,6 +63,14 @@ const CHAT_ERROR_MESSAGES: Record<string, { title: string; description?: string 
     title: "Response cancelled",
     description: "The message was stopped before it finished.",
   },
+  event_stream_connect_timeout: {
+    title: "Connection timed out",
+    description: "The workspace took too long to respond. Try sending your message again.",
+  },
+  event_stream_unavailable: {
+    title: "Couldn't reach the workspace",
+    description: "The live connection to the assistant could not be established. Try sending your message again.",
+  },
   execution_termination_unconfirmed: {
     title: "Couldn't confirm the response stopped",
     description: "The assistant may still be running. Wait a moment before sending another message.",
@@ -94,6 +102,10 @@ const CHAT_ERROR_MESSAGES: Record<string, { title: string; description?: string 
   stream_incomplete: {
     title: "Response interrupted",
     description: "The model stopped before returning any visible content.",
+  },
+  stream_timeout: {
+    title: "Response timed out",
+    description: "The assistant ran for too long and was stopped. Try again with a smaller request.",
   },
   too_many_attachments: {
     title: "Too many attachments",

--- a/apps/web/src/components/workspace/workspace-shell.tsx
+++ b/apps/web/src/components/workspace/workspace-shell.tsx
@@ -89,6 +89,19 @@ type MobileWorkspaceView = "chat" | "left" | "right";
 const clamp = (value: number, min: number, max: number) =>
   Math.min(max, Math.max(min, value));
 
+const CONNECTION_ERROR_COPY: Record<string, string> = {
+  connection_check_failed: "Couldn't reach the workspace. Retrying...",
+  forbidden: "You are not allowed to access this workspace.",
+  health_check_timeout: "The workspace is taking too long to respond. Retrying...",
+  instance_unavailable: "The workspace is not ready right now. Retrying...",
+  unauthorized: "Your session has expired. Sign in again.",
+  unhealthy: "The workspace is not ready right now. Retrying...",
+  user_not_found: "This workspace could not be found.",
+};
+
+const getConnectionErrorText = (error: string | undefined) =>
+  (error && CONNECTION_ERROR_COPY[error]) || `Error: ${error ?? "unknown"}`;
+
 const getMinCenter = (containerWidth: number) =>
   Math.min(MIN_CENTER_PX, Math.max(0, containerWidth - MIN_LEFT_PX - MIN_RIGHT_PX - 2 * PANEL_GAP));
 
@@ -1634,7 +1647,7 @@ export function WorkspaceShell({
                 </h2>
                 <p className="text-sm text-muted-foreground">
                   {workspace.connection.status === 'error'
-                    ? `Error: ${workspace.connection.error}`
+                    ? getConnectionErrorText(workspace.connection.error)
                     : 'Establishing connection...'}
                 </p>
               </div>

--- a/apps/web/src/hooks/__tests__/use-workspace-connection.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-workspace-connection.test.tsx
@@ -97,6 +97,32 @@ describe("useWorkspaceConnection", () => {
     expect(onConnected).toHaveBeenCalledTimes(1);
   });
 
+  it("continues retrying periodically after the fast retry budget is exhausted", async () => {
+    vi.useFakeTimers();
+    opencodeMocks.checkConnectionAction.mockResolvedValue({
+      status: "error",
+      error: "unavailable",
+    });
+
+    renderHook(() => useWorkspaceConnection("alice", true));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+      for (let attempt = 0; attempt < 12; attempt += 1) {
+        await vi.runOnlyPendingTimersAsync();
+      }
+    });
+
+    expect(opencodeMocks.checkConnectionAction.mock.calls.length).toBeGreaterThan(11);
+    const callCount = opencodeMocks.checkConnectionAction.mock.calls.length;
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    expect(opencodeMocks.checkConnectionAction).toHaveBeenCalledTimes(callCount + 1);
+  });
+
   it("resets to connecting state when disabled after being connected", async () => {
     opencodeMocks.checkConnectionAction.mockResolvedValue({ status: "connected" });
     const onConnected = vi.fn().mockResolvedValue(undefined);

--- a/apps/web/src/hooks/__tests__/use-workspace-streaming.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-workspace-streaming.test.tsx
@@ -1689,6 +1689,335 @@ describe("useWorkspace streaming", () => {
   // -----------------------------------------------------------------------
 
   describe("fetch error handling", () => {
+    it("reattaches to the active run after a non-terminal stream EOF", async () => {
+      const firstStream = createSSEStream();
+      const secondStream = createSSEStream();
+      const streamBodies: Record<string, unknown>[] = [];
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          if (String(input) === "/api/u/alice/agents") {
+            return { ok: true, json: async () => ({ agents: DEFAULT_AGENTS }) };
+          }
+          if (String(input).startsWith("/api/w/alice/chat/runs?")) {
+            return { ok: true, json: async () => ({ activeRun: null }) };
+          }
+          if (String(input) === "/api/w/alice/chat/stream") {
+            streamBodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+            return {
+              ok: true,
+              headers: new Headers({ "X-Arche-Run-Id": "run-1" }),
+              body: streamBodies.length === 1 ? firstStream : secondStream,
+            };
+          }
+          throw new Error(`Unexpected fetch: ${String(input)}`);
+        })
+      );
+
+      const result = await renderConnectedHook();
+
+      await act(async () => {
+        await result.current.sendMessage("hello");
+      });
+
+      opencodeMocks.listMessagesAction.mockResolvedValue({
+        ok: true,
+        messages: [
+          {
+            id: "assistant-1",
+            sessionId: "s1",
+            role: "assistant",
+            content: "",
+            timestamp: "now",
+            parts: [],
+            pending: true,
+          },
+        ],
+      });
+
+      act(() => {
+        firstStream.close();
+      });
+
+      await waitFor(() => {
+        const assistant = result.current.messages.find((message) => message.id === "assistant-1");
+        expect(assistant?.pending).toBe(true);
+        expect(assistant?.statusInfo).toEqual({
+          status: "thinking",
+          detail: "stream_interrupted",
+        });
+      });
+
+      await waitFor(() => {
+        expect(streamBodies).toHaveLength(2);
+      }, { timeout: 4_000 });
+
+      expect(streamBodies[1]).toEqual({
+        sessionId: "s1",
+        runId: "run-1",
+        resume: false,
+      });
+
+      opencodeMocks.listMessagesAction.mockResolvedValue({
+        ok: true,
+        messages: [
+          {
+            id: "assistant-1",
+            sessionId: "s1",
+            role: "assistant",
+            content: "Recovered",
+            timestamp: "now",
+            parts: [{ id: "part-1", type: "text", text: "Recovered" }],
+            pending: false,
+          },
+        ],
+      });
+
+      act(() => {
+        secondStream.push(sseEvent("message", { id: "assistant-1", role: "assistant" }));
+        secondStream.push(sseEvent("part", {
+          messageId: "assistant-1",
+          part: {
+            id: "part-1",
+            messageID: "assistant-1",
+            text: "Recovered",
+            type: "text",
+          },
+        }));
+        secondStream.push(sseEvent("done", {}));
+        secondStream.close();
+      });
+
+      await waitFor(() => {
+        const assistant = result.current.messages.find((message) => message.id === "assistant-1");
+        expect(assistant?.pending).toBe(false);
+        expect(assistant?.content).toBe("Recovered");
+        expect(result.current.isSending).toBe(false);
+      });
+    }, 10_000);
+
+    it("schedules recovery after a recoverable upstream error event", async () => {
+      const firstStream = createSSEStream();
+      const secondStream = createSSEStream();
+      const streamBodies: Record<string, unknown>[] = [];
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          if (String(input) === "/api/u/alice/agents") {
+            return { ok: true, json: async () => ({ agents: DEFAULT_AGENTS }) };
+          }
+          if (String(input).startsWith("/api/w/alice/chat/runs?")) {
+            return { ok: true, json: async () => ({ activeRun: null }) };
+          }
+          if (String(input) === "/api/w/alice/chat/stream") {
+            streamBodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+            return {
+              ok: true,
+              headers: new Headers({ "X-Arche-Run-Id": "run-1" }),
+              body: streamBodies.length === 1 ? firstStream : secondStream,
+            };
+          }
+          throw new Error(`Unexpected fetch: ${String(input)}`);
+        })
+      );
+
+      const result = await renderConnectedHook();
+
+      await act(async () => {
+        await result.current.sendMessage("hello");
+      });
+
+      opencodeMocks.listMessagesAction.mockResolvedValue({
+        ok: true,
+        messages: [
+          {
+            id: "assistant-1",
+            sessionId: "s1",
+            role: "assistant",
+            content: "",
+            timestamp: "now",
+            parts: [],
+            pending: true,
+          },
+        ],
+      });
+
+      act(() => {
+        firstStream.push(sseEvent("error", { error: "upstream_eof", recoverable: true, runId: "run-1" }));
+        firstStream.close();
+      });
+
+      await waitFor(() => {
+        const assistant = result.current.messages.find((message) => message.id === "assistant-1");
+        expect(assistant?.pending).toBe(true);
+        expect(assistant?.statusInfo).toEqual({
+          status: "thinking",
+          detail: "upstream_eof",
+        });
+      });
+
+      await waitFor(() => {
+        expect(streamBodies).toHaveLength(2);
+      }, { timeout: 4_000 });
+
+      expect(streamBodies[1]).toEqual({
+        sessionId: "s1",
+        runId: "run-1",
+        resume: false,
+      });
+
+      opencodeMocks.listMessagesAction.mockResolvedValue({
+        ok: true,
+        messages: [
+          {
+            id: "assistant-1",
+            sessionId: "s1",
+            role: "assistant",
+            content: "Recovered via error event",
+            timestamp: "now",
+            parts: [{ id: "part-1", type: "text", text: "Recovered via error event" }],
+            pending: false,
+          },
+        ],
+      });
+
+      act(() => {
+        secondStream.push(sseEvent("message", { id: "assistant-1", role: "assistant" }));
+        secondStream.push(sseEvent("part", {
+          messageId: "assistant-1",
+          part: {
+            id: "part-1",
+            messageID: "assistant-1",
+            text: "Recovered via error event",
+            type: "text",
+          },
+        }));
+        secondStream.push(sseEvent("done", {}));
+        secondStream.close();
+      });
+
+      await waitFor(() => {
+        const assistant = result.current.messages.find((message) => message.id === "assistant-1");
+        expect(assistant?.pending).toBe(false);
+        expect(assistant?.content).toBe("Recovered via error event");
+        expect(result.current.isSending).toBe(false);
+      });
+    }, 10_000);
+
+    it("keeps recovering when a run reattachment fails before the stream opens", async () => {
+      const firstStream = createSSEStream();
+      const secondStream = createSSEStream();
+      let streamAttempts = 0;
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL) => {
+          if (String(input) === "/api/u/alice/agents") {
+            return { ok: true, json: async () => ({ agents: DEFAULT_AGENTS }) };
+          }
+          if (String(input).startsWith("/api/w/alice/chat/runs?")) {
+            return { ok: true, json: async () => ({ activeRun: null }) };
+          }
+          if (String(input) === "/api/w/alice/chat/stream") {
+            streamAttempts += 1;
+            if (streamAttempts === 2) {
+              // Transport failure on the first reattachment attempt (e.g. BFF
+              // restart during a deployment): the run was already accepted, so
+              // this must not fail the message.
+              throw new TypeError("fetch failed");
+            }
+            return {
+              ok: true,
+              headers: new Headers({ "X-Arche-Run-Id": "run-1" }),
+              body: streamAttempts === 1 ? firstStream : secondStream,
+            };
+          }
+          throw new Error(`Unexpected fetch: ${String(input)}`);
+        })
+      );
+
+      const result = await renderConnectedHook();
+
+      await act(async () => {
+        await result.current.sendMessage("hello");
+      });
+
+      opencodeMocks.listMessagesAction.mockResolvedValue({
+        ok: true,
+        messages: [
+          {
+            id: "assistant-1",
+            sessionId: "s1",
+            role: "assistant",
+            content: "",
+            timestamp: "now",
+            parts: [],
+            pending: true,
+          },
+        ],
+      });
+
+      act(() => {
+        firstStream.close();
+      });
+
+      // The interrupted run keeps the message pending while reattaching.
+      await waitFor(() => {
+        expect(streamAttempts).toBe(2);
+      }, { timeout: 4_000 });
+
+      // The failed reattachment must schedule another recovery attempt instead
+      // of declaring a terminal error.
+      await waitFor(() => {
+        expect(streamAttempts).toBe(3);
+      }, { timeout: 6_000 });
+
+      const assistantDuringRecovery = result.current.messages.find(
+        (message) => message.id === "assistant-1"
+      );
+      expect(assistantDuringRecovery?.pending).toBe(true);
+      expect(assistantDuringRecovery?.statusInfo?.status).toBe("thinking");
+
+      opencodeMocks.listMessagesAction.mockResolvedValue({
+        ok: true,
+        messages: [
+          {
+            id: "assistant-1",
+            sessionId: "s1",
+            role: "assistant",
+            content: "Recovered after transport failure",
+            timestamp: "now",
+            parts: [{ id: "part-1", type: "text", text: "Recovered after transport failure" }],
+            pending: false,
+          },
+        ],
+      });
+
+      act(() => {
+        secondStream.push(sseEvent("message", { id: "assistant-1", role: "assistant" }));
+        secondStream.push(sseEvent("part", {
+          messageId: "assistant-1",
+          part: {
+            id: "part-1",
+            messageID: "assistant-1",
+            text: "Recovered after transport failure",
+            type: "text",
+          },
+        }));
+        secondStream.push(sseEvent("done", {}));
+        secondStream.close();
+      });
+
+      await waitFor(() => {
+        const assistant = result.current.messages.find((message) => message.id === "assistant-1");
+        expect(assistant?.pending).toBe(false);
+        expect(assistant?.content).toBe("Recovered after transport failure");
+        expect(result.current.isSending).toBe(false);
+      });
+    }, 15_000);
+
     it("sets error status when stream endpoint returns HTTP error", async () => {
       vi.stubGlobal(
         "fetch",

--- a/apps/web/src/hooks/use-workspace-connection.ts
+++ b/apps/web/src/hooks/use-workspace-connection.ts
@@ -39,7 +39,10 @@ export function useWorkspaceConnection(
   }, [onConnected]);
 
   const checkConnection = useCallback(async () => {
-    const result = await checkConnectionAction(slug);
+    const result = await checkConnectionAction(slug).catch((error: unknown) => ({
+      status: "error" as const,
+      error: error instanceof Error ? error.message : "connection_check_failed",
+    }));
     setConnection(result);
     return result.status === "connected";
   }, [slug]);
@@ -61,22 +64,19 @@ export function useWorkspaceConnection(
       if (connected) {
         retryCount = 0;
         await onConnectedRef.current?.();
-      } else if (retryCount < MAX_RETRIES) {
+      } else {
         retryCount++;
-        const delay = Math.min(
-          BASE_DELAY_MS * Math.pow(2, retryCount - 1),
-          MAX_DELAY_MS,
-        );
+        const delay = retryCount <= MAX_RETRIES
+          ? Math.min(BASE_DELAY_MS * Math.pow(2, retryCount - 1), MAX_DELAY_MS)
+          : MAX_DELAY_MS;
         console.log(
-          `[useWorkspaceConnection] Connection failed, retrying in ${delay}ms (attempt ${retryCount}/${MAX_RETRIES})`,
+          retryCount <= MAX_RETRIES
+            ? `[useWorkspaceConnection] Connection failed, retrying in ${delay}ms (attempt ${retryCount}/${MAX_RETRIES})`
+            : `[useWorkspaceConnection] Connection still unavailable, retrying in ${delay}ms`,
         );
         retryTimeout = setTimeout(() => {
           if (mounted) init();
         }, delay);
-      } else {
-        console.log(
-          "[useWorkspaceConnection] Max retries reached, giving up",
-        );
       }
     }
 

--- a/apps/web/src/hooks/workspace/__tests__/use-workspace-streaming-helpers.test.ts
+++ b/apps/web/src/hooks/workspace/__tests__/use-workspace-streaming-helpers.test.ts
@@ -142,6 +142,25 @@ describe("workspace streaming helpers", () => {
     expect(result).toEqual({ action: "none" });
   });
 
+  it("keeps a recoverably interrupted message pending when hydration fails", () => {
+    const result = reconcileStreamMessages({
+      mode: "send",
+      assistantMessageId: null,
+      targetMessageId: "temp-assistant",
+      receivedAssistantPart: false,
+      receivedStreamData: true,
+      interruptionDetail: "upstream_eof",
+      terminalErrorDetail: null,
+      result: { ok: false, error: "offline" },
+      resumeFailureState: new Map(),
+    });
+
+    expect(result).toEqual({
+      action: "stream-interrupted",
+      detail: "upstream_eof",
+    });
+  });
+
   it("marks failed streams as incomplete when hydration fails without assistant parts", () => {
     const result = reconcileStreamMessages({
       mode: "send",

--- a/apps/web/src/hooks/workspace/use-workspace-streaming.ts
+++ b/apps/web/src/hooks/workspace/use-workspace-streaming.ts
@@ -48,6 +48,7 @@ export type StreamReconciliationInput = {
   targetMessageId: string;
   receivedAssistantPart: boolean;
   receivedStreamData: boolean;
+  interruptionDetail?: string | null;
   terminalErrorDetail: string | null;
   result: ListMessagesResult;
   resumeFailureState: Map<string, ResumeFailureState>;
@@ -57,9 +58,24 @@ export type StreamReconciliationResult =
   | { action: "hydrate"; messages: WorkspaceMessage[] }
   | { action: "fallback-error"; messageId: string; detail: string }
   | { action: "stream-incomplete"; detail: string }
+  | { action: "stream-interrupted"; detail: string }
   | { action: "none" };
 
 const STREAM_RECONCILIATION_DELAY_MS = 250;
+const STREAM_RECOVERY_BASE_DELAY_MS = 1_000;
+const STREAM_RECOVERY_MAX_DELAY_MS = 30_000;
+
+type StreamMode = "send" | "resume";
+type StreamOptions = {
+  sessionId: string;
+  mode: StreamMode;
+  targetMessageId: string;
+  runId?: string;
+  text?: string;
+  model?: { providerId: string; modelId: string };
+  attachments?: { path: string; filename?: string; mime?: string }[];
+  contextPaths?: string[];
+};
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -106,11 +122,15 @@ export function reconcileStreamMessages({
   targetMessageId,
   receivedAssistantPart,
   receivedStreamData,
+  interruptionDetail,
   terminalErrorDetail,
   result,
   resumeFailureState,
 }: StreamReconciliationInput): StreamReconciliationResult {
   if (!result.ok || !result.messages) {
+    if (interruptionDetail) {
+      return { action: "stream-interrupted", detail: interruptionDetail };
+    }
     if (!terminalErrorDetail && receivedAssistantPart) return { action: "none" };
     return {
       action: "stream-incomplete",
@@ -130,6 +150,12 @@ export function reconcileStreamMessages({
   let hydratedMessages: WorkspaceMessage[] = result.messages.map(
     (message): WorkspaceMessage => {
       const resumeState = resumeFailureState.get(message.id);
+      if (message.role === "assistant" && message.pending && interruptionDetail) {
+        return {
+          ...message,
+          statusInfo: { status: "thinking", detail: interruptionDetail },
+        };
+      }
       if (
         message.role === "assistant" &&
         message.pending &&
@@ -145,6 +171,10 @@ export function reconcileStreamMessages({
       return message;
     }
   );
+
+  if (interruptionDetail && hydratedMessages.length === 0) {
+    return { action: "stream-interrupted", detail: interruptionDetail };
+  }
 
   if (mode === "send" && assistantMessageId && !receivedAssistantPart) {
     const assistantMessage = hydratedMessages.find(
@@ -226,6 +256,9 @@ export function useWorkspaceStreaming({
     abortController: AbortController;
   }>());
   const latestStreamTokensRef = useRef(new Map<string, number>());
+  const recoveryAttemptsRef = useRef(new Map<string, number>());
+  const recoveryTimeoutsRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+  const streamChatRef = useRef<((options: StreamOptions) => Promise<void>) | null>(null);
   const isMountedRef = useRef(true);
   const workspaceRefreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -241,13 +274,21 @@ export function useWorkspaceStreaming({
   }, [getSessions]);
 
   const setSessionStreamStatusTo = useCallback(
-    (sessionId: string, status: "submitted" | "streaming" | "error" | "ready") => {
+    (
+      sessionId: string,
+      status: "submitted" | "streaming" | "error" | "ready",
+      notifyBackgroundCompletion = true
+    ) => {
       setSessionStreamStatus((prev) => {
         if (status === "ready") {
           if (!(sessionId in prev)) return prev;
 
           const wasStreaming = prev[sessionId] === "submitted" || prev[sessionId] === "streaming";
-          if (wasStreaming && sessionId !== activeSessionIdGetterRef.current()) {
+          if (
+            notifyBackgroundCompletion &&
+            wasStreaming &&
+            sessionId !== activeSessionIdGetterRef.current()
+          ) {
             onBackgroundStreamCompleted(sessionId);
           }
 
@@ -269,6 +310,12 @@ export function useWorkspaceStreaming({
 
   const abortSessionStream = useCallback(
     (sessionId: string) => {
+      const recoveryTimeout = recoveryTimeoutsRef.current.get(sessionId);
+      if (recoveryTimeout) {
+        clearTimeout(recoveryTimeout);
+        recoveryTimeoutsRef.current.delete(sessionId);
+      }
+
       const activeStream = activeStreamsRef.current.get(sessionId);
       if (!activeStream) return;
 
@@ -284,6 +331,12 @@ export function useWorkspaceStreaming({
   );
 
   const abortAllStreams = useCallback(() => {
+    for (const recoveryTimeout of recoveryTimeoutsRef.current.values()) {
+      clearTimeout(recoveryTimeout);
+    }
+    recoveryTimeoutsRef.current.clear();
+    recoveryAttemptsRef.current.clear();
+
     for (const sessionId of activeStreamsRef.current.keys()) {
       const activeStream = activeStreamsRef.current.get(sessionId);
       activeStream?.abortController.abort();
@@ -404,18 +457,6 @@ export function useWorkspaceStreaming({
     [deriveStatusInfoFromPart, updateSessionMessages]
   );
 
-  type StreamMode = "send" | "resume";
-  type StreamOptions = {
-    sessionId: string;
-    mode: StreamMode;
-    targetMessageId: string;
-    runId?: string;
-    text?: string;
-    model?: { providerId: string; modelId: string };
-    attachments?: { path: string; filename?: string; mime?: string }[];
-    contextPaths?: string[];
-  };
-
   const streamChat = useCallback(
     async ({
       sessionId,
@@ -459,12 +500,14 @@ export function useWorkspaceStreaming({
 
       let assistantMessageId: string | null =
         mode === "resume" ? targetMessageId : null;
-      const runId = existingRunId ?? null;
+      let observedRunId = existingRunId ?? null;
       const bufferedParts = new Map<string, MessagePart[]>();
       const textAccumulatorByPart = new Map<string, string>();
       let streamCompleted = false;
+      let streamResponseOpened = false;
       let receivedAssistantPart = false;
       let receivedStreamData = false;
+      let interruptionDetail: string | null = null;
       let terminalErrorDetail: string | null = null;
       let resumePollInterval: ReturnType<typeof setInterval> | null = null;
 
@@ -574,10 +617,10 @@ export function useWorkspaceStreaming({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             sessionId,
-            ...(runId ? { runId } : {}),
+            ...(observedRunId ? { runId: observedRunId } : {}),
             resume: mode === "resume",
             messageId: mode === "resume" ? targetMessageId : undefined,
-            ...(mode === "send" && !runId
+            ...(mode === "send" && !observedRunId
               ? { text, model, attachments, contextPaths }
               : {}),
           }),
@@ -590,6 +633,9 @@ export function useWorkspaceStreaming({
             .catch(() => ({ error: "Failed to send message" }));
           throw new Error(error.error || "Failed to send message");
         }
+
+        streamResponseOpened = true;
+        observedRunId = response.headers?.get("X-Arche-Run-Id") || observedRunId;
 
         const reader = response.body?.getReader();
         if (!reader) {
@@ -634,11 +680,19 @@ export function useWorkspaceStreaming({
               setSessionStreamStatusTo(sessionId, "streaming");
               const data = JSON.parse(parsedEvent.data);
 
+              if (
+                parsedEvent.event !== "error" &&
+                parsedEvent.event !== "status"
+              ) {
+                recoveryAttemptsRef.current.delete(sessionId);
+              }
+
               switch (parsedEvent.event) {
                 case "status": {
                   const status = data.status as MessageStatus;
                   updateStatus(status, data.toolName, data.detail);
                   if (status === "complete" || status === "error") {
+                    recoveryAttemptsRef.current.delete(sessionId);
                     streamCompleted = true;
                   }
                   break;
@@ -697,14 +751,25 @@ export function useWorkspaceStreaming({
                 }
 
                 case "done": {
+                  recoveryAttemptsRef.current.delete(sessionId);
                   updateStatus("complete");
                   streamCompleted = true;
                   break;
                 }
 
                 case "error": {
-                  terminalErrorDetail = typeof data.error === "string" ? data.error : terminalErrorDetail;
-                  updateStatus("error", undefined, data.error);
+                  const detail = typeof data.error === "string" ? data.error : "stream_interrupted";
+                  if (data.recoverable === true) {
+                    interruptionDetail = detail;
+                    if (typeof data.runId === "string") {
+                      observedRunId = data.runId;
+                    }
+                    updateStatus("thinking", undefined, detail);
+                  } else {
+                    recoveryAttemptsRef.current.delete(sessionId);
+                    terminalErrorDetail = detail;
+                    updateStatus("error", undefined, detail);
+                  }
                   streamCompleted = true;
                   break;
                 }
@@ -722,17 +787,27 @@ export function useWorkspaceStreaming({
             break;
           }
         }
+
+        if (!streamCompleted) {
+          interruptionDetail = "stream_interrupted";
+          updateStatus("thinking", undefined, interruptionDetail);
+        }
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
           return;
         }
         console.error("[useWorkspace] Streaming error:", error);
-        terminalErrorDetail = error instanceof Error ? error.message : "Unknown error";
-        updateStatus(
-          "error",
-          undefined,
-          terminalErrorDetail
-        );
+        const detail = error instanceof Error ? error.message : "Unknown error";
+        // A runId-carrying stream only observes an already-accepted run, so a
+        // transport failure before the response opens is recoverable: nothing
+        // was sent and the run may still be active and reattachable.
+        if (streamResponseOpened || observedRunId) {
+          interruptionDetail = "stream_interrupted";
+          updateStatus("thinking", undefined, interruptionDetail);
+        } else {
+          terminalErrorDetail = detail;
+          updateStatus("error", undefined, terminalErrorDetail);
+        }
       } finally {
         if (resumePollInterval) {
           clearInterval(resumePollInterval);
@@ -741,7 +816,7 @@ export function useWorkspaceStreaming({
         const isLatestStream = () => latestStreamTokensRef.current.get(sessionId) === token;
 
         if (mode === "resume") {
-          if (streamCompleted || receivedAssistantPart) {
+          if (interruptionDetail || streamCompleted || receivedAssistantPart) {
             resumeFailureStateRef.current.delete(targetMessageId);
           } else {
             // If the session is still actively processing, don't record a
@@ -769,7 +844,11 @@ export function useWorkspaceStreaming({
         if (isLatestStream()) {
           activeStreamsRef.current.delete(sessionId);
           if (isMountedRef.current) {
-            setSessionStreamStatusTo(sessionId, "ready");
+            setSessionStreamStatusTo(
+              sessionId,
+              "ready",
+              interruptionDetail === null
+            );
           }
         }
 
@@ -789,12 +868,32 @@ export function useWorkspaceStreaming({
             return;
           }
 
+          if (interruptionDetail && result.ok && result.messages) {
+            const pendingAssistant = [...result.messages].reverse().find(
+              (message) => message.role === "assistant" && message.pending
+            );
+            if (!assistantMessageId && pendingAssistant) {
+              assistantMessageId = pendingAssistant.id;
+            }
+
+            const observedAssistantId = assistantMessageId ?? (
+              mode === "resume" ? targetMessageId : null
+            );
+            const observedAssistant = observedAssistantId
+              ? result.messages.find((message) => message.id === observedAssistantId)
+              : null;
+            if (observedAssistant && !observedAssistant.pending) {
+              interruptionDetail = null;
+            }
+          }
+
           const reconciliation = reconcileStreamMessages({
             mode,
             assistantMessageId,
             targetMessageId,
             receivedAssistantPart,
             receivedStreamData,
+            interruptionDetail,
             terminalErrorDetail,
             result,
             resumeFailureState: resumeFailureStateRef.current,
@@ -820,8 +919,40 @@ export function useWorkspaceStreaming({
             !receivedAssistantPart
           ) {
             updateStatus("error", undefined, reconciliation.detail);
+          } else if (reconciliation.action === "stream-interrupted") {
+            updateStatus("thinking", undefined, reconciliation.detail);
           }
           scheduleWorkspaceRefresh();
+
+          if (interruptionDetail && isLatestStream() && isMountedRef.current) {
+            const attempt = (recoveryAttemptsRef.current.get(sessionId) ?? 0) + 1;
+            recoveryAttemptsRef.current.set(sessionId, attempt);
+            const recoveryDelay = Math.min(
+              STREAM_RECOVERY_BASE_DELAY_MS * Math.pow(2, attempt - 1),
+              STREAM_RECOVERY_MAX_DELAY_MS
+            );
+            const recoveryTargetMessageId = assistantMessageId ?? targetMessageId;
+            const recoveryOptions: StreamOptions = observedRunId
+              ? {
+                  sessionId,
+                  mode: "send",
+                  targetMessageId: recoveryTargetMessageId,
+                  runId: observedRunId,
+                }
+              : {
+                  sessionId,
+                  mode: "resume",
+                  targetMessageId: recoveryTargetMessageId,
+                };
+
+            const recoveryTimeout = setTimeout(() => {
+              if (recoveryTimeoutsRef.current.get(sessionId) !== recoveryTimeout) return;
+              recoveryTimeoutsRef.current.delete(sessionId);
+              if (!isMountedRef.current || activeStreamsRef.current.has(sessionId)) return;
+              void streamChatRef.current?.(recoveryOptions);
+            }, recoveryDelay);
+            recoveryTimeoutsRef.current.set(sessionId, recoveryTimeout);
+          }
         }
 
         if (isLatestStream()) {
@@ -842,6 +973,10 @@ export function useWorkspaceStreaming({
       resumeFailureStateRef,
     ]
   );
+
+  useEffect(() => {
+    streamChatRef.current = streamChat;
+  }, [streamChat]);
 
   const isSending = useMemo(() => {
     return Object.values(sessionStreamStatus).some(


### PR DESCRIPTION
- add 5s health check timeout with explicit classification
- implement persistent connection retry with 30s slow backoff
- distinguish terminal send failures from recoverable stream interruptions
- add 8s event stream connection timeout with diagnostics
- preserve pending UI state during stream recovery and reattachment
- add comprehensive tests for health checks, retries, and recovery