### PR TITLE
fix(web): clear orphaned setTimeout in SSE read loop

### DIFF
--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -815,12 +815,14 @@ export const POST = withAuth(
           let streamReadResult: ReadableStreamReadResult<Uint8Array> | null = null
 
           while (!aborted && !streamReadResult) {
+            let tickTimer: ReturnType<typeof setTimeout> | undefined
             const readResult = await Promise.race([
               readPromise.then((result) => ({ type: 'data' as const, result })),
-              new Promise<{ type: 'tick' }>((resolve) =>
-                setTimeout(() => resolve({ type: 'tick' }), STREAM_RELEVANT_EVENT_TICK_MS)
-              ),
+              new Promise<{ type: 'tick' }>((resolve) => {
+                tickTimer = setTimeout(() => resolve({ type: 'tick' }), STREAM_RELEVANT_EVENT_TICK_MS)
+              }),
             ])
+            if (readResult.type !== 'tick') clearTimeout(tickTimer)
 
             if (readResult.type === 'tick') {
               if (Date.now() - lastRelevantEventAt > relevantEventTimeoutMs) {


### PR DESCRIPTION
## Summary
- The `Promise.race` watchdog tick in the SSE read loop created a new `setTimeout` on every iteration but never stored the handle — when the data arm won the race, the timer leaked and its callback fired on an abandoned promise
- Capture the timer handle and `clearTimeout` it when data arrives before the tick

Closes #448

## Verification
- `pnpm test` — 531 passed, 4 skipped; 5,165 passed, 16 skipped
- Coverage badges unchanged