### PR TITLE
fix(workspace): validate attachment rename destination path

### DIFF
--- a/apps/web/src/app/api/w/[slug]/attachments/__tests__/route.test.ts
+++ b/apps/web/src/app/api/w/[slug]/attachments/__tests__/route.test.ts
@@ -261,6 +261,23 @@ describe('/api/w/[slug]/attachments', () => {
       expect(json.error).toBe('invalid_path')
     })
 
+    it('returns 400 and skips the agent when rename destination path is invalid', async () => {
+      mocks.isWorkspaceAttachmentPath.mockImplementation(
+        (path: string) => path !== '/workspace/attachments/new.txt',
+      )
+      const res = await PATCH(
+        makeRequest('PATCH', 'http://localhost/api/w/alice/attachments', {
+          body: JSON.stringify({ path: '/workspace/attachments/old.txt', name: 'new.txt' }),
+          headers: { 'content-type': 'application/json' },
+        }),
+        bodyParams(),
+      )
+      expect(res.status).toBe(400)
+      const json = await res.json()
+      expect(json.error).toBe('invalid_path')
+      expect(mocks.workspaceAgentFetch).not.toHaveBeenCalled()
+    })
+
     it('returns 400 for invalid name', async () => {
       mocks.sanitizeAttachmentFilename.mockReturnValue('')
       const res = await PATCH(

--- a/apps/web/src/app/api/w/[slug]/attachments/route.ts
+++ b/apps/web/src/app/api/w/[slug]/attachments/route.ts
@@ -273,6 +273,9 @@ export const PATCH = withAuth(
     }
 
     const newPath = `${WORKSPACE_ATTACHMENTS_DIR}/${sanitizedName}`
+    if (!isWorkspaceAttachmentPath(newPath)) {
+      return jsonResponse(400, { error: 'invalid_path' })
+    }
 
     const response = await workspaceAgentFetch<{ ok: boolean; path?: string; newPath?: string; error?: string }>(
       auth.agent,


### PR DESCRIPTION
## Summary

Closes **#439**: the attachments PATCH endpoint validated the rename **source** path with `isWorkspaceAttachmentPath` but sent the **destination** (`newPath`) to the workspace-agent `/files/rename` without validation. The Go agent only guarantees "inside workspace", not "inside `.arche/attachments/`", so the BFF must enforce the attachment-directory invariant on both paths.

- Add destination validation in `PATCH /api/w/[slug]/attachments`: after building `newPath`, reject with `400 { error: 'invalid_path' }` if `isWorkspaceAttachmentPath(newPath)` fails — before contacting the workspace-agent.
- Reuses the exact existing error code/string (`invalid_path`) — no new codes, no frontend/UI changes.
- Regression test in `src/app/api/w/[slug]/attachments/__tests__/route.test.ts` (PATCH describe block) proving the destination is validated independently of the source and the agent is not contacted on rejection. Written test-first (TDD): failed with `404` before the fix, passes after.

## Tests / checks run

- `pnpm vitest run src/app/api/w/\[slug\]/attachments/__tests__/route.test.ts` (from `apps/web/`) — 21/21 passed
- `pnpm test` (from `apps/web/`) — 5125 passed, 15 skipped (pre-existing `vi.unmock` warnings in unrelated files)
- `pnpm lint` (from `apps/web/`) — 0 errors, 20 pre-existing warnings (none in touched files)
- `bash scripts/check-podman-images.sh` (from repo root) — passed

## Review notes / risks

- Happy path unchanged: valid renames behave exactly as before (existing tests still pass).
- Test seam note: `tests/attachments-routes.test.ts` (real sanitizer) cannot exercise this path by construction — a sanitized name can never produce an invalid destination — so the unit suite is the correct seam; no attempt made to force it.
- No DB, migration, infra, UI, or workspace-agent changes. Diff is +3 lines in the route, +17 in the test.

## Checklist

- [x] Tests pass: `pnpm test`
- [x] Linter passes: `pnpm lint`
- [x] Podman images build locally: `bash scripts/check-podman-images.sh`
- [x] Self-review: diff scoped to the two intended files, minimal necessary change
- [x] No docs/config changes required
- [x] No secrets, `.env`, or credentials committed
