### PR TITLE
fix(workspace): keep chat live after permission approval

### DIFF
--- a/apps/web/src/actions/__tests__/opencode.test.ts
+++ b/apps/web/src/actions/__tests__/opencode.test.ts
@@ -849,6 +849,58 @@ describe('listMessagesAction', () => {
     })
   })
 
+  it('hydrates child-session pending permissions onto the parent assistant', async () => {
+    mockSessionMessages.mockResolvedValue({
+      data: [
+        {
+          info: { id: 'msg-1', role: 'assistant', time: { created: Date.now() } },
+          parts: [{ type: 'tool', id: 'task-1', tool: 'task', state: { status: 'running', input: {} } }],
+        },
+      ],
+    })
+    const mockSessionChildren = vi.fn().mockResolvedValue({
+      data: [{ id: 'child-1' }],
+    })
+    mockCreateInstanceClient.mockResolvedValue({
+      ...makeClient(),
+      session: {
+        ...makeClient().session,
+        children: mockSessionChildren,
+      },
+    } as never)
+    mockPermissionList.mockResolvedValue({
+      data: [
+        {
+          id: 'child-perm',
+          metadata: { tool: 'arche_custom_mailerlite_delete_campaign' },
+          patterns: ['arche_custom_mailerlite_delete_campaign'],
+          permission: 'Delete campaign',
+          sessionID: 'child-1',
+          tool: { callID: 'call-child', messageID: 'child-msg' },
+        },
+      ],
+    })
+
+    const result = await listMessagesAction('alice', 'sess-1')
+
+    expect(result.messages![0]).toMatchObject({
+      pending: true,
+      statusInfo: {
+        status: 'tool-calling',
+        detail: 'permission_required',
+      },
+      parts: [
+        { type: 'tool', id: 'task-1' },
+        {
+          type: 'permission',
+          permissionId: 'child-perm',
+          sessionId: 'child-1',
+          state: 'pending',
+        },
+      ],
+    })
+  })
+
   it.each([
     ['a non-array result', { id: 'permission-1' }],
     ['a permission with non-array patterns', [

--- a/apps/web/src/actions/opencode.ts
+++ b/apps/web/src/actions/opencode.ts
@@ -76,55 +76,110 @@ type PendingPermission = {
   patterns: string[];
   permission: string;
   sessionID: string;
-  tool: {
-    callID?: string;
-    messageID: string;
-  };
+  messageID?: string;
+  callID?: string;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-function isPendingPermission(value: unknown): value is PendingPermission {
-  if (!isRecord(value) || !isRecord(value.tool)) return false;
+function normalizeListedPermission(value: unknown): PendingPermission | null {
+  if (!isRecord(value)) return null;
 
-  return (
-    typeof value.id === "string" &&
-    typeof value.permission === "string" &&
-    typeof value.sessionID === "string" &&
-    typeof value.tool.messageID === "string" &&
-    (value.tool.callID === undefined || typeof value.tool.callID === "string") &&
-    Array.isArray(value.patterns) &&
-    value.patterns.every((pattern) => typeof pattern === "string") &&
-    (value.metadata === undefined || isRecord(value.metadata))
-  );
+  const id = typeof value.id === "string" && value.id.trim() ? value.id.trim() : null;
+  const sessionID =
+    typeof value.sessionID === "string" && value.sessionID.trim()
+      ? value.sessionID.trim()
+      : typeof value.sessionId === "string" && value.sessionId.trim()
+        ? value.sessionId.trim()
+        : null;
+  if (!id || !sessionID) return null;
+
+  const tool = isRecord(value.tool) ? value.tool : null;
+  const source = isRecord(value.source) ? value.source : null;
+  const messageID =
+    (typeof tool?.messageID === "string" && tool.messageID.trim()) ||
+    (typeof tool?.messageId === "string" && tool.messageId.trim()) ||
+    (typeof source?.messageID === "string" && source.messageID.trim()) ||
+    (typeof source?.messageId === "string" && source.messageId.trim()) ||
+    (typeof value.messageID === "string" && value.messageID.trim()) ||
+    (typeof value.messageId === "string" && value.messageId.trim()) ||
+    undefined;
+  const callID =
+    (typeof tool?.callID === "string" && tool.callID.trim()) ||
+    (typeof tool?.callId === "string" && tool.callId.trim()) ||
+    (typeof source?.callID === "string" && source.callID.trim()) ||
+    (typeof source?.callId === "string" && source.callId.trim()) ||
+    (typeof value.callID === "string" && value.callID.trim()) ||
+    (typeof value.callId === "string" && value.callId.trim()) ||
+    undefined;
+
+  const resources = Array.isArray(value.resources)
+    ? value.resources.filter((resource): resource is string => typeof resource === "string")
+    : [];
+  if (value.patterns !== undefined && !Array.isArray(value.patterns) && resources.length === 0) {
+    return null;
+  }
+
+  const patterns = Array.isArray(value.patterns)
+    ? value.patterns.filter((pattern): pattern is string => typeof pattern === "string")
+    : resources;
+
+  const permission =
+    (typeof value.permission === "string" && value.permission.trim()) ||
+    (typeof value.title === "string" && value.title.trim()) ||
+    (typeof value.action === "string" && value.action.trim()) ||
+    (patterns.length > 0 ? patterns.join(", ") : "Tool approval required");
+
+  return {
+    id,
+    sessionID,
+    permission,
+    patterns,
+    ...(messageID ? { messageID } : {}),
+    ...(callID ? { callID } : {}),
+    ...(isRecord(value.metadata) ? { metadata: value.metadata } : {}),
+  };
 }
 
 function getPendingPermissionPartsByMessageId(
   permissions: unknown,
-  sessionId: string
+  sessionId: string,
+  options: {
+    familySessionIds: Set<string>;
+    fallbackMessageId?: string;
+    messageIds: Set<string>;
+  }
 ) {
   const partsByMessageId = new Map<string, ReturnType<typeof transformParts>>();
   if (!Array.isArray(permissions)) return partsByMessageId;
 
   for (const permission of permissions) {
-    if (!isPendingPermission(permission) || permission.sessionID !== sessionId) continue;
+    const normalized = normalizeListedPermission(permission);
+    if (!normalized || !options.familySessionIds.has(normalized.sessionID)) continue;
 
-    const parts = partsByMessageId.get(permission.tool.messageID) ?? [];
+    const targetMessageId = normalized.messageID && options.messageIds.has(normalized.messageID)
+      ? normalized.messageID
+      : normalized.sessionID === sessionId
+        ? undefined
+        : options.fallbackMessageId;
+    if (!targetMessageId) continue;
+
+    const parts = partsByMessageId.get(targetMessageId) ?? [];
     parts.push({
       type: "permission",
-      id: `permission:${permission.id}`,
-      permissionId: permission.id,
-      sessionId,
-      title: permission.permission,
+      id: `permission:${normalized.id}`,
+      permissionId: normalized.id,
+      sessionId: normalized.sessionID,
+      title: normalized.permission,
       state: "pending",
-      ...(permission.tool.callID && { callId: permission.tool.callID }),
-      pattern: permission.patterns.join(", "),
+      ...(normalized.callID && { callId: normalized.callID }),
+      pattern: normalized.patterns.join(", "),
       permissionType: "tool",
-      ...(permission.metadata && { metadata: permission.metadata }),
+      ...(normalized.metadata && { metadata: normalized.metadata }),
     });
-    partsByMessageId.set(permission.tool.messageID, parts);
+    partsByMessageId.set(targetMessageId, parts);
   }
 
   return partsByMessageId;
@@ -853,9 +908,37 @@ export async function listMessagesAction(
     const pendingPermissions = await client!.permission.list()
       .then((result) => result.data)
       .catch(() => []);
+    const familySessionIds = new Set<string>([sessionId]);
+    try {
+      const childrenResult = await client!.session.children({ sessionID: sessionId });
+      for (const child of childrenResult.data ?? []) {
+        if (typeof child.id === "string" && child.id.trim()) {
+          familySessionIds.add(child.id);
+        }
+      }
+    } catch {
+      // Family discovery is best-effort; parent permissions still hydrate.
+    }
+
+    const messageIds = new Set(
+      messages
+        .map((message) => message.info.id)
+        .filter((id): id is string => typeof id === "string" && id.length > 0)
+    );
+    const fallbackMessageId = [...messages].reverse().find((message) => {
+      if (normalizeMessageRole(message.info.role) !== "assistant") return false;
+      const completedAt = (message.info.time as { completed?: number } | undefined)?.completed;
+      return typeof completedAt !== "number" || completedAt <= 0;
+    })?.info.id;
+
     const pendingPermissionPartsByMessageId = getPendingPermissionPartsByMessageId(
       pendingPermissions,
-      sessionId
+      sessionId,
+      {
+        familySessionIds,
+        messageIds,
+        ...(typeof fallbackMessageId === "string" ? { fallbackMessageId } : {}),
+      }
     );
 
     const transformed: WorkspaceMessage[] = [];

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/route.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/route.test.ts
@@ -852,6 +852,115 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     expect(text).toContain('event: done')
   })
 
+  it('forwards permission.asked events from delegated child sessions', async () => {
+    const fetchMock = mockOpenCodeFetch([
+      {
+        type: 'message.updated',
+        properties: { info: { id: 'm1', role: 'assistant', sessionID: 's1' } },
+      },
+      {
+        type: 'session.created',
+        properties: { info: { id: 'child-1', parentID: 's1' } },
+      },
+      {
+        type: 'permission.asked',
+        properties: {
+          id: 'child-perm',
+          sessionID: 'child-1',
+          permission: 'Delete Mailerlite campaign',
+          patterns: ['arche_custom_mailerlite_delete_campaign'],
+          metadata: { tool: 'arche_custom_mailerlite_delete_campaign' },
+          tool: { callID: 'call-child', messageID: 'child-msg' },
+        },
+      },
+      { type: 'session.idle', properties: { info: { sessionID: 's1' } } },
+    ])
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
+
+    const text = await res.text()
+
+    expect(text).toContain('event: permission\ndata:')
+    expect(text).toContain('"id":"child-perm"')
+    expect(text).toContain('Delete Mailerlite campaign')
+  })
+
+  it('forwards OpenCode permission.v2.asked and permission.v2.replied events', async () => {
+    const fetchMock = mockOpenCodeFetch([
+      {
+        type: 'message.updated',
+        properties: { info: { id: 'm1', role: 'assistant', sessionID: 's1' } },
+      },
+      {
+        type: 'permission.v2.asked',
+        properties: {
+          id: 'perm-v2',
+          sessionID: 's1',
+          action: 'external_directory_write',
+          resources: ['/tmp/out.md'],
+          metadata: { tool: 'write' },
+          source: { type: 'tool', messageID: 'm1', callID: 'call-v2' },
+        },
+      },
+      {
+        type: 'permission.v2.replied',
+        properties: { sessionID: 's1', requestID: 'perm-v2', reply: 'once' },
+      },
+      { type: 'session.idle', properties: { info: { sessionID: 's1' } } },
+    ])
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
+
+    const text = await res.text()
+
+    expect(text).toContain('event: permission\ndata:')
+    expect(text).toContain('"id":"perm-v2"')
+    expect(text).toContain('"title":"external_directory_write"')
+    expect(text).toContain('event: permission-replied')
+    expect(text).toContain('"response":"once"')
+    expect(text.indexOf('"detail":"permission_required"')).toBeLessThan(text.lastIndexOf('"status":"thinking"'))
+  })
+
+  it('does not finalize while a delegated task tool is still running', async () => {
+    const fetchMock = mockOpenCodeFetch([
+      {
+        type: 'message.updated',
+        properties: { info: { id: 'm1', role: 'assistant', sessionID: 's1' } },
+      },
+      {
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            id: 'task-1',
+            messageID: 'm1',
+            sessionID: 's1',
+            type: 'tool',
+            tool: 'task',
+            state: {
+              status: 'running',
+              input: { subagent_type: 'copywriter' },
+              metadata: { sessionId: 'child-1' },
+            },
+          },
+        },
+      },
+      { type: 'session.idle', properties: { info: { sessionID: 's1' } } },
+    ])
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
+
+    const text = await res.text()
+
+    expect(text).toContain('"tool":"task"')
+    expect(text).not.toContain('event: done')
+  })
+
   it('forwards legacy permission.updated events', async () => {
     const fetchMock = mockOpenCodeFetch([
       {

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/route.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/route.test.ts
@@ -961,6 +961,78 @@ describe('POST /api/w/[slug]/chat/stream', () => {
     expect(text).not.toContain('event: done')
   })
 
+  it('does not finalize when family status is unknown at parent idle', async () => {
+    mocks.createUpstreamSessionStatusReader.mockReturnValue(vi.fn().mockResolvedValue(null))
+    const fetchMock = mockOpenCodeFetch([
+      {
+        type: 'message.updated',
+        properties: { info: { id: 'm1', role: 'assistant', sessionID: 's1' } },
+      },
+      {
+        type: 'session.created',
+        properties: { info: { id: 'child-1', parentID: 's1' } },
+      },
+      { type: 'session.idle', properties: { info: { sessionID: 's1' } } },
+    ])
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
+
+    const text = await res.text()
+
+    expect(text).not.toContain('event: done')
+    expect(mocks.messageRunService.markRunSucceeded).not.toHaveBeenCalled()
+  })
+
+  it('does not finalize when a child session is still busy at parent idle', async () => {
+    mocks.createUpstreamSessionStatusReader.mockReturnValue(vi.fn().mockResolvedValue('busy'))
+    const fetchMock = mockOpenCodeFetch([
+      {
+        type: 'message.updated',
+        properties: { info: { id: 'm1', role: 'assistant', sessionID: 's1' } },
+      },
+      {
+        type: 'session.created',
+        properties: { info: { id: 'child-1', parentID: 's1' } },
+      },
+      { type: 'session.idle', properties: { info: { sessionID: 's1' } } },
+    ])
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
+
+    const text = await res.text()
+
+    expect(text).not.toContain('event: done')
+    expect(mocks.messageRunService.markRunSucceeded).not.toHaveBeenCalled()
+  })
+
+  it('finalizes after parent idle once the session family is confirmed idle', async () => {
+    mocks.createUpstreamSessionStatusReader.mockReturnValue(vi.fn().mockResolvedValue('idle'))
+    const fetchMock = mockOpenCodeFetch([
+      {
+        type: 'message.updated',
+        properties: { info: { id: 'm1', role: 'assistant', sessionID: 's1' } },
+      },
+      {
+        type: 'session.created',
+        properties: { info: { id: 'child-1', parentID: 's1' } },
+      },
+      { type: 'session.idle', properties: { info: { sessionID: 's1' } } },
+    ])
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({ sessionId: 's1', runId: 'run-1' }), params())
+
+    const text = await res.text()
+
+    expect(text).toContain('event: done')
+    expect(mocks.messageRunService.markRunSucceeded).toHaveBeenCalledWith('run-1')
+  })
+
   it('forwards legacy permission.updated events', async () => {
     const fetchMock = mockOpenCodeFetch([
       {

--- a/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/status-reader.test.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/__tests__/status-reader.test.ts
@@ -99,4 +99,26 @@ describe('createUpstreamSessionStatusReader', () => {
       terminalError: 'free_tier_limit',
     })
   })
+
+  it('treats the family as busy when a child session is still running', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          'session-1': { type: 'idle' },
+          'child-1': { type: 'busy' },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const readStatus = createUpstreamSessionStatusReader({
+      baseUrl: 'http://127.0.0.1:4096',
+      authHeader: 'Basic token',
+      sessionId: 'session-1',
+      getSessionIds: () => ['session-1', 'child-1'],
+    })
+
+    await expect(readStatus()).resolves.toBe('busy')
+  })
 })

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -943,7 +943,7 @@ export const POST = withAuth(
 
           if (sessionFamilyIds.size > 1) {
             const familyStatus = await readUpstreamSessionStatus()
-            if (familyStatus === 'busy' || familyStatus === 'retry') {
+            if (familyStatus !== 'idle') {
               markWatchdogCheck()
               return
             }
@@ -1026,7 +1026,7 @@ export const POST = withAuth(
 
                 if (watchdogOutcome === 'finalize_idle') {
                   markWatchdogCheck()
-                      await finalizeFromIdle()
+                  await finalizeFromIdle()
                   continue
                 }
 
@@ -1074,7 +1074,7 @@ export const POST = withAuth(
             if (terminalRetryError) {
               failForTerminalRetry(terminalRetryError)
             } else if (!aborted && upstreamStatus === 'idle') {
-                    await finalizeFromIdle()
+              await finalizeFromIdle()
             } else if (!aborted) {
               closeForObservationInterruption('upstream_eof')
             }

--- a/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/route.ts
@@ -93,7 +93,24 @@ function getPermissionPattern(permission: Record<string, unknown>): string | und
     if (patterns.length > 0) return patterns.join(', ')
   }
 
+  if (Array.isArray(permission.resources)) {
+    const resources = permission.resources
+      .map(getString)
+      .filter((resource): resource is string => Boolean(resource))
+    if (resources.length > 0) return resources.join(', ')
+  }
+
   return getString(permission.pattern)
+}
+
+function isPermissionEventType(eventType: string): boolean {
+  return (
+    eventType === 'permission.asked' ||
+    eventType === 'permission.updated' ||
+    eventType === 'permission.replied' ||
+    eventType === 'permission.v2.asked' ||
+    eventType === 'permission.v2.replied'
+  )
 }
 
 function normalizePendingPermission(
@@ -103,6 +120,7 @@ function normalizePendingPermission(
   if (!isRecord(value)) return null
 
   const tool = isRecord(value.tool) ? value.tool : null
+  const source = isRecord(value.source) ? value.source : null
   const id = getString(value.id)
   const sessionId = getString(value.sessionID) ?? getString(value.sessionId) ?? fallback.sessionId
   if (!id || !sessionId) return null
@@ -112,12 +130,16 @@ function normalizePendingPermission(
   const messageId =
     getString(tool?.messageID) ??
     getString(tool?.messageId) ??
+    getString(source?.messageID) ??
+    getString(source?.messageId) ??
     getString(value.messageID) ??
     getString(value.messageId) ??
     fallback.messageId
   const callId =
     getString(tool?.callID) ??
     getString(tool?.callId) ??
+    getString(source?.callID) ??
+    getString(source?.callId) ??
     getString(value.callID) ??
     getString(value.callId)
 
@@ -126,7 +148,12 @@ function normalizePendingPermission(
     sessionId,
     ...(messageId && { messageId }),
     ...(callId && { callId }),
-    title: getString(value.permission) ?? getString(value.title) ?? pattern ?? 'Tool approval required',
+    title:
+      getString(value.permission) ??
+      getString(value.title) ??
+      getString(value.action) ??
+      pattern ??
+      'Tool approval required',
     ...(pattern && { pattern }),
     ...(metadata && { metadata }),
     state: 'pending',
@@ -608,10 +635,13 @@ export const POST = withAuth(
         try {
           sendEvent('status', { status: 'connecting' })
           let terminalRetryError: string | null = null
+          const sessionFamilyIds = new Set<string>([sessionId])
+          const runningTaskPartIds = new Set<string>()
           const readUpstreamSessionStatus = createUpstreamSessionStatusReader({
             baseUrl,
             authHeader,
             sessionId,
+            getSessionIds: () => sessionFamilyIds,
             onRead: ({ durationMs, outcome, responseStatus, status, terminalError }) => {
               if (terminalError) {
                 terminalRetryError = terminalError
@@ -760,6 +790,36 @@ export const POST = withAuth(
           ? RESUME_STREAM_RELEVANT_EVENT_TIMEOUT_MS
           : SEND_STREAM_RELEVANT_EVENT_TIMEOUT_MS
 
+        const rememberFamilySession = (id?: string) => {
+          if (id) sessionFamilyIds.add(id)
+        }
+
+        const rememberSessionFamilyFromInfo = (value: unknown) => {
+          if (!isRecord(value)) return
+          const createdId = getString(value.id)
+          const parentId = getString(value.parentID) ?? getString(value.parentId)
+          if (createdId && parentId && sessionFamilyIds.has(parentId)) {
+            sessionFamilyIds.add(createdId)
+          }
+        }
+
+        const rememberTaskPart = (part: Record<string, unknown>) => {
+          const toolName = getString(part.tool) ?? getString(part.name)
+          const partId = getString(part.id) ?? getString(part.callID)
+          if (toolName !== 'task' || !partId) return
+
+          const state = isRecord(part.state) ? part.state : null
+          const status = getString(state?.status)
+          if (status === 'running' || status === 'pending') {
+            runningTaskPartIds.add(partId)
+          } else {
+            runningTaskPartIds.delete(partId)
+          }
+
+          const metadata = isRecord(state?.metadata) ? state.metadata : null
+          rememberFamilySession(getString(metadata?.sessionId) ?? getString(metadata?.sessionID))
+        }
+
         const markRelevantEvent = () => {
           const now = Date.now()
           lastRelevantEventAt = now
@@ -788,16 +848,28 @@ export const POST = withAuth(
           sendEvent('permission', permission)
         }
 
-        if (resume) {
+        try {
+          const client = await createConfiguredOpencodeClient({ authHeader, baseUrl })
           try {
-            const client = await createConfiguredOpencodeClient({ authHeader, baseUrl })
+            const childrenResult = await client.session?.children?.({ sessionID: sessionId })
+            for (const child of childrenResult?.data ?? []) {
+              rememberFamilySession(getString(child.id))
+            }
+          } catch (error) {
+            console.warn('[chat/stream] Failed to list session children', { error, sessionId })
+          }
+
+          if (resume) {
             const result = await client.permission.list()
             const permissions = Array.isArray(result.data) ? result.data : []
             for (const permission of permissions) {
               const normalizedPermission = normalizePendingPermission(permission)
+              if (!normalizedPermission || !sessionFamilyIds.has(normalizedPermission.sessionId)) {
+                continue
+              }
               if (
-                !normalizedPermission ||
-                normalizedPermission.sessionId !== sessionId ||
+                normalizedPermission.sessionId === sessionId &&
+                normalizedPermission.messageId &&
                 normalizedPermission.messageId !== assistantMessageId
               ) {
                 continue
@@ -805,9 +877,9 @@ export const POST = withAuth(
 
               emitPendingPermission(normalizedPermission)
             }
-          } catch (error) {
-            console.warn('[chat/stream] Failed to list pending resume permissions', { error, sessionId })
           }
+        } catch (error) {
+          console.warn('[chat/stream] Failed to hydrate session family permissions', { error, sessionId })
         }
 
         const failForTerminalRetry = (detail: string) => {
@@ -861,12 +933,20 @@ export const POST = withAuth(
           }
         }
 
-        const finalizeFromIdle = () => {
+        const finalizeFromIdle = async () => {
           if (aborted) return
 
-          if (pendingPermissionIds.size > 0) {
+          if (pendingPermissionIds.size > 0 || runningTaskPartIds.size > 0) {
             markWatchdogCheck()
             return
+          }
+
+          if (sessionFamilyIds.size > 1) {
+            const familyStatus = await readUpstreamSessionStatus()
+            if (familyStatus === 'busy' || familyStatus === 'retry') {
+              markWatchdogCheck()
+              return
+            }
           }
 
           const outcome = getIdleFinalizationOutcome({
@@ -908,7 +988,7 @@ export const POST = withAuth(
 
             if (readResult.type === 'tick') {
               if (Date.now() - lastRelevantEventAt > relevantEventTimeoutMs) {
-                if (pendingPermissionIds.size > 0) {
+                if (pendingPermissionIds.size > 0 || runningTaskPartIds.size > 0) {
                   markWatchdogCheck()
                   continue
                 }
@@ -946,7 +1026,7 @@ export const POST = withAuth(
 
                 if (watchdogOutcome === 'finalize_idle') {
                   markWatchdogCheck()
-                  finalizeFromIdle()
+                      await finalizeFromIdle()
                   continue
                 }
 
@@ -994,7 +1074,7 @@ export const POST = withAuth(
             if (terminalRetryError) {
               failForTerminalRetry(terminalRetryError)
             } else if (!aborted && upstreamStatus === 'idle') {
-              finalizeFromIdle()
+                    await finalizeFromIdle()
             } else if (!aborted) {
               closeForObservationInterruption('upstream_eof')
             }
@@ -1028,27 +1108,27 @@ export const POST = withAuth(
                   firstUpstreamEventSeen = true
                   logObservation('first_upstream_event', { eventType })
                 }
+
+                if (eventType === 'session.created' || eventType === 'session.updated') {
+                  rememberSessionFamilyFromInfo(event.properties?.info)
+                }
+
                 const isWorkspaceEvent =
                   eventType === 'file.edited' ||
                   eventType === 'file.created' ||
                   eventType === 'file.deleted' ||
                   eventType === 'todo.updated'
 
-                const isSessionScopedEvent =
-                  eventType === 'session.status' ||
-                  eventType === 'session.idle' ||
-                  eventType === 'session.error' ||
-                  eventType === 'permission.asked' ||
-                  eventType === 'permission.updated' ||
-                  eventType === 'permission.replied'
+                const isPermissionEvent = isPermissionEventType(eventType)
 
-                // Filter events for our session only
+                // Filter events for our session only. Permission events from
+                // delegated child sessions must still reach the parent transcript.
                 if (!isWorkspaceEvent) {
-                  if (isSessionScopedEvent && eventSessionId !== sessionId) {
-                    continue
-                  }
-
-                  if (!isSessionScopedEvent && eventSessionId && eventSessionId !== sessionId) {
+                  if (isPermissionEvent) {
+                    if (eventSessionId && !sessionFamilyIds.has(eventSessionId)) {
+                      continue
+                    }
+                  } else if (eventSessionId && eventSessionId !== sessionId) {
                     continue
                   }
                 }
@@ -1067,20 +1147,20 @@ export const POST = withAuth(
                     } else if (status?.type === 'retry') {
                       emitStatus('thinking', undefined, status?.message)
                     } else if (status?.type === 'idle') {
-                      if (pendingPermissionIds.size > 0) {
+                      if (pendingPermissionIds.size > 0 || runningTaskPartIds.size > 0) {
                         break
                       }
-                      finalizeFromIdle()
+                      await finalizeFromIdle()
                     }
                     break
                   }
 
                   case 'session.idle': {
                     markRelevantEvent()
-                    if (pendingPermissionIds.size > 0) {
+                    if (pendingPermissionIds.size > 0 || runningTaskPartIds.size > 0) {
                       break
                     }
-                    finalizeFromIdle()
+                    await finalizeFromIdle()
                     break
                   }
 
@@ -1098,6 +1178,7 @@ export const POST = withAuth(
                     break
                   }
 
+                  case 'permission.v2.asked':
                   case 'permission.asked':
                   case 'permission.updated': {
                     markRelevantEvent()
@@ -1111,10 +1192,12 @@ export const POST = withAuth(
                     )
                     if (!permission) break
 
+                    rememberFamilySession(permission.sessionId)
                     emitPendingPermission(permission)
                     break
                   }
 
+                  case 'permission.v2.replied':
                   case 'permission.replied': {
                     markRelevantEvent()
 
@@ -1137,6 +1220,9 @@ export const POST = withAuth(
                         getString(permission?.reply) ??
                         getString(permission?.response),
                     })
+                    if (pendingPermissionIds.size === 0) {
+                      emitStatus('thinking')
+                    }
                     break
                   }
 
@@ -1198,6 +1284,10 @@ export const POST = withAuth(
                     const isAssistantPart = assistantMessageId
                       ? partMessageId === assistantMessageId
                       : knownRole === 'assistant'
+
+                    if (isRecord(part)) {
+                      rememberTaskPart(part)
+                    }
 
                     sendEvent('part', { messageId: partMessageId, part, delta })
 

--- a/apps/web/src/app/api/w/[slug]/chat/stream/status-reader.ts
+++ b/apps/web/src/app/api/w/[slug]/chat/stream/status-reader.ts
@@ -13,7 +13,37 @@ type UpstreamSessionStatusReaderOptions = {
   baseUrl: string
   authHeader: string
   sessionId: string
+  getSessionIds?: () => Iterable<string>
   onRead?: (result: UpstreamSessionStatusReadResult) => void
+}
+
+function readAggregatedSessionStatus(
+  data: UpstreamSessionStatusResponse,
+  sessionId: string,
+  sessionIds: Iterable<string>,
+): { status: string | null; terminalError?: string } {
+  const ids = new Set<string>([sessionId, ...sessionIds])
+  let sawBusy = false
+  let sawRetry = false
+  let sawIdle = false
+  let terminalError: string | undefined
+
+  for (const id of ids) {
+    const sessionStatus = data[id]
+    const status = typeof sessionStatus?.type === 'string' ? sessionStatus.type : null
+    const nextTerminalError = getTerminalRetryError(sessionStatus)
+    if (nextTerminalError && !terminalError) {
+      terminalError = nextTerminalError
+    }
+    if (status === 'busy') sawBusy = true
+    else if (status === 'retry') sawRetry = true
+    else if (status === 'idle') sawIdle = true
+  }
+
+  if (sawBusy) return { status: 'busy', ...(terminalError ? { terminalError } : {}) }
+  if (sawRetry) return { status: 'retry', ...(terminalError ? { terminalError } : {}) }
+  if (sawIdle) return { status: 'idle', ...(terminalError ? { terminalError } : {}) }
+  return { status: null, ...(terminalError ? { terminalError } : {}) }
 }
 
 export type UpstreamSessionStatusReadResult = {
@@ -31,13 +61,18 @@ export function createUpstreamSessionStatusReader({
   baseUrl,
   authHeader,
   sessionId,
+  getSessionIds,
   onRead,
 }: UpstreamSessionStatusReaderOptions): () => Promise<string | null> {
-  let cache: { expiresAt: number; status: string | null } | null = null
+  let cache: { expiresAt: number; sessionKey: string; status: string | null } | null = null
+
+  const getSessionKey = () =>
+    [sessionId, ...new Set(getSessionIds?.() ?? [sessionId])].sort().join(',')
 
   return async () => {
     const now = Date.now()
-    if (cache && now < cache.expiresAt) {
+    const sessionKey = getSessionKey()
+    if (cache && now < cache.expiresAt && cache.sessionKey === sessionKey) {
       return cache.status
     }
 
@@ -59,7 +94,7 @@ export function createUpstreamSessionStatusReader({
           sessionId,
           status: response.status,
         })
-        cache = { expiresAt: now + UPSTREAM_STATUS_CACHE_WINDOW_MS, status: null }
+        cache = { expiresAt: now + UPSTREAM_STATUS_CACHE_WINDOW_MS, sessionKey, status: null }
         onRead?.({
           durationMs: Date.now() - startedAt,
           outcome: 'http_error',
@@ -70,10 +105,10 @@ export function createUpstreamSessionStatusReader({
       }
 
       const data = await response.json().catch(() => null) as UpstreamSessionStatusResponse | null
-      const sessionStatus = data?.[sessionId]
-      const status = typeof sessionStatus?.type === 'string' ? sessionStatus.type : null
-      const terminalError = getTerminalRetryError(sessionStatus)
-      cache = { expiresAt: now + UPSTREAM_STATUS_CACHE_WINDOW_MS, status }
+      const { status, terminalError } = data
+        ? readAggregatedSessionStatus(data, sessionId, getSessionIds?.() ?? [sessionId])
+        : { status: null }
+      cache = { expiresAt: now + UPSTREAM_STATUS_CACHE_WINDOW_MS, sessionKey, status }
       onRead?.({
         durationMs: Date.now() - startedAt,
         outcome: 'success',
@@ -87,7 +122,7 @@ export function createUpstreamSessionStatusReader({
         sessionId,
         error: error instanceof Error ? error.message : String(error),
       })
-      cache = { expiresAt: now + UPSTREAM_STATUS_CACHE_WINDOW_MS, status: null }
+      cache = { expiresAt: now + UPSTREAM_STATUS_CACHE_WINDOW_MS, sessionKey, status: null }
       onRead?.({ durationMs: Date.now() - startedAt, outcome: 'error', status: null })
       return null
     }

--- a/apps/web/src/hooks/__tests__/use-workspace-streaming.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-workspace-streaming.test.tsx
@@ -2587,5 +2587,74 @@ describe("useWorkspace streaming", () => {
         sse.close();
       });
     });
+
+    it("does not graft the previous turn onto the new bubble before assistantMessageId is set", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const previousAssistant = {
+        id: "prev-assistant",
+        sessionId: "s1",
+        role: "assistant" as const,
+        content: "previous turn text",
+        timestamp: "now",
+        timestampRaw: Date.now(),
+        pending: false,
+        parts: [
+          { type: "text" as const, id: "prev-text", text: "previous turn text" },
+          {
+            type: "permission" as const,
+            id: "permission:stale-perm",
+            permissionId: "stale-perm",
+            sessionId: "s1",
+            title: "Delete old campaign",
+            state: "pending" as const,
+          },
+        ],
+      };
+
+      opencodeMocks.listMessagesAction.mockResolvedValue({
+        ok: true,
+        messages: [previousAssistant],
+      });
+
+      const sse = createSSEStream();
+      stubFetchWithStream(() => sse);
+
+      const result = await renderConnectedHook();
+
+      await waitFor(() => {
+        expect(result.current.messages.some((message) => message.id === "prev-assistant")).toBe(true);
+      });
+
+      await act(async () => {
+        await result.current.sendMessage("do something new");
+      });
+
+      const liveAssistant = result.current.messages.find(
+        (message) => message.role === "assistant" && message.id !== "prev-assistant"
+      );
+      expect(liveAssistant?.id).toMatch(/^temp-assistant-/);
+      expect(liveAssistant?.parts).toEqual([]);
+
+      for (let i = 0; i < 10; i++) {
+        await act(async () => {
+          vi.advanceTimersByTime(500);
+          await new Promise((r) => setTimeout(r, 0));
+        });
+      }
+
+      const grafted = result.current.messages.find(
+        (message) => message.role === "assistant" && message.id !== "prev-assistant"
+      );
+      expect(grafted?.id).toMatch(/^temp-assistant-/);
+      expect(grafted?.parts).not.toContainEqual(expect.objectContaining({
+        permissionId: "stale-perm",
+      }));
+      expect(grafted?.content).not.toBe("previous turn text");
+
+      act(() => {
+        sse.close();
+      });
+    });
   });
 });

--- a/apps/web/src/hooks/__tests__/use-workspace-streaming.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-workspace-streaming.test.tsx
@@ -597,6 +597,23 @@ describe("useWorkspace streaming", () => {
       });
 
       act(() => {
+        sse.push(sseEvent("permission-replied", {
+          id: "perm-1",
+          response: "once",
+          sessionId: "s1",
+        }));
+      });
+
+      await waitFor(() => {
+        const assistant = result.current.messages.find((message) => message.role === "assistant");
+        expect(assistant?.parts).toContainEqual(expect.objectContaining({
+          permissionId: "perm-1",
+          state: "approved",
+        }));
+        expect(assistant?.statusInfo?.detail).not.toBe("permission_required");
+      });
+
+      act(() => {
         sse.close();
       });
     });
@@ -2505,6 +2522,69 @@ describe("useWorkspace streaming", () => {
         const msg = result.current.messages.find((m) => m.id === "msg-1");
         expect(msg?.pending).toBe(false);
         expect(msg?.content).toBe("finished response");
+      });
+    });
+
+    it("hydrates a missed permission card from polling during send", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const sse = createSSEStream();
+      stubFetchWithStream(() => sse);
+
+      const result = await renderConnectedHook();
+
+      await act(async () => {
+        await result.current.sendMessage("delete the campaign");
+      });
+
+      act(() => {
+        sse.push(sseEvent("message", { id: "assistant-1", role: "assistant" }));
+      });
+
+      opencodeMocks.listMessagesAction.mockResolvedValue({
+        ok: true,
+        messages: [
+          {
+            id: "assistant-1",
+            sessionId: "s1",
+            role: "assistant",
+            content: "",
+            timestamp: "now",
+            timestampRaw: Date.now(),
+            pending: true,
+            parts: [
+              {
+                type: "permission",
+                id: "permission:perm-missed",
+                permissionId: "perm-missed",
+                sessionId: "s1",
+                title: "Delete campaign",
+                state: "pending",
+              },
+            ],
+            statusInfo: { status: "tool-calling", detail: "permission_required" },
+          },
+        ],
+      });
+
+      for (let i = 0; i < 10; i++) {
+        await act(async () => {
+          vi.advanceTimersByTime(500);
+          await new Promise((r) => setTimeout(r, 0));
+        });
+      }
+
+      await waitFor(() => {
+        const assistant = result.current.messages.find((message) => message.role === "assistant");
+        expect(assistant?.parts).toContainEqual(expect.objectContaining({
+          permissionId: "perm-missed",
+          state: "pending",
+          type: "permission",
+        }));
+      });
+
+      act(() => {
+        sse.close();
       });
     });
   });

--- a/apps/web/src/hooks/__tests__/use-workspace.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-workspace.test.tsx
@@ -2013,6 +2013,7 @@ describe("useWorkspace", () => {
             },
           ],
           pending: true,
+          statusInfo: { status: "tool-calling", detail: "permission_required" },
         },
       ],
     });
@@ -2068,6 +2069,7 @@ describe("useWorkspace", () => {
       type: "permission",
       state: "approved",
     });
+    expect(result.current.messages[0]?.statusInfo?.detail).not.toBe("permission_required");
   });
 
   it("cleans messages and model selection state for deleted session families", async () => {

--- a/apps/web/src/hooks/__tests__/use-workspace.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-workspace.test.tsx
@@ -2072,6 +2072,91 @@ describe("useWorkspace", () => {
     expect(result.current.messages[0]?.statusInfo?.detail).not.toBe("permission_required");
   });
 
+  it("optimistically updates a delegated permission card on the parent session", async () => {
+    let permissionBody: { sessionId?: string; response?: string } | null = null;
+
+    opencodeMocks.listMessagesAction.mockResolvedValue({
+      ok: true,
+      messages: [
+        {
+          id: "assistant-permission",
+          sessionId: "s1",
+          role: "assistant",
+          content: "Need approval",
+          timestamp: "now",
+          parts: [
+            {
+              type: "permission",
+              id: "permission:perm-child",
+              permissionId: "perm-child",
+              sessionId: "child-1",
+              title: "Delete Mailerlite campaign",
+              state: "pending",
+            },
+          ],
+          pending: true,
+          statusInfo: { status: "tool-calling", detail: "permission_required" },
+        },
+      ],
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input) === "/api/u/alice/agents") {
+          return {
+            ok: true,
+            json: async () => ({ agents: [] }),
+          };
+        }
+
+        if (String(input) === "/api/u/alice/providers") {
+          return {
+            ok: true,
+            json: async () => ({ providers: [] }),
+          };
+        }
+
+        if (String(input) === "/api/w/alice/chat/permissions/perm-child") {
+          permissionBody = JSON.parse(String(init?.body ?? "{}")) as {
+            sessionId?: string;
+            response?: string;
+          };
+          return { ok: true };
+        }
+
+        throw new Error(`Unexpected fetch: ${String(input)}`);
+      })
+    );
+
+    const { result } = renderHook(() =>
+      useWorkspace({ slug: "alice", pollInterval: 0 })
+    );
+
+    await waitFor(() => {
+      expect(result.current.messages[0]?.parts[0]).toMatchObject({
+        permissionId: "perm-child",
+        sessionId: "child-1",
+        state: "pending",
+        type: "permission",
+      });
+    });
+
+    let accepted = false;
+    await act(async () => {
+      accepted = await result.current.answerPermission("child-1", "perm-child", "once");
+    });
+
+    expect(accepted).toBe(true);
+    expect(permissionBody).toEqual({ sessionId: "child-1", response: "once" });
+    expect(result.current.messages[0]?.parts[0]).toMatchObject({
+      permissionId: "perm-child",
+      state: "approved",
+      type: "permission",
+    });
+    expect(result.current.messages[0]?.statusInfo?.detail).not.toBe("permission_required");
+  });
+
   it("cleans messages and model selection state for deleted session families", async () => {
     opencodeMocks.listSessionsAction.mockResolvedValue({
       ok: true,

--- a/apps/web/src/hooks/workspace/use-workspace-message-actions.ts
+++ b/apps/web/src/hooks/workspace/use-workspace-message-actions.ts
@@ -7,6 +7,7 @@ import type {
   AvailableModel,
   MessagePart,
   PermissionResponse,
+  PermissionState,
   WorkspaceMessage,
   WorkspaceSession,
 } from "@/lib/opencode/types";
@@ -236,15 +237,28 @@ export function useWorkspaceMessageActions({
 
         if (!reply.ok) return false;
 
+        const nextState: PermissionState = response === "reject" ? "rejected" : "approved";
         updateSessionMessages(permissionSessionId, (prev) =>
-          prev.map((message) => ({
-            ...message,
-            parts: message.parts.map((part) =>
+          prev.map((message) => {
+            const parts = message.parts.map((part) =>
               part.type === "permission" && part.permissionId === permissionId
-                ? { ...part, state: response === "reject" ? "rejected" : "approved" }
+                ? { ...part, state: nextState }
                 : part
-            ),
-          }))
+            );
+            const stillWaiting = parts.some(
+              (part) => part.type === "permission" && part.state === "pending"
+            );
+
+            return {
+              ...message,
+              parts,
+              statusInfo: stillWaiting
+                ? message.statusInfo
+                : message.statusInfo?.detail === "permission_required"
+                  ? { status: "thinking" }
+                  : message.statusInfo,
+            };
+          })
         );
 
         return true;

--- a/apps/web/src/hooks/workspace/use-workspace-message-actions.ts
+++ b/apps/web/src/hooks/workspace/use-workspace-message-actions.ts
@@ -238,7 +238,7 @@ export function useWorkspaceMessageActions({
         if (!reply.ok) return false;
 
         const nextState: PermissionState = response === "reject" ? "rejected" : "approved";
-        updateSessionMessages(permissionSessionId, (prev) =>
+        const applyOptimisticReply = (prev: WorkspaceMessage[]): WorkspaceMessage[] =>
           prev.map((message) => {
             const parts = message.parts.map((part) =>
               part.type === "permission" && part.permissionId === permissionId
@@ -258,15 +258,20 @@ export function useWorkspaceMessageActions({
                   ? { status: "thinking" }
                   : message.statusInfo,
             };
-          })
-        );
+          });
+
+        const displaySessionId = activeSessionIdRef.current;
+        updateSessionMessages(permissionSessionId, applyOptimisticReply);
+        if (displaySessionId && displaySessionId !== permissionSessionId) {
+          updateSessionMessages(displaySessionId, applyOptimisticReply);
+        }
 
         return true;
       } catch {
         return false;
       }
     },
-    [slug, updateSessionMessages]
+    [activeSessionIdRef, slug, updateSessionMessages]
   );
 
   const abortSession = useCallback(async () => {

--- a/apps/web/src/hooks/workspace/use-workspace-streaming.ts
+++ b/apps/web/src/hooks/workspace/use-workspace-streaming.ts
@@ -6,6 +6,7 @@ import { listMessagesAction } from "@/actions/opencode";
 import type {
   MessagePart,
   MessageStatus,
+  PermissionState,
   WorkspaceMessage,
   WorkspaceSession,
 } from "@/lib/opencode/types";
@@ -417,6 +418,22 @@ export function useWorkspaceStreaming({
         return { status: "thinking" as const };
       case "retry":
         return { status: "thinking" as const };
+      case "permission": {
+        if (part.state === "pending") {
+          const metadataTool =
+            typeof part.metadata?.tool === "string" && part.metadata.tool.trim()
+              ? part.metadata.tool
+              : typeof part.metadata?.toolName === "string" && part.metadata.toolName.trim()
+                ? part.metadata.toolName
+                : part.pattern;
+          return {
+            status: "tool-calling" as const,
+            toolName: metadataTool,
+            detail: "permission_required",
+          };
+        }
+        return { status: "thinking" as const };
+      }
       default:
         return null;
     }
@@ -509,7 +526,7 @@ export function useWorkspaceStreaming({
       let receivedStreamData = false;
       let interruptionDetail: string | null = null;
       let terminalErrorDetail: string | null = null;
-      let resumePollInterval: ReturnType<typeof setInterval> | null = null;
+      let livePollInterval: ReturnType<typeof setInterval> | null = null;
 
       // Pre-check: if the message has already completed (e.g. OpenCode
       // finished while the page was reloading), skip the SSE subscription.
@@ -576,18 +593,28 @@ export function useWorkspaceStreaming({
         const permissionId = getString(data.id);
         if (!permissionId) return;
 
-        const state = data.response === "reject" ? "rejected" : "approved";
+        const state: PermissionState = data.response === "reject" ? "rejected" : "approved";
         updateSessionMessages(sessionId, (prev) =>
           prev.map((message) => {
             if (message.id !== targetMessageId) return message;
 
+            const parts = message.parts.map((part) =>
+              part.type === "permission" && part.permissionId === permissionId
+                ? { ...part, state }
+                : part
+            );
+            const stillWaiting = parts.some(
+              (part) => part.type === "permission" && part.state === "pending"
+            );
+
             return {
               ...message,
-              parts: message.parts.map((part) =>
-                part.type === "permission" && part.permissionId === permissionId
-                  ? { ...part, state }
-                  : part
-              ),
+              parts,
+              statusInfo: stillWaiting
+                ? message.statusInfo
+                : message.statusInfo?.detail === "permission_required"
+                  ? { status: "thinking" }
+                  : message.statusInfo,
             };
           })
         );
@@ -642,27 +669,36 @@ export function useWorkspaceStreaming({
           throw new Error("No response body");
         }
 
-        // During resume, periodically poll the message API so we detect
-        // completion even when no SSE events arrive (e.g. subagent work
-        // produces events on the child session, not the parent).
-        if (mode === "resume") {
-          resumePollInterval = setInterval(async () => {
-            try {
-              const poll = await listMessagesAction(slug, sessionId);
-              if (poll.ok && poll.messages) {
-                const target = poll.messages.find((m) => m.id === targetMessageId);
-                if (target && !target.pending) {
-                  streamCompleted = true;
-                  updateSessionMessages(sessionId, poll.messages);
-                  syncRuntimeMetadataForSession(sessionId, poll.messages);
-                  abortController.abort();
-                }
-              }
-            } catch {
-              // Ignore individual poll errors
+        // Poll the message API while the SSE is open so we still surface
+        // later parts and permission cards when events arrive on a child
+        // session, or when the live reader goes quiet after an approval.
+        livePollInterval = setInterval(async () => {
+          try {
+            const poll = await listMessagesAction(slug, sessionId);
+            if (!poll.ok || !poll.messages) return;
+
+            const observedId =
+              assistantMessageId ?? (mode === "resume" ? targetMessageId : null);
+            const polledAssistant = observedId
+              ? poll.messages.find((message) => message.id === observedId)
+              : [...poll.messages].reverse().find((message) => message.role === "assistant");
+            if (!polledAssistant) return;
+
+            if (mode === "resume" && !polledAssistant.pending) {
+              streamCompleted = true;
+              updateSessionMessages(sessionId, poll.messages);
+              syncRuntimeMetadataForSession(sessionId, poll.messages);
+              abortController.abort();
+              return;
             }
-          }, RESUME_POLL_INTERVAL_MS);
-        }
+
+            polledAssistant.parts.forEach((part) => {
+              upsertMessagePart(sessionId, targetMessageId, part);
+            });
+          } catch {
+            // Ignore individual poll errors
+          }
+        }, RESUME_POLL_INTERVAL_MS);
 
         const decoder = new TextDecoder();
         let parseState = INITIAL_SSE_PARSE_STATE;
@@ -809,8 +845,8 @@ export function useWorkspaceStreaming({
           updateStatus("error", undefined, terminalErrorDetail);
         }
       } finally {
-        if (resumePollInterval) {
-          clearInterval(resumePollInterval);
+        if (livePollInterval) {
+          clearInterval(livePollInterval);
         }
 
         const isLatestStream = () => latestStreamTokensRef.current.get(sessionId) === token;

--- a/apps/web/src/hooks/workspace/use-workspace-streaming.ts
+++ b/apps/web/src/hooks/workspace/use-workspace-streaming.ts
@@ -679,9 +679,8 @@ export function useWorkspaceStreaming({
 
             const observedId =
               assistantMessageId ?? (mode === "resume" ? targetMessageId : null);
-            const polledAssistant = observedId
-              ? poll.messages.find((message) => message.id === observedId)
-              : [...poll.messages].reverse().find((message) => message.role === "assistant");
+            if (!observedId) return;
+            const polledAssistant = poll.messages.find((message) => message.id === observedId);
             if (!polledAssistant) return;
 
             if (mode === "resume" && !polledAssistant.pending) {


### PR DESCRIPTION
## What

- Keep the parent chat SSE open while a delegated `task` is running or a child session is still busy.
- Forward permission events from the session family, including OpenCode `permission.v2.*`.
- Clear the stale `Waiting for approval` badge when a permission is answered.
- Poll `listMessages` during send (not only resume) so later parts and approval cards still appear if the live reader goes quiet.
- Hydrate child-session pending permissions onto the parent assistant.

## Why

After allowing a tool, the composer stayed on **Waiting for approval** with no new card. Later messages and approvals never arrived until reload.

The parent often goes idle after delegating (e.g. Copywriter). That finalized the stream, dropped child `permission.asked` events, and locked refresh because the client still treated the SSE as active.

Follow-up to #479: 1.18 permission relay got the first card on screen, but the post-approve continuation path was still parent-session-only.

## Test plan

- [ ] Delegate to a subagent that then needs a connector approval (Mailerlite/Linear/etc.).
- [ ] Allow once. Confirm the badge leaves `Waiting for approval` and the next tool/card streams in without reload.
- [ ] Approve a second permission in the same turn. Confirm the card appears live.
- [ ] Reload mid-wait and confirm a pending child permission still hydrates onto the parent transcript.