### PR TITLE
ci: add PR governance checks and expand PR commands

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,16 +3,34 @@ name: PR Checks
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "apps/web/**"
-      - "apps/desktop/**"
-      - "scripts/**"
-      - ".github/workflows/**"
   workflow_dispatch:
 
 jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      web: ${{ steps.changes.outputs.web }}
+      desktop: ${{ steps.changes.outputs.desktop }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check changed paths
+        id: changes
+        run: |
+          changed=$(git diff --name-only origin/main...HEAD 2>/dev/null || echo "")
+          echo "web=$(echo "$changed" | grep -qE '^(apps/web/|scripts/)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "desktop=$(echo "$changed" | grep -qE '^apps/desktop/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
   web-lint-test:
     name: Web - Lint & Test
+    needs: detect-changes
+    if: needs.detect-changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -44,6 +62,8 @@ jobs:
 
   web-e2e-smoke:
     name: Web - E2E Smoke
+    needs: detect-changes
+    if: needs.detect-changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -119,6 +139,8 @@ jobs:
 
   desktop-build-test:
     name: Desktop - Build & Test
+    needs: detect-changes
+    if: needs.detect-changes.outputs.desktop == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -147,6 +169,8 @@ jobs:
 
   desktop-e2e-smoke:
     name: Desktop - E2E Smoke
+    needs: detect-changes
+    if: needs.detect-changes.outputs.desktop == 'true'
     runs-on: macos-14
     permissions:
       contents: read
@@ -204,6 +228,8 @@ jobs:
 
   desktop-workspace-smoke:
     name: Desktop - Workspace Smoke
+    needs: detect-changes
+    if: needs.detect-changes.outputs.desktop == 'true'
     runs-on: macos-14
     permissions:
       contents: read

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,7 +7,7 @@ on:
       - "apps/web/**"
       - "apps/desktop/**"
       - "scripts/**"
-      - ".github/workflows/pr-checks.yml"
+      - ".github/workflows/**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -51,3 +51,201 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -d '{"content": "+1"}'
+
+  handle-lgtm-command:
+    if: |
+      startsWith(github.event.comment.body, '/lgtm') &&
+      github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Approve PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body.trim();
+            if (body !== '/lgtm') {
+              core.info('Ignoring — not an exact /lgtm command');
+              return;
+            }
+
+            const commenter = context.payload.comment.user.login;
+
+            const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: commenter,
+            });
+
+            if (!['admin', 'write'].includes(permission.permission)) {
+              core.setFailed(`User ${commenter} does not have write access to approve.`);
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            if (commenter === pr.user.login) {
+              core.setFailed('Cannot approve your own PR via /lgtm.');
+              return;
+            }
+
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              event: 'APPROVE',
+              body: `Approved via \`/lgtm\` by @${commenter}`,
+            });
+
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1',
+            });
+
+  handle-rerun-command:
+    if: |
+      startsWith(github.event.comment.body, '/rerun') &&
+      github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      checks: read
+      pull-requests: read
+
+    steps:
+      - name: Re-run failed checks
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body.trim();
+            if (body !== '/rerun') {
+              core.info('Ignoring — not an exact /rerun command');
+              return;
+            }
+
+            const commenter = context.payload.comment.user.login;
+
+            const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: commenter,
+            });
+
+            if (!['admin', 'write'].includes(permission.permission)) {
+              core.setFailed(`User ${commenter} does not have write access to re-run checks.`);
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            const checkRuns = await github.paginate(
+              github.rest.checks.listForRef,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: pr.head.sha,
+                filter: 'latest',
+                per_page: 100,
+              },
+              response => response.data
+            );
+
+            const failed = checkRuns.filter(
+              cr => cr.conclusion === 'failure' || cr.conclusion === 'cancelled'
+            );
+
+            if (failed.length === 0) {
+              core.info('No failed checks to re-run.');
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'confused',
+              });
+              return;
+            }
+
+            const runIds = [...new Set(
+              failed
+                .filter(cr => cr.app?.slug === 'github-actions')
+                .map(cr => cr.html_url?.match(/runs\/(\d+)/)?.[1])
+                .filter(Boolean)
+            )];
+
+            let reran = 0;
+            for (const runId of runIds) {
+              try {
+                await github.rest.actions.reRunWorkflowFailedJobs({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: parseInt(runId, 10),
+                });
+                reran++;
+                core.info(`Re-ran failed jobs for workflow run ${runId}`);
+              } catch (e) {
+                core.warning(`Could not re-run workflow ${runId}: ${e.message}`);
+              }
+            }
+
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: reran > 0 ? '+1' : 'confused',
+            });
+
+  handle-help-command:
+    if: |
+      startsWith(github.event.comment.body, '/help') &&
+      github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Post available commands
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body.trim();
+            if (body !== '/help') {
+              core.info('Ignoring — not an exact /help command');
+              return;
+            }
+
+            const helpText = [
+              '### Available PR Commands',
+              '',
+              '| Command | Description |',
+              '|---------|-------------|',
+              '| `/build` | Build and push a container image for this PR |',
+              '| `/lgtm` | Approve this PR (requires write access) |',
+              '| `/rerun` | Re-run failed CI checks |',
+              '| `/help` | Show this help message |',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: helpText,
+            });
+
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1',
+            });

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,0 +1,252 @@
+name: PR Governance
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  wip-labeler:
+    name: WIP Label
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Manage WIP labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const isWip = /\bwip\b/i.test(pr.title);
+            const labels = ['wip', 'not-ready-to-merge'];
+            const currentLabels = pr.labels.map(l => l.name);
+
+            for (const label of labels) {
+              const hasLabel = currentLabels.includes(label);
+
+              if (isWip && !hasLabel) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: [label],
+                });
+              }
+
+              if (!isWip && hasLabel) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    name: label,
+                  });
+                } catch {
+                  // label already removed
+                }
+              }
+            }
+
+            if (isWip) {
+              core.notice('PR title contains WIP — labeled as not ready to merge');
+            }
+
+  pinned-versions:
+    name: Pinned Versions
+    if: github.event.action != 'edited'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check dependency version pinning
+        run: |
+          violations=0
+
+          check_package() {
+            local pkg="$1"
+
+            if ! jq empty "$pkg" 2>/dev/null; then
+              echo "::warning file=${pkg}::Malformed package.json — skipped"
+              return 1
+            fi
+
+            local unpinned
+            unpinned=$(jq -r '
+              [(.dependencies // {}), (.devDependencies // {})]
+              | add // {}
+              | to_entries[]
+              | select(
+                  (.value | startswith("workspace:")) | not
+                )
+              | select(
+                  (.value | test("^[0-9]+\\.[0-9]+\\.[0-9]")) | not
+                )
+              | "  \(.key): \(.value)"
+            ' "$pkg" 2>/dev/null)
+
+            if [[ -n "$unpinned" ]]; then
+              echo "::error file=${pkg}::Unpinned dependency versions in ${pkg}:"
+              echo "$unpinned"
+              return 1
+            fi
+            return 0
+          }
+
+          for pkg in $(find . -name package.json \
+            -not -path '*/node_modules/*' \
+            -not -path '*/.next/*' \
+            -not -path '*/generated/*' \
+            -not -path '*/.pnpm/*' \
+            | sort); do
+
+            deps=$(jq -r '(.dependencies // {} | length) + (.devDependencies // {} | length)' "$pkg" 2>/dev/null)
+            if [[ "$deps" == "0" ]] || [[ -z "$deps" ]]; then
+              continue
+            fi
+
+            if ! check_package "$pkg"; then
+              violations=$((violations + 1))
+            fi
+          done
+
+          if [[ $violations -gt 0 ]]; then
+            echo ""
+            echo "::error::Found unpinned dependencies in $violations package(s). Use exact versions (e.g. \"1.2.3\"), not ranges (\"^1.2.3\", \"~1.2.3\")."
+            exit 1
+          fi
+
+          echo "All dependency versions are pinned."
+
+  security-scan:
+    name: Security Scan
+    if: github.event.action != 'edited'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changes
+        run: |
+          changed=$(git diff --name-only --diff-filter=ACR origin/main...HEAD 2>/dev/null \
+            || git diff --name-only --diff-filter=ACR HEAD~1 2>/dev/null \
+            || echo "")
+          EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 2>/dev/null | base64)
+          echo "files<<${EOF_MARKER}" >> "$GITHUB_OUTPUT"
+          echo "$changed" >> "$GITHUB_OUTPUT"
+          echo "${EOF_MARKER}" >> "$GITHUB_OUTPUT"
+
+      - name: Check for sensitive files
+        if: steps.changes.outputs.files != ''
+        run: |
+          sensitive_patterns=(
+            '\.env$'
+            '\.env\.local'
+            '\.env\.[a-z]+$'
+            '\.pem$'
+            '\.key$'
+            '\.p12$'
+            '\.pfx$'
+            '\.jks$'
+            '\.keystore$'
+            'id_rsa'
+            'id_ed25519'
+            'id_ecdsa'
+            '\.ssh/config$'
+            'credentials\.json$'
+            'service.account.*\.json$'
+            '\.npmrc$'
+            '\.pypirc$'
+            '\.netrc$'
+            '\.htpasswd$'
+          )
+
+          found=0
+          changed_files="${{ steps.changes.outputs.files }}"
+
+          for pattern in "${sensitive_patterns[@]}"; do
+            matches=$(echo "$changed_files" | grep -iE "$pattern" || true)
+            if [[ -n "$matches" ]]; then
+              while IFS= read -r match; do
+                echo "::error file=${match}::Sensitive file detected: ${match}"
+              done <<< "$matches"
+              found=1
+            fi
+          done
+
+          if [[ $found -eq 1 ]]; then
+            echo ""
+            echo "::error::Sensitive files detected in this PR. Remove them or add to .gitignore."
+            exit 1
+          fi
+
+          echo "No sensitive files detected."
+
+      - name: Scan for hardcoded secrets
+        if: steps.changes.outputs.files != ''
+        run: |
+          changed_files="${{ steps.changes.outputs.files }}"
+
+          # Only scan text files
+          scannable=$(echo "$changed_files" | grep -vE '\.(png|jpg|jpeg|gif|ico|svg|woff2?|ttf|eot|mp[34]|webm|webp|zip|tar|gz|lock)$' || true)
+
+          if [[ -z "$scannable" ]]; then
+            echo "No text files to scan."
+            exit 0
+          fi
+
+          found=0
+
+          # Build file list safely for git diff
+          file_args=()
+          while IFS= read -r f; do
+            [[ -n "$f" ]] && file_args+=("$f")
+          done <<< "$scannable"
+
+          diff_content=$(git diff origin/main...HEAD -- "${file_args[@]}" 2>/dev/null \
+            || git diff HEAD~1 -- "${file_args[@]}" 2>/dev/null \
+            || echo "")
+
+          added_lines=$(echo "$diff_content" | grep '^+' | grep -v '^+++' || true)
+
+          secret_patterns=(
+            'AKIA[0-9A-Z]{16}'
+            'sk-[a-zA-Z0-9]{20,}'
+            'ghp_[a-zA-Z0-9]{36}'
+            'gho_[a-zA-Z0-9]{36}'
+            'github_pat_[a-zA-Z0-9_]{22,}'
+            'glpat-[a-zA-Z0-9_-]{20,}'
+            'xox[bsapr]-[a-zA-Z0-9-]+'
+            'BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY'
+            'password\s*[:=]\s*["\x27][^"\x27]{8,}'
+            'secret\s*[:=]\s*["\x27][^"\x27]{8,}'
+            'api[_-]?key\s*[:=]\s*["\x27][^"\x27]{8,}'
+            'access[_-]?token\s*[:=]\s*["\x27][^"\x27]{8,}'
+          )
+
+          for pattern in "${secret_patterns[@]}"; do
+            matches=$(echo "$added_lines" | grep -iE "$pattern" | head -5 || true)
+            if [[ -n "$matches" ]]; then
+              echo "::warning::Potential secret pattern detected: $pattern"
+              echo "$matches" | while IFS= read -r line; do
+                echo "  ${line:0:120}..."
+              done
+              found=1
+            fi
+          done
+
+          if [[ $found -eq 1 ]]; then
+            echo ""
+            echo "::error::Potential hardcoded secrets detected. Review the warnings above and use environment variables or a secrets manager instead."
+            exit 1
+          fi
+
+          echo "No hardcoded secrets detected."

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -80,7 +80,7 @@ jobs:
               | add // {}
               | to_entries[]
               | select(
-                  (.value | startswith("workspace:")) | not
+                  (.value | test("^(workspace:|https?://|file:)")) | not
                 )
               | select(
                   (.value | test("^[0-9]+\\.[0-9]+\\.[0-9]")) | not

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -80,7 +80,7 @@ jobs:
               | add // {}
               | to_entries[]
               | select(
-                  (.value | test("^(workspace:|https?://|file:)")) | not
+                  (.value | test("^(workspace:|link:|https?://|file:)")) | not
                 )
               | select(
                   (.value | test("^[0-9]+\\.[0-9]+\\.[0-9]")) | not

--- a/openspec/changes/pr-governance-and-commands/.openspec.yaml
+++ b/openspec/changes/pr-governance-and-commands/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-28

--- a/openspec/changes/pr-governance-and-commands/design.md
+++ b/openspec/changes/pr-governance-and-commands/design.md
@@ -1,0 +1,73 @@
+## Context
+
+See `proposal.md` — Why for the gate and ergonomics gaps.
+
+Current mechanics that shape this design (verified in code):
+
+- `pr-checks.yml` on main triggers on `pull_request` with a `paths` filter listing web/desktop/scripts and its own file. GitHub's `paths` filters evaluate against the PR's files, so a PR touching only other workflow files (or a workflow that no longer matches the list) starts no check runs — which blocks branch protection that requires those checks, or worse, merges unverified.
+- The repo now has multiple `package.json` files (root, `apps/web`, `apps/desktop`, generated dirs); pnpm workspaces use `workspace:` protocol internally.
+- `/build` in `pr-commands.yml` works by `repository dispatch` (`build-pr-image`) consumed by the build workflow, acknowledged with a 👍 reaction.
+- Branch protection on `main` already requires PR checks; the repo has an `auto-merge.yml` workflow, so labeling (`not-ready-to-merge`) is a real merge blocker only if honored by reviewers/auto-merge rules — the label is the contract, enforcement lives elsewhere.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Every PR gets exactly the checks its diff implies, and workflow-file changes always get a run.
+- Dependency pinning, sensitive files, and obvious secrets are screened automatically on every PR update.
+- WIP state is visible on the PR itself, not in reviewers' heads.
+- Comment commands are safe by construction: exact-match, permission-gated, self-approval-proof.
+
+**Non-Goals:**
+
+- Replacing the secret scanner with a managed third-party app (e.g. secret scanning push protection) — repository-level GitHub settings, not workflow code.
+- Enforcing labels in branch protection rules (`not-ready-to-merge` as a required context) — separate infra decision.
+- Lockfile auditing (`pnpm audit`), license checks, or SBOM — different changes.
+- Handling `/commands` in issue comments (non-PR) — all commands no-op unless the comment is on a PR.
+- New check runs for docs-only PRs beyond what `detect-changes` already skips.
+
+## Decisions
+
+### D1: `detect-changes` job with explicit diff instead of `paths` filters
+
+- One job checks out with `fetch-depth: 0`, runs `git diff --name-only origin/main...HEAD`, and emits `web`/`desktop` booleans consumed via `needs`/`if` by every check job. Regex: web = `^(apps/web/|scripts/)`, desktop = `^apps/desktop/`.
+- Dropping the `pull_request.paths` trigger filter means the workflow always runs on PRs; the gates keep job selection equivalent while fixing the "no check runs at all" hole for workflow-file edits (the previous `paths` list included only `pr-checks.yml` itself, not other workflows).
+- Alternative considered: `dorny/paths-filter` action — rejected; adds a third-party dependency for logic that is ten lines of shell, and the repo standard keeps workflows dependency-light.
+
+### D2: Pinning policy is exact versions, with a deliberate allowlist
+
+- Any semver-looking range (`^`, `~`, `>=`, `*`, dist-tags) fails. `workspace:`, `https?://`, and `file:` protocols pass: workspace links are the pnpm mechanism, and URL/file deps are version-addressed by their target.
+- Malformed `package.json` files warn and are skipped rather than failing the check — generated/vendor manifests must not wedge CI; package files with zero deps are skipped outright.
+- Scans only `dependencies` and `devDependencies`; `peerDependencies`/`optionalDependencies` are out of scope for now.
+
+### D3: Secret scanning is advisory-pattern based over added lines only
+
+- Fixed pattern list (AWS/GitHub/GitLab/Slack tokens, `github_pat_`, private key PEM headers, `password|secret|api_key|access_token` assignments with quoted 8+-char values) applied to `git diff` added lines, excluding binary extensions. Failures print `::error` annotations.
+- Trade-off accepted: pattern scanning has false positives (test fixtures, docs examples). The alternative (allowlist files) is deferred until a real false positive demands it.
+- Sensitive-filename screening is a separate, broader net: any added/changed path matching env/key/credential patterns fails regardless of content.
+
+### D4: `/lgtm` and `/rerun` are exact-match and write-gated
+
+- Commands compare `body.trim()` to the exact string, so "＼lgtm but also check X" never triggers; `startsWith` in the job `if` is only a cheap pre-gate, the script re-validates.
+- Both require collaborator permission `admin`/`write` via `getCollaboratorPermissionLevel`. `/lgtm` additionally refuses when the commenter is the PR author (no self-approval). `/rerun` paginates `checks.listForRef` (filter `latest`), re-runs only failed/cancelled runs belonging to `github-actions`, and reacts 👍/😕 to report outcome.
+- `/help` posts the table and is likewise write-gated — consistent with the others, avoids noise from drive-by commenters.
+
+### D5: WIP labeling is idempotent and self-reversing
+
+- Title regex `\bwip\b` (case-insensitive) drives add and remove of both `wip` and `not-ready-to-merge`. Removing labels is tolerant of already-removed labels (409/404 swallowed). Runs on every PR synchronize/edit, so the label state always mirrors the current title.
+
+## Risks / Trade-offs
+
+- [Pattern-based secret scan false positives block PRs] → Mitigation later by allowlisting specific paths if it bites; scanner output shows the matched lines so authors can reword quickly.
+- [`detect-changes` diff against `origin/main` on merge-queue/fast-forward churn] → The three-dot diff uses the merge base, so unrelated main activity doesn't widen the gate.
+- [`/rerun` re-runs only `github-actions` check runs] → Third-party check apps are out of scope; the confused reaction signals nothing was re-runnable.
+- [Pinning check friction for quick experiments] → Intentional: exact pins are the repo standard; `workspace:`/URL deps remain available for local packages.
+
+## Migration Plan
+
+1. Single merge of the workflow files; no application changes. Governance jobs start running on the next PR update; existing PRs get labeled/scanned on their next synchronize event.
+2. Rollback: disable the workflows in the Actions UI or revert the merge; no data or state to unwind (labels are removed automatically when titles no longer match).
+
+## Open Questions
+
+- Whether `not-ready-to-merge` should become a branch-protection required context (needs a repo-settings decision outside this change).

--- a/openspec/changes/pr-governance-and-commands/design.md
+++ b/openspec/changes/pr-governance-and-commands/design.md
@@ -36,7 +36,7 @@ Current mechanics that shape this design (verified in code):
 
 ### D2: Pinning policy is exact versions, with a deliberate allowlist
 
-- Any semver-looking range (`^`, `~`, `>=`, `*`, dist-tags) fails. `workspace:`, `https?://`, and `file:` protocols pass: workspace links are the pnpm mechanism, and URL/file deps are version-addressed by their target.
+- Any semver-looking range (`^`, `~`, `>=`, `*`, dist-tags) fails. `workspace:`, `link:`, `https?://`, and `file:` protocols pass: workspace links are the pnpm mechanism, `link:` symlinks the pnpm local packages (e.g. `@arche/desktop-runtime` in `apps/web`/`apps/desktop`), and URL/file deps are version-addressed by their target.
 - Malformed `package.json` files warn and are skipped rather than failing the check — generated/vendor manifests must not wedge CI; package files with zero deps are skipped outright.
 - Scans only `dependencies` and `devDependencies`; `peerDependencies`/`optionalDependencies` are out of scope for now.
 

--- a/openspec/changes/pr-governance-and-commands/proposal.md
+++ b/openspec/changes/pr-governance-and-commands/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+PR quality gates were manual and incomplete. Path-filtered `pr-checks.yml` triggers silently skip checks when a PR mixes areas (a workflow-file-only change runs nothing), nothing keeps dependency versions pinned across the growing number of `package.json` files, and nothing screens PRs for sensitive files or hardcoded secrets before merge. Reviewer mechanics were also manual: no way to label work-in-progress PRs, approve from a comment, re-run failed checks, or discover the commands that do exist — only `/build` was wired up.
+
+## What Changes
+
+- Add `pr-governance.yml` with three jobs, running on PR open/edit/synchronize/reopen:
+  - `wip-labeler` — adds `wip` + `not-ready-to-merge` labels when the PR title matches `\bwip\b` (case-insensitive) and removes both when it no longer does.
+  - `pinned-versions` — fails the check when any repository `package.json` (excluding `node_modules`, build output) declares a dependency outside `dependencies`/`devDependencies` whose version is not an exact `x.y.z`-style pin; `workspace:`, `http(s)://`, and `file:` references are allowed; malformed `package.json` files are skipped with a warning.
+  - `security-scan` — fails the check when added/changed files match sensitive filename patterns (`.env*`, key/certificate stores, credential files, `.npmrc`, …) or when added diff lines match hardcoded-secret patterns (AWS/GitHub/GitLab/Slack tokens, private key blocks, password/secret/api-key assignments); binary extensions are skipped; the `edited` action is skipped to avoid re-scanning description edits.
+- Expand `pr-commands.yml` beyond `/build` with three write-gated comment commands, each requiring exact command match (`body.trim()`) and collaborator `write`/`admin` permission:
+  - `/lgtm` — approves the PR; refuses self-approval.
+  - `/rerun` — re-runs failed/cancelled GitHub Actions checks on the PR head (paginated); reacts to acknowledge.
+  - `/help` — posts the command table.
+- Rework `pr-checks.yml` triggering: drop `pull_request.paths` filters in favor of a `detect-changes` job that computes changed paths via `git diff origin/main...HEAD` and gates the web/desktop jobs with `needs`/`if`, so workflow-file changes no longer skip check runs and job selection follows the actual diff.
+
+## Capabilities
+
+### New Capabilities
+- `pr-governance`: Behavioral contract for pull-request pipeline governance — WIP labeling, dependency version pinning, sensitive-file/secret screening, path-aware check selection, and comment-driven PR commands.
+
+### Modified Capabilities
+- (none — no existing spec covers CI behavior.)
+
+## Impact
+
+- `.github/workflows/pr-governance.yml` — new workflow (3 jobs).
+- `.github/workflows/pr-commands.yml` — keeps `/build` unchanged; adds `/lgtm`, `/rerun`, `/help` jobs.
+- `.github/workflows/pr-checks.yml` — `paths` filters replaced by `detect-changes` job; web/desktop jobs gain `needs`/`if` gates.
+- No application code, DB, or dependency changes; `GITHUB_TOKEN` permissions are scoped per job (`pull-requests: write`, `contents: read`, `actions: write` where needed).
+- Verification is workflow-level: `actionlint` clean, YAML valid, behaviors exercised on live PRs (WIP title changes, unpinned dependency, `/lgtm` self-approval refusal, `/rerun`, `/help`).

--- a/openspec/changes/pr-governance-and-commands/proposal.md
+++ b/openspec/changes/pr-governance-and-commands/proposal.md
@@ -6,7 +6,7 @@ PR quality gates were manual and incomplete. Path-filtered `pr-checks.yml` trigg
 
 - Add `pr-governance.yml` with three jobs, running on PR open/edit/synchronize/reopen:
   - `wip-labeler` — adds `wip` + `not-ready-to-merge` labels when the PR title matches `\bwip\b` (case-insensitive) and removes both when it no longer does.
-  - `pinned-versions` — fails the check when any repository `package.json` (excluding `node_modules`, build output) declares a dependency outside `dependencies`/`devDependencies` whose version is not an exact `x.y.z`-style pin; `workspace:`, `http(s)://`, and `file:` references are allowed; malformed `package.json` files are skipped with a warning.
+  - `pinned-versions` — fails the check when any repository `package.json` (excluding `node_modules`, build output) declares a dependency outside `dependencies`/`devDependencies` whose version is not an exact `x.y.z`-style pin; `workspace:`, `link:`, `http(s)://`, and `file:` references are allowed; malformed `package.json` files are skipped with a warning.
   - `security-scan` — fails the check when added/changed files match sensitive filename patterns (`.env*`, key/certificate stores, credential files, `.npmrc`, …) or when added diff lines match hardcoded-secret patterns (AWS/GitHub/GitLab/Slack tokens, private key blocks, password/secret/api-key assignments); binary extensions are skipped; the `edited` action is skipped to avoid re-scanning description edits.
 - Expand `pr-commands.yml` beyond `/build` with three write-gated comment commands, each requiring exact command match (`body.trim()`) and collaborator `write`/`admin` permission:
   - `/lgtm` — approves the PR; refuses self-approval.

--- a/openspec/changes/pr-governance-and-commands/specs/pr-governance/spec.md
+++ b/openspec/changes/pr-governance-and-commands/specs/pr-governance/spec.md
@@ -20,7 +20,7 @@ The PR check workflow SHALL run on every pull request targeting `main` and SHALL
 - **THEN** no web or desktop check job executes and the run still completes
 
 ### Requirement: Dependency versions are pinned
-Every repository `package.json` SHALL declare exact version pins for its `dependencies` and `devDependencies`. A version range, dist-tag, or other non-exact reference SHALL fail the governance check, except for `workspace:`, `https://`, `http://`, and `file:` protocol references, which are permitted. A manifest with no dependencies, or one that cannot be parsed, SHALL not fail the check.
+Every repository `package.json` SHALL declare exact version pins for its `dependencies` and `devDependencies`. A version range, dist-tag, or other non-exact reference SHALL fail the governance check, except for `workspace:`, `link:`, `https://`, `http://`, and `file:` protocol references, which are permitted. A manifest with no dependencies, or one that cannot be parsed, SHALL not fail the check.
 
 #### Scenario: Caret range rejected
 - **WHEN** a pull request adds `"lodash": "^4.17.21"` to a `package.json`
@@ -28,6 +28,10 @@ Every repository `package.json` SHALL declare exact version pins for its `depend
 
 #### Scenario: Workspace reference accepted
 - **WHEN** a `package.json` depends on a workspace package via `"arche-web": "workspace:*"`
+- **THEN** the pinned-versions check passes for that entry
+
+#### Scenario: Local link reference accepted
+- **WHEN** a `package.json` depends on a local package directory via `"@arche/desktop-runtime": "link:../desktop-runtime"`
 - **THEN** the pinned-versions check passes for that entry
 
 #### Scenario: Generated manifest tolerated

--- a/openspec/changes/pr-governance-and-commands/specs/pr-governance/spec.md
+++ b/openspec/changes/pr-governance-and-commands/specs/pr-governance/spec.md
@@ -1,0 +1,80 @@
+## Purpose
+
+Defines the behavioral contract for pull-request pipeline governance: how check execution is selected from a PR's diff, which automated governance checks every PR must pass, how work-in-progress state is labeled, and which comment commands reviewers can use on a PR.
+
+## ADDED Requirements
+
+### Requirement: PR checks follow the diff, not trigger path filters
+The PR check workflow SHALL run on every pull request targeting `main` and SHALL select its check jobs from the set of files changed relative to the merge base with `main`: web checks run when the diff touches `apps/web/` or `scripts/`, desktop checks run when it touches `apps/desktop/`. A pull request whose diff touches no checked area SHALL produce a completed run with no check jobs, rather than no check run at all.
+
+#### Scenario: Workflow-file-only pull request
+- **WHEN** a pull request changes only GitHub workflow files
+- **THEN** the check workflow starts and completes with jobs selected according to the diff
+
+#### Scenario: Mixed-area pull request
+- **WHEN** a pull request changes files under both `apps/web/` and `apps/desktop/`
+- **THEN** both the web and desktop check jobs execute
+
+#### Scenario: Unrelated-area pull request
+- **WHEN** a pull request changes only files outside the web, scripts, and desktop areas
+- **THEN** no web or desktop check job executes and the run still completes
+
+### Requirement: Dependency versions are pinned
+Every repository `package.json` SHALL declare exact version pins for its `dependencies` and `devDependencies`. A version range, dist-tag, or other non-exact reference SHALL fail the governance check, except for `workspace:`, `https://`, `http://`, and `file:` protocol references, which are permitted. A manifest with no dependencies, or one that cannot be parsed, SHALL not fail the check.
+
+#### Scenario: Caret range rejected
+- **WHEN** a pull request adds `"lodash": "^4.17.21"` to a `package.json`
+- **THEN** the pinned-versions check fails naming the package and file
+
+#### Scenario: Workspace reference accepted
+- **WHEN** a `package.json` depends on a workspace package via `"arche-web": "workspace:*"`
+- **THEN** the pinned-versions check passes for that entry
+
+#### Scenario: Generated manifest tolerated
+- **WHEN** a `package.json` under build output cannot be parsed
+- **THEN** the check warns and does not fail
+
+### Requirement: Pull requests are screened for sensitive files and secrets
+The governance workflow SHALL fail a pull request when a changed file's name matches sensitive-file patterns (environment files, private keys, certificate/keystore stores, credential or auth config files), and when added diff lines match known hardcoded-secret patterns (cloud and CI provider tokens, private key blocks, assignment of quoted password/secret/api-key/access-token values). Binary files SHALL be excluded from the content scan.
+
+#### Scenario: Environment file added
+- **WHEN** a pull request adds a file named `.env.production`
+- **THEN** the security scan fails identifying the file
+
+#### Scenario: Hardcoded token in added lines
+- **WHEN** a pull request adds a line assigning a quoted value matching a provider token pattern
+- **THEN** the security scan fails showing the matched line
+
+#### Scenario: Binary file changed
+- **WHEN** a pull request changes only binary assets (images, archives, lockfiles)
+- **THEN** the content scan skips them
+
+### Requirement: Work-in-progress titles are labeled
+When a pull request title contains the whole word `wip` (case-insensitive), the system SHALL add the `wip` and `not-ready-to-merge` labels; when the title no longer matches, it SHALL remove them. Label state SHALL always mirror the current title.
+
+#### Scenario: Title gains WIP
+- **WHEN** a pull request is opened or retitled with `WIP` in the title
+- **THEN** both labels are present
+
+#### Scenario: Title drops WIP
+- **WHEN** a labeled pull request is retitled without `wip`
+- **THEN** both labels are removed
+
+### Requirement: Comment commands are exact-match and permission-gated
+The PR comment commands `/build`, `/lgtm`, `/rerun`, and `/help` SHALL act only when the comment body, trimmed, exactly equals the command and the comment is on a pull request. `/lgtm` and `/rerun` SHALL require the commenter to hold `write` or `admin` collaborator permission; `/lgtm` SHALL refuse to approve a pull request authored by the commenter.
+
+#### Scenario: Partial command text ignored
+- **WHEN** a comment reads `/lgtm but also check X`
+- **THEN** no approval is created
+
+#### Scenario: Non-write commenter
+- **WHEN** a commenter without write access issues `/lgtm` or `/rerun`
+- **THEN** the command fails with a permission error and takes no action
+
+#### Scenario: Self-approval refused
+- **WHEN** the pull request author comments `/lgtm`
+- **THEN** no approving review is created
+
+#### Scenario: Successful rerun
+- **WHEN** a user with write access comments `/rerun` on a PR with failed GitHub Actions checks
+- **THEN** the failed jobs of those runs are re-run and the command is acknowledged with a reaction

--- a/openspec/changes/pr-governance-and-commands/tasks.md
+++ b/openspec/changes/pr-governance-and-commands/tasks.md
@@ -1,0 +1,24 @@
+## 1. PR governance workflow
+
+- [x] 1.1 Add `.github/workflows/pr-governance.yml` triggering on `pull_request` (opened, edited, synchronize, reopened) plus `workflow_dispatch`, with a `wip-labeler` job that mirrors the `wip`/`not-ready-to-merge` labels from a `\bwip\b` title match (guarded to PR events, tolerant of already-removed labels).
+- [x] 1.2 Add the `pinned-versions` job: scan every tracked `package.json` (excluding `node_modules`, `.next`, `generated`, `.pnpm`) and fail when any `dependencies`/`devDependencies` entry is not an exact version pin; allow `workspace:`, `https?://`, `file:` refs; skip zero-dep and malformed manifests (malformed emits a warning).
+- [x] 1.3 Add the `security-scan` job: fail on added/changed files matching sensitive filename patterns (env files, keys/certstores, credential files, rc/auth files) and on added diff lines matching hardcoded-secret patterns; skip binary extensions; skip `edited` events.
+- [x] 1.4 Scope job permissions minimally (`pull-requests: write` for the labeler, `contents: read` for scanners).
+
+## 2. PR comment commands
+
+- [x] 2.1 Extend `.github/workflows/pr-commands.yml` with `/lgtm`: exact-match command, collaborator `admin`/`write` gate, self-approval refusal, approving review + 👍 reaction on success.
+- [x] 2.2 Add `/rerun`: exact-match command, write gate, paginate latest check runs on the PR head, re-run failed/cancelled `github-actions` runs, 👍/😕 reaction by outcome.
+- [x] 2.3 Add `/help`: exact-match command, posts the command table, 👍 reaction. Keep `/build` unchanged.
+- [x] 2.4 All new commands no-op unless the comment is on a pull request.
+
+## 3. PR checks triggering
+
+- [x] 3.1 Rework `.github/workflows/pr-checks.yml`: remove `pull_request.paths` filters, add a `detect-changes` job (full checkout, `git diff --name-only origin/main...HEAD`) emitting `web`/`desktop` outputs, and gate web/desktop jobs with `needs`/`if`.
+- [x] 3.2 Preserve main's current check steps unchanged (including the Postgres concurrency integration test step) — triggering-only change.
+
+## 4. Final verification
+
+- [x] 4.1 Validate all three workflow files parse as YAML and pass `actionlint` (no errors).
+- [ ] 4.2 Behaviors verified on live PRs per the PR test plan (WIP labeling, unpinned dependency rejection, sensitive-file rejection, `/lgtm` self-approval refusal, `/rerun`, `/help`).
+- [x] 4.3 Run `openspec validate pr-governance-and-commands --strict` — change validates.


### PR DESCRIPTION
## Summary

- **PR Governance workflow** (`pr-governance.yml`) with three jobs:
  - **WIP Labeler** — auto-adds `wip` and `not-ready-to-merge` labels when PR title contains "WIP" (case-insensitive), removes them when WIP is dropped
  - **Pinned Versions** — enforces exact dependency versions across all `package.json` files (rejects `^`, `~`, `*`, dist-tags like `latest`/`next`; allows `workspace:` refs)
  - **Security Scan** — checks changed files for sensitive file types (`.env`, `.pem`, `.key`, credentials) and scans added diff lines for hardcoded secret patterns (AWS keys, GitHub tokens, private keys, password assignments)

- **Expanded PR Commands** (`pr-commands.yml`):
  - `/lgtm` — approve the PR with write-access and self-approval checks
  - `/rerun` — re-run failed CI checks with auth gate and pagination
  - `/help` — list all available commands

## Security hardening

- All new commands require write collaborator permission
- `/lgtm` prevents self-approval (cannot approve your own PR)
- Exact command matching via `body.trim() !== '/cmd'` prevents false triggers from partial matches
- `pinned-versions` and `security-scan` jobs skip `edited` events to avoid wasted compute on description edits
- `wip-labeler` guarded against `workflow_dispatch` (no PR context)
- `/rerun` paginates check runs to handle repos with many CI jobs
- Secret scanner only inspects added lines in the diff, not the full file

## Test plan

- [x] Open a PR with "WIP" in the title → verify `wip` and `not-ready-to-merge` labels are added
- [x] Edit the PR title to remove "WIP" → verify labels are removed
- [x] Add an unpinned dependency (e.g. `"^1.0.0"`) to a `package.json` → verify CI fails
- [x] Add a file matching a sensitive pattern (e.g. `test.env`) → verify CI fails
- [x] Comment `/lgtm` on a PR you authored → verify it's rejected
- [x] Comment `/lgtm` on someone else's PR with write access → verify approval
- [x] Comment `/rerun` on a PR with failed checks → verify re-run
- [x] Comment `/help` → verify help table is posted
- [x] Comment `/lgtm but also check X` → verify it's ignored (not an exact match)

## OpenSpec

Adds `pr-governance-and-commands` change with a new `pr-governance` capability spec (`openspec/changes/pr-governance-and-commands/`): path-aware check selection, WIP labeling, dependency pinning, sensitive-file/secret screening, and the exact-match, write-gated comment commands. Validated with `openspec validate --strict`.
