### PR TITLE
chore: gitignore local codegraph index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,8 @@ archectl_*
 infra/**/.env
 infra/**/.env.local*
 
+# CodeGraph local index (per-machine cache, regenerable with `codegraph init`)
+.codegraph/
+
 # Claude AI local config
 .claude/


### PR DESCRIPTION
## What

Adds `.codegraph/` to the root `.gitignore`.

## Why

CodeGraph generates a local index (symbol/dependency graph) in `.codegraph/` when you run `codegraph init`:

- `codegraph.db` (~77 MB, SQLite) plus transient files (`-shm`, `-wal`, `daemon.pid`, `daemon.log`)
- It is a regenerable, per-machine cache — like `node_modules` or `.next` — not part of the source code
- The folder already self-protects with an internal `.gitignore` (ignores everything but itself), but that makes `git status` show it as untracked and a careless `git add .` could commit `.codegraph/.gitignore`

The root `.gitignore` entry is the canonical fix: the folder disappears from git entirely.

## Verification

- `git status` no longer shows `.codegraph/` as untracked
- `git check-ignore .codegraph/codegraph.db` → ignored
