### PR TITLE
fix(workspace): stop terminal provider retries

### DIFF
--- a/apps/web/src/actions/__tests__/opencode.test.ts
+++ b/apps/web/src/actions/__tests__/opencode.test.ts
@@ -733,6 +733,35 @@ describe('listMessagesAction', () => {
     expect(result.ok).toBe(true)
   })
 
+  it('stops the latest incomplete assistant for terminal provider retries', async () => {
+    mockSessionMessages.mockResolvedValue({
+      data: [
+        {
+          info: { id: 'msg-1', role: 'assistant', time: { created: Date.now() } },
+          parts: [],
+        },
+      ],
+    })
+    mockSessionStatus.mockResolvedValue({
+      data: {
+        'sess-1': {
+          type: 'retry',
+          action: { reason: 'free_tier_limit' },
+        },
+      },
+    })
+
+    const result = await listMessagesAction('alice', 'sess-1')
+
+    expect(result.messages).toMatchObject([
+      {
+        id: 'msg-1',
+        pending: false,
+        statusInfo: { status: 'error', detail: 'free_tier_limit' },
+      },
+    ])
+  })
+
   it('hydrates pending permissions onto their assistant message and keeps it pending', async () => {
     mockSessionMessages.mockResolvedValue({
       data: [

--- a/apps/web/src/actions/opencode.ts
+++ b/apps/web/src/actions/opencode.ts
@@ -3,6 +3,7 @@
 import { createFlowActorScope } from "@/lib/flows/authorization";
 import { isLearningSessionTitle } from "@/lib/learning/session-title";
 import { createInstanceClient, getInstanceUrl } from "@/lib/opencode/client";
+import { getTerminalRetryError } from "@/lib/opencode/retry-state";
 import {
   abortSessionFamilyAndConfirmIdle,
   EXECUTION_TERMINATION_UNCONFIRMED_ERROR,
@@ -438,8 +439,19 @@ type ListWorkspaceSessionFamilyResult = {
   error?: string;
 };
 
-function toBusyStatus(type: unknown): "active" | "idle" | "busy" | "error" {
-  if (type === "busy" || type === "retry") {
+type RuntimeSessionStatus = {
+  action?: {
+    reason?: string;
+  };
+  type?: string;
+};
+
+function toBusyStatus(status: RuntimeSessionStatus | undefined): "active" | "idle" | "busy" | "error" {
+  if (getTerminalRetryError(status)) {
+    return "error";
+  }
+
+  if (status?.type === "busy" || status?.type === "retry") {
     return "busy";
   }
 
@@ -448,7 +460,7 @@ function toBusyStatus(type: unknown): "active" | "idle" | "busy" | "error" {
 
 function toWorkspaceSessions(
   sessions: WorkspaceSessionListEntry[],
-  statuses: Record<string, { type?: string }>,
+  statuses: Record<string, RuntimeSessionStatus>,
   flowBySessionId: Map<string, Awaited<ReturnType<typeof flowService.findSessionMetadataForWorkspace>>[number]>,
 ): WorkspaceSession[] {
   return sessions.map((session) => {
@@ -457,7 +469,7 @@ function toWorkspaceSessions(
     return {
       id: session.id,
       title: session.title || "Untitled",
-      status: toBusyStatus(statuses[session.id]?.type),
+      status: toBusyStatus(statuses[session.id]),
       updatedAt: formatTimestamp(session.updatedAtRaw),
       updatedAtRaw: session.updatedAtRaw,
       parentId: session.parentId,
@@ -509,7 +521,7 @@ async function getWorkspaceSessionMetadata(
     client.session.status(),
     getAuthorizedWorkspaceUserId(slug),
   ]);
-  const statuses = statusResult?.data ?? {};
+  const statuses = (statusResult?.data ?? {}) as Record<string, RuntimeSessionStatus>;
   const targetUserId = workspaceUser.ok ? workspaceUser.userId : null;
   const flowMetadata = targetUserId
     ? await flowService.findSessionMetadataForWorkspace(targetUserId, sessionIds)
@@ -815,13 +827,12 @@ export async function listMessagesAction(
     const messages = result.data ?? [];
 
     let sessionRuntimeStatus: "busy" | "idle" | "unknown" = "unknown";
+    let terminalRetryError: string | null = null;
     try {
       const statusResult = await client!.session.status();
-      const statuses = (statusResult.data ?? {}) as Record<
-        string,
-        { type?: string } | undefined
-      >;
+      const statuses = (statusResult.data ?? {}) as Record<string, RuntimeSessionStatus | undefined>;
       const sessionStatus = statuses[sessionId]?.type;
+      terminalRetryError = getTerminalRetryError(statuses[sessionId]);
       if (sessionStatus === "busy" || sessionStatus === "retry") {
         sessionRuntimeStatus = "busy";
       } else if (sessionStatus === "idle") {
@@ -830,6 +841,14 @@ export async function listMessagesAction(
     } catch {
       // Keep unknown status when status endpoint fails.
     }
+
+    const terminalAssistantMessageId = terminalRetryError
+      ? [...messages].reverse().find((message) => {
+          if (normalizeMessageRole(message.info.role) !== "assistant") return false;
+          const completedAt = (message.info.time as { completed?: number } | undefined)?.completed;
+          return typeof completedAt !== "number" || completedAt <= 0;
+        })?.info.id
+      : undefined;
 
     const pendingPermissions = await client!.permission.list()
       .then((result) => result.data)
@@ -858,6 +877,8 @@ export async function listMessagesAction(
         completedAt,
         parts,
         sessionStatus: sessionRuntimeStatus,
+        terminalError:
+          m.info.id === terminalAssistantMessageId ? terminalRetryError ?? undefined : undefined,
       });
       const info = m.info as Record<string, unknown>;
       const infoModel = info.model as Record<string, unknown> | undefined;

--- a/apps/web/src/app/api/w/[slug]/chat/runs/__tests__/route.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/runs/__tests__/route.test.ts
@@ -205,6 +205,26 @@ describe('/api/w/[slug]/chat/runs', () => {
     })
   })
 
+  it('fails active runs for terminal provider retries', async () => {
+    mocks.messageRunService.findActiveRun.mockResolvedValue(activeRun())
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      s1: {
+        type: 'retry',
+        action: { reason: 'free_tier_limit' },
+      },
+    }), { status: 200 })))
+
+    const { GET } = await import('../route')
+    const res = await GET(getRequest('s1'), params())
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ activeRun: null })
+    expect(mocks.messageRunService.markRunFailed).toHaveBeenCalledWith(
+      'run-1',
+      'free_tier_limit',
+    )
+  })
+
   it('keeps active runs when runtime status cannot be read', async () => {
     mocks.messageRunService.findActiveRun.mockResolvedValue(activeRun())
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('status down')))

--- a/apps/web/src/app/api/w/[slug]/chat/runs/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/runs/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { getInstanceUrl } from '@/lib/opencode/client'
+import { getTerminalRetryError } from '@/lib/opencode/retry-state'
 import { withAuth } from '@/lib/runtime/with-auth'
 import { instanceService, messageRunService } from '@/lib/services'
 import type { ActiveRunRuntimeState, MessageRunRecord } from '@/lib/services/message-run'
@@ -12,6 +13,10 @@ export const dynamic = 'force-dynamic'
 function jsonErrorResponse(status: number, error: string) {
   return NextResponse.json({ error }, { status })
 }
+
+type RuntimeSessionState =
+  | ActiveRunRuntimeState
+  | { terminalError: string }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
@@ -31,7 +36,7 @@ async function readRuntimeSessionState(params: {
   authHeader: string
   baseUrl: string
   sessionId: string
-}): Promise<ActiveRunRuntimeState> {
+}): Promise<RuntimeSessionState> {
   try {
     const response = await fetch(`${params.baseUrl}/session/status`, {
       headers: {
@@ -47,6 +52,9 @@ async function readRuntimeSessionState(params: {
 
     const statusRecord = data[params.sessionId]
     if (!isRecord(statusRecord)) return 'idle'
+
+    const terminalError = getTerminalRetryError(statusRecord)
+    if (terminalError) return { terminalError }
 
     const statusType = statusRecord.type
     if (statusType === 'busy' || statusType === 'retry') return 'busy'
@@ -101,6 +109,11 @@ export const GET = withAuth(
       baseUrl: connection.baseUrl,
       sessionId,
     })
+    if (typeof runtimeState === 'object') {
+      await messageRunService.markRunFailed(activeRun.id, runtimeState.terminalError)
+      return NextResponse.json({ activeRun: null })
+    }
+
     if (runtimeState === 'idle') {
       await messageRunService.markRunSucceeded(activeRun.id)
       return NextResponse.json({ activeRun: null })

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/route.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/route.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   instanceService: { findCredentialsBySlug: vi.fn() },
   messageRunService: {
     createActiveRunAfterRuntimeStateCheck: vi.fn(),
+    findActiveRun: vi.fn(),
     findRunById: vi.fn(),
     markRunAborted: vi.fn(),
     markRunFailed: vi.fn(),
@@ -180,6 +181,7 @@ describe('POST /api/w/[slug]/chat/stream', () => {
       startedAt: new Date(),
       finishedAt: null,
     })
+    mocks.messageRunService.findActiveRun.mockResolvedValue(null)
     mocks.messageRunService.createActiveRunAfterRuntimeStateCheck.mockResolvedValue({
       ok: true,
       run: {
@@ -992,6 +994,102 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     expect(text).toContain('"recoverable":true')
     expect(mocks.messageRunService.markRunFailed).not.toHaveBeenCalled()
     expect(mocks.abortSessionFamilyAndConfirmIdle).not.toHaveBeenCalled()
+  })
+
+  it('fails terminal provider retries instead of leaving their run resumable', async () => {
+    const fetchMock = mockOpenCodeFetch([
+      {
+        type: 'session.status',
+        properties: {
+          info: { sessionID: 's1' },
+          status: {
+            type: 'retry',
+            action: { reason: 'free_tier_limit' },
+          },
+        },
+      },
+    ])
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
+
+    await expect(res.text()).resolves.toContain('free_tier_limit')
+    expect(mocks.messageRunService.markRunFailed).toHaveBeenCalledWith(
+      'run-1',
+      'free_tier_limit',
+    )
+  })
+
+  it('fails terminal retries after the upstream event stream ends', async () => {
+    let onRead: ((result: {
+      durationMs: number
+      outcome: 'success'
+      status: string
+      terminalError: string
+    }) => void) | undefined
+    mocks.createUpstreamSessionStatusReader.mockImplementation(({ onRead: callback }) => {
+      onRead = callback
+      return vi.fn(async () => {
+        onRead?.({
+          durationMs: 0,
+          outcome: 'success',
+          status: 'retry',
+          terminalError: 'free_tier_limit',
+        })
+        return 'retry'
+      })
+    })
+    vi.stubGlobal('fetch', vi.fn((url: string | URL) => {
+      if (String(url) === 'http://test-slug:3000/event') {
+        return Promise.resolve(new Response(eventStream([]), { status: 200 }))
+      }
+      return Promise.reject(new Error(`unexpected fetch ${String(url)}`))
+    }))
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
+
+    await expect(res.text()).resolves.toContain('free_tier_limit')
+    expect(mocks.messageRunService.markRunFailed).toHaveBeenCalledWith(
+      'run-1',
+      'free_tier_limit',
+    )
+  })
+
+  it('links resume streams to the active run before handling terminal retries', async () => {
+    mocks.messageRunService.findActiveRun.mockResolvedValue({
+      id: 'run-1',
+      slug: 'alice',
+      sessionId: 's1',
+      source: 'web',
+      status: 'running',
+      error: null,
+      startedAt: new Date(),
+      finishedAt: null,
+    })
+    const fetchMock = mockOpenCodeFetch([
+      {
+        type: 'session.status',
+        properties: {
+          info: { sessionID: 's1' },
+          status: {
+            type: 'retry',
+            action: { reason: 'free_tier_limit' },
+          },
+        },
+      },
+    ])
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({ sessionId: 's1', resume: true }), params())
+
+    await expect(res.text()).resolves.toContain('free_tier_limit')
+    expect(mocks.messageRunService.markRunFailed).toHaveBeenCalledWith(
+      'run-1',
+      'free_tier_limit',
+    )
   })
 
   it('closes the observation recoverably when the upstream reader errors mid-stream', async () => {

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/status-reader.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/status-reader.test.ts
@@ -67,4 +67,36 @@ describe('createUpstreamSessionStatusReader', () => {
       }),
     )
   })
+
+  it('reports terminal retry reasons from the upstream status', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          'session-1': {
+            type: 'retry',
+            action: { reason: 'free_tier_limit' },
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const onRead = vi.fn()
+
+    const readStatus = createUpstreamSessionStatusReader({
+      baseUrl: 'http://127.0.0.1:4096',
+      authHeader: 'Basic token',
+      sessionId: 'session-1',
+      onRead,
+    })
+
+    await expect(readStatus()).resolves.toBe('retry')
+
+    expect(onRead).toHaveBeenCalledWith({
+      durationMs: 0,
+      outcome: 'success',
+      status: 'retry',
+      terminalError: 'free_tier_limit',
+    })
+  })
 })

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -8,6 +8,7 @@ import { AUTO_LEARNING_MIN_MESSAGES, canQueueAutoLearningRun, dispatchLearningRu
 import { getInstanceUrl } from '@/lib/opencode/client'
 import { createConfiguredOpencodeClient } from '@/lib/opencode/client-factory'
 import { ensureProviderAccessFreshForExecution } from '@/lib/opencode/providers'
+import { getTerminalRetryError } from '@/lib/opencode/retry-state'
 import {
   abortSessionFamilyAndConfirmIdle,
   EXECUTION_TERMINATION_UNCONFIRMED_ERROR,
@@ -341,6 +342,14 @@ export const POST = withAuth(
       runStartedAt = run.startedAt.getTime()
     }
 
+    if (!activeRunId && resume) {
+      const activeRun = await messageRunService.findActiveRun(slug, sessionId)
+      if (activeRun?.status === 'running') {
+        activeRunId = activeRun.id
+        runStartedAt = activeRun.startedAt.getTime()
+      }
+    }
+
     if (startsPrompt) {
       const runResult = await messageRunService.createActiveRunAfterRuntimeStateCheck({
         readRuntimeSessionState: () => readRuntimeSessionState({
@@ -530,11 +539,15 @@ export const POST = withAuth(
 
         try {
           sendEvent('status', { status: 'connecting' })
+          let terminalRetryError: string | null = null
           const readUpstreamSessionStatus = createUpstreamSessionStatusReader({
             baseUrl,
             authHeader,
             sessionId,
-            onRead: ({ durationMs, outcome, responseStatus, status }) => {
+            onRead: ({ durationMs, outcome, responseStatus, status, terminalError }) => {
+              if (terminalError) {
+                terminalRetryError = terminalError
+              }
               logObservation('upstream_status_read', {
                 durationMs,
                 outcome,
@@ -713,6 +726,15 @@ export const POST = withAuth(
           sendEvent('status', { status, toolName, detail })
         }
 
+        const failForTerminalRetry = (detail: string) => {
+          emitStatus('error', undefined, detail)
+          sendEvent('error', { error: detail })
+          recordRunUsage()
+          markRunFailed(detail)
+          recordTerminalReason('terminal_retry', { detail })
+          aborted = true
+        }
+
         const getPartKey = (partMessageId: string, partId: unknown) =>
           typeof partId === 'string' && partId.trim().length > 0
             ? `${partMessageId}:${partId}`
@@ -808,6 +830,10 @@ export const POST = withAuth(
                 }
 
                 const upstreamStatus = await readUpstreamSessionStatus()
+                if (terminalRetryError) {
+                  failForTerminalRetry(terminalRetryError)
+                  continue
+                }
                 const statusReadAt = Date.now()
                 if (upstreamStatus === 'busy' || upstreamStatus === 'retry' || upstreamStatus === 'idle') {
                   unknownStatusSince = null
@@ -880,7 +906,10 @@ export const POST = withAuth(
           const { done, value } = streamReadResult
           if (done || !value) {
             logObservation('upstream_eof')
-            if (!aborted && await readUpstreamSessionStatus() === 'idle') {
+            const upstreamStatus = await readUpstreamSessionStatus()
+            if (terminalRetryError) {
+              failForTerminalRetry(terminalRetryError)
+            } else if (!aborted && upstreamStatus === 'idle') {
               finalizeFromIdle()
             } else if (!aborted) {
               closeForObservationInterruption('upstream_eof')
@@ -945,7 +974,10 @@ export const POST = withAuth(
                     markRelevantEvent()
                     const status = event.properties?.status
 
-                    if (status?.type === 'busy') {
+                    const terminalError = getTerminalRetryError(status)
+                    if (terminalError) {
+                      failForTerminalRetry(terminalError)
+                    } else if (status?.type === 'busy') {
                       emitStatus('thinking')
                     } else if (status?.type === 'retry') {
                       emitStatus('thinking', undefined, status?.message)

--- a/apps/web/src/app/api/w/[slug]/chat/stream/status-reader.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/status-reader.ts
@@ -1,4 +1,9 @@
+import { getTerminalRetryError } from '@/lib/opencode/retry-state'
+
 type UpstreamSessionStatusEntry = {
+  action?: {
+    reason?: string
+  }
   type?: string
 }
 
@@ -16,6 +21,7 @@ export type UpstreamSessionStatusReadResult = {
   outcome: 'error' | 'http_error' | 'success'
   responseStatus?: number
   status: string | null
+  terminalError?: string
 }
 
 const UPSTREAM_STATUS_CACHE_WINDOW_MS = 2_000
@@ -66,8 +72,14 @@ export function createUpstreamSessionStatusReader({
       const data = await response.json().catch(() => null) as UpstreamSessionStatusResponse | null
       const sessionStatus = data?.[sessionId]
       const status = typeof sessionStatus?.type === 'string' ? sessionStatus.type : null
+      const terminalError = getTerminalRetryError(sessionStatus)
       cache = { expiresAt: now + UPSTREAM_STATUS_CACHE_WINDOW_MS, status }
-      onRead?.({ durationMs: Date.now() - startedAt, outcome: 'success', status })
+      onRead?.({
+        durationMs: Date.now() - startedAt,
+        outcome: 'success',
+        status,
+        ...(terminalError ? { terminalError } : {}),
+      })
       return status
     } catch (error) {
       console.warn('[chat-stream] Failed to read upstream session status', {

--- a/apps/web/src/components/workspace/chat-panel/__tests__/messages.test.tsx
+++ b/apps/web/src/components/workspace/chat-panel/__tests__/messages.test.tsx
@@ -318,6 +318,11 @@ describe("ChatPanelMessages", () => {
           statusInfo: { status: "error", detail: "rate_limited" },
           attachments: [{ type: "file", label: "log.txt", path: "logs/log.txt" }],
         }),
+        assistantMessage([], {
+          id: "a3",
+          content: "",
+          statusInfo: { status: "error", detail: "free_tier_limit" },
+        }),
         {
           id: "s1",
           sessionId: "s1",
@@ -333,6 +338,8 @@ describe("ChatPanelMessages", () => {
     expect(onScrollContainer).toHaveBeenCalled();
     expect(screen.getByText("Rate limited")).toBeTruthy();
     expect(screen.getByText("Too many requests were sent at once. Try again in a moment.")).toBeTruthy();
+    expect(screen.getByText("Free model limit reached")).toBeTruthy();
+    expect(screen.getByText("Choose another model or try again after your free usage resets.")).toBeTruthy();
     expect(screen.getByText("System note")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: /input.pdf/ }));

--- a/apps/web/src/components/workspace/chat-panel/messages.tsx
+++ b/apps/web/src/components/workspace/chat-panel/messages.tsx
@@ -79,6 +79,10 @@ const CHAT_ERROR_MESSAGES: Record<string, { title: string; description?: string 
     title: "Permission denied",
     description: "You are not allowed to perform this action.",
   },
+  free_tier_limit: {
+    title: "Free model limit reached",
+    description: "Choose another model or try again after your free usage resets.",
+  },
   instance_unavailable: {
     title: "Workspace unavailable",
     description: "The workspace is not ready right now. Try again in a moment.",

--- a/apps/web/src/lib/__tests__/workspace-message-state.test.ts
+++ b/apps/web/src/lib/__tests__/workspace-message-state.test.ts
@@ -26,6 +26,20 @@ describe('deriveWorkspaceMessageRuntimeState', () => {
     expect(result).toEqual({ pending: true, statusInfo: { status: 'thinking' } })
   })
 
+  it('marks terminal retry errors as non-pending', () => {
+    const result = deriveWorkspaceMessageRuntimeState({
+      role: 'assistant',
+      parts: [],
+      sessionStatus: 'busy',
+      terminalError: 'free_tier_limit',
+    })
+
+    expect(result).toEqual({
+      pending: false,
+      statusInfo: { status: 'error', detail: 'free_tier_limit' },
+    })
+  })
+
   it('marks empty assistant response as incomplete when session is idle', () => {
     const result = deriveWorkspaceMessageRuntimeState({
       role: 'assistant',

--- a/apps/web/src/lib/opencode/__tests__/retry-state.test.ts
+++ b/apps/web/src/lib/opencode/__tests__/retry-state.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { getTerminalRetryError } from '@/lib/opencode/retry-state'
+
+describe('getTerminalRetryError', () => {
+  it('identifies free tier limit retries as terminal', () => {
+    expect(getTerminalRetryError({
+      type: 'retry',
+      action: { reason: 'free_tier_limit' },
+    })).toBe('free_tier_limit')
+  })
+
+  it('keeps ordinary retries recoverable', () => {
+    expect(getTerminalRetryError({
+      type: 'retry',
+      action: { reason: 'temporary_failure' },
+    })).toBeNull()
+  })
+})

--- a/apps/web/src/lib/opencode/retry-state.ts
+++ b/apps/web/src/lib/opencode/retry-state.ts
@@ -1,0 +1,16 @@
+const TERMINAL_RETRY_REASONS = new Set(['free_tier_limit'])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function getTerminalRetryError(status: unknown): string | null {
+  if (!isRecord(status) || status.type !== 'retry' || !isRecord(status.action)) {
+    return null
+  }
+
+  const reason = status.action.reason
+  return typeof reason === 'string' && TERMINAL_RETRY_REASONS.has(reason)
+    ? reason
+    : null
+}

--- a/apps/web/src/lib/workspace-message-state.ts
+++ b/apps/web/src/lib/workspace-message-state.ts
@@ -14,6 +14,7 @@ type DeriveWorkspaceMessageStateInput = {
   completedAt?: number
   parts: MessagePart[]
   sessionStatus?: 'busy' | 'idle' | 'unknown'
+  terminalError?: string
 }
 
 export function deriveWorkspaceMessageRuntimeState({
@@ -21,8 +22,12 @@ export function deriveWorkspaceMessageRuntimeState({
   completedAt,
   parts,
   sessionStatus = 'unknown',
+  terminalError,
 }: DeriveWorkspaceMessageStateInput): WorkspaceMessageRuntimeState {
   if (role !== 'assistant') return { pending: false }
+  if (terminalError) {
+    return { pending: false, statusInfo: { status: 'error', detail: terminalError } }
+  }
 
   const lastPart = parts[parts.length - 1]
   if (!lastPart) {

--- a/apps/web/tests/chat-stream-route.test.ts
+++ b/apps/web/tests/chat-stream-route.test.ts
@@ -8,6 +8,7 @@ const mockIsDesktop = vi.fn(() => false)
 const mockValidateDesktopToken = vi.fn(() => false)
 
 const mockFindCredentialsBySlug = vi.fn()
+const mockFindActiveRun = vi.fn()
 const mockFindRunById = vi.fn()
 const mockMarkRunFailed = vi.fn()
 const mockMarkRunSucceeded = vi.fn()
@@ -51,6 +52,7 @@ async function loadRoute() {
       findCredentialsBySlug: (...args: unknown[]) => mockFindCredentialsBySlug(...args),
     },
     messageRunService: {
+      findActiveRun: (...args: unknown[]) => mockFindActiveRun(...args),
       findRunById: (...args: unknown[]) => mockFindRunById(...args),
       markRunFailed: (...args: unknown[]) => mockMarkRunFailed(...args),
       markRunSucceeded: (...args: unknown[]) => mockMarkRunSucceeded(...args),
@@ -142,6 +144,7 @@ describe('POST /api/w/[slug]/chat/stream', () => {
       startedAt: new Date(),
       finishedAt: null,
     })
+    mockFindActiveRun.mockResolvedValue(null)
     mockMarkRunFailed.mockResolvedValue(undefined)
     mockMarkRunSucceeded.mockResolvedValue(undefined)
     mockDecryptPassword.mockReturnValue('secret-password')


### PR DESCRIPTION
## Summary
- classify OpenCode `free_tier_limit` retry states as terminal rather than recoverable
- finish the affected message run and prevent auto-resume after reload
- render a clear free-model-limit message in chat

## Verification
- `pnpm lint` — passes with 20 pre-existing warnings
- `pnpm test` — 531 passed, 4 skipped; 5,165 passed, 16 skipped
- `bash scripts/check-podman-images.sh` — passed