### PR TITLE
test(web): add PG integration test documenting reapStaleRuns TOCTOU safety (#422)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -88,6 +88,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Apply database migrations
+        run: pnpm exec prisma migrate deploy
+
+      - name: Run stale message-run reap integration test
+        run: pnpm exec vitest run src/lib/services/__tests__/message-run.e2e.test.ts
+
       - name: Install Playwright browser
         run: pnpm exec playwright install --with-deps chromium
 

--- a/apps/web/src/lib/services/__tests__/message-run.e2e.test.ts
+++ b/apps/web/src/lib/services/__tests__/message-run.e2e.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Integration test for reapStaleRuns() against a real Postgres.
+ *
+ * Reproduces the TOCTOU interleaving from issue #422: the reaper reads stale
+ * locks, and while it is paused a session finishes its run and starts a fresh
+ * one for the same (slug, sessionId).
+ *
+ * Requires DATABASE_URL pointing at a Postgres with migrations applied:
+ *   DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/arche_ci pnpm exec vitest run src/lib/services/__tests__/message-run.e2e.test.ts
+ */
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+const DATABASE_URL = process.env.DATABASE_URL
+const SKIP = !DATABASE_URL
+
+type PrismaModule = typeof import('@/lib/prisma')
+type MessageRunModule = typeof import('../message-run')
+type PrismaClientType = import('@prisma/client').PrismaClient
+
+let prismaModule: PrismaModule
+let messageRunModule: MessageRunModule
+let baseClient: PrismaClientType
+let controlClient: PrismaClientType
+
+describe.runIf(!SKIP)('reapStaleRuns stale-lock read vs reap race', () => {
+  beforeAll(async () => {
+    // Dynamic imports so the module loads without a DATABASE_URL when skipped.
+    prismaModule = await import('@/lib/prisma')
+    messageRunModule = await import('../message-run')
+
+    await prismaModule.initWebPrisma()
+    baseClient = globalThis.prisma!
+
+    const { PrismaClient } = await import('@prisma/client')
+    const { PrismaPg } = await import('@prisma/adapter-pg')
+    const { Pool } = await import('pg')
+    controlClient = new PrismaClient({
+      adapter: new PrismaPg(new Pool({ connectionString: DATABASE_URL })),
+    })
+  })
+
+  afterAll(async () => {
+    globalThis.prisma = baseClient
+    await Promise.allSettled([controlClient.$disconnect(), baseClient.$disconnect()])
+  })
+
+  it('does not fail a replacement run started for the same session between the stale-lock query and the reap', async () => {
+    const now = new Date()
+    const slug = `e2e-reap-${randomUUID()}`
+    const sessionId = `session-${randomUUID()}`
+    const staleRunId = randomUUID()
+    const replacementRunId = randomUUID()
+
+    // Seed a stale running run R1 with its lock L1 for (slug, sessionId).
+    await controlClient.messageRun.create({
+      data: {
+        id: staleRunId,
+        slug,
+        sessionId,
+        source: 'test',
+        status: 'running',
+        startedAt: new Date(now.getTime() - messageRunModule.MESSAGE_RUN_TIMEOUT_MS - 60_000),
+      },
+    })
+    await controlClient.messageRunLock.create({
+      data: { slug, sessionId, runId: staleRunId },
+    })
+
+    // Pause the reaper immediately after its stale-lock findMany returns.
+    let markStaleLocksRead!: () => void
+    const staleLocksRead = new Promise<void>((resolve) => {
+      markStaleLocksRead = resolve
+    })
+    let releaseReaper!: () => void
+    const reaperGate = new Promise<void>((resolve) => {
+      releaseReaper = resolve
+    })
+
+    const gatedClient = baseClient.$extends({
+      query: {
+        messageRunLock: {
+          async findMany({ args, query }) {
+            const result = await query(args)
+            markStaleLocksRead()
+            await reaperGate
+            return result
+          },
+        },
+      },
+    })
+    vi.stubGlobal('prisma', gatedClient)
+
+    try {
+      const reapPromise = messageRunModule.reapStaleRuns(now)
+      await staleLocksRead
+
+      // Interleaving from a second client while the reaper is paused:
+      // R1 finishes successfully, its lock is deleted, and a fresh run R2
+      // with a fresh lock L2 starts for the same session.
+      await controlClient.messageRun.updateMany({
+        where: { id: staleRunId, status: 'running' },
+        data: { status: 'succeeded', error: null, finishedAt: new Date() },
+      })
+      await controlClient.messageRunLock.deleteMany({ where: { runId: staleRunId } })
+      await controlClient.messageRun.create({
+        data: {
+          id: replacementRunId,
+          slug,
+          sessionId,
+          source: 'test',
+          status: 'running',
+          startedAt: new Date(),
+        },
+      })
+      await controlClient.messageRunLock.create({
+        data: { slug, sessionId, runId: replacementRunId },
+      })
+
+      releaseReaper()
+      const reaped = await reapPromise
+
+      expect(reaped).toBe(0)
+      const staleRun = await controlClient.messageRun.findUnique({
+        where: { id: staleRunId },
+      })
+      expect(staleRun?.status).toBe('succeeded')
+      expect(staleRun?.error).toBeNull()
+      const replacementRun = await controlClient.messageRun.findUnique({
+        where: { id: replacementRunId },
+      })
+      expect(replacementRun?.status).toBe('running')
+      const lock = await controlClient.messageRunLock.findUnique({
+        where: { slug_sessionId: { slug, sessionId } },
+      })
+      expect(lock?.runId).toBe(replacementRunId)
+    } finally {
+      vi.unstubAllGlobals()
+      await controlClient.messageRunLock.deleteMany({
+        where: { runId: { in: [staleRunId, replacementRunId] } },
+      })
+      await controlClient.messageRun.deleteMany({
+        where: { id: { in: [staleRunId, replacementRunId] } },
+      })
+    }
+  })
+})


### PR DESCRIPTION
## What & why

Investigation deliverable for [#422](https://github.com/peaberry-studio/arche/issues/422): `reapStaleRuns()` TOCTOU between the stale-lock query and the delete. Outcome: **confirmed false positive** — a deterministic Postgres-backed integration test reproduces the suspected interleaving and proves the existing invariants already protect it. No production code changed.

- **New integration test** `apps/web/src/lib/services/__tests__/message-run.e2e.test.ts`:
  - Seeds a stale running run R1 + lock L1 for a unique `(slug, sessionId)`.
  - Pauses `reapStaleRuns()` immediately after its `messageRunLock.findMany` returns via a Prisma `$extends` query-extension gate on the client behind `globalThis.prisma` (pure promise gating, no timers — deterministic).
  - From a second, independent Prisma client: finishes R1 (`succeeded`), deletes L1, starts a fresh R2 + L2 for the same session.
  - Asserts: reaper returns `0`, R1 not overwritten to `failed`, R2 still `running`, L2 still present.
  - Unique ids per run; cleans up only its own rows; `describe.runIf(!DATABASE_URL)` so it skips cleanly (not fails) where no DB is configured.
- **CI wiring** `.github/workflows/pr-checks.yml`: reuses the existing `web-e2e-smoke` job (postgres:16 service + `DATABASE_URL`), adding `prisma migrate deploy` + the vitest run of the new test before the Playwright smoke. DB-less `web-lint-test` is untouched.

The issue's suggested fix (`status: 'running'` in the `deleteMany` WHERE) was deliberately **not** implemented — it is wrong as written: the same transaction flips the run to `failed` before the delete executes, which would suppress the very deletes the reaper must perform.

## Tests / checks run (local)

- `pnpm test` (full unit suite, DB-less) → `5124 passed | 16 skipped` (new test skips cleanly without DB)
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/arche_ci pnpm exec vitest run src/lib/services/__tests__/message-run.e2e.test.ts` → `1 passed` (run twice sequentially against the same DB; postgres:16, `prisma migrate deploy` applied)
- Negative control: removing the interleaving step makes the test fail (`reaped` 1 ≠ 0) — proves the test detects the destructive behavior
- `pnpm lint` → `0 errors` (20 warnings, all pre-existing)
- `tsc --noEmit` → 0 errors in the new file (pre-existing errors elsewhere in `tests/`, not gated)
- `bash scripts/check-podman-images.sh` → passed

## Review notes / risks

- Sync seam lives entirely in the test (`$extends` + `vi.stubGlobal('prisma', …)`); production code is untouched (`message-run.ts` not modified).
- CI runs the new test in `web-e2e-smoke` against a fresh `arche_ci` DB; the test cleans up after itself (verified by running twice back-to-back).
- Minimal surface: one test file + 6 lines of workflow.

## Checklist

- [x] Tests run and green (`pnpm test`, targeted e2e against Postgres)
- [x] Self-review: `pnpm lint` clean, `tsc --noEmit` clean for the new file
- [x] No secrets committed
- [x] Docs/config updates where relevant (CI workflow updated intentionally)
- [x] Conventional commit: `test(web): add PG integration test documenting reapStaleRuns TOCTOU safety (#422)`
