### PR TITLE
fix(workspace): bound startup and prevent container races

### DIFF
--- a/apps/web/src/components/workspace/__tests__/workspace-startup-screens.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/workspace-startup-screens.test.tsx
@@ -1,0 +1,83 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { WorkspaceConnectingBanner } from "@/components/workspace/workspace-startup-screens";
+import type { WorkspaceConnectionState } from "@/lib/opencode/types";
+
+function renderBanner({
+  connection = { status: "connecting" } satisfies WorkspaceConnectionState,
+  instanceStatus = null,
+  instanceError = null,
+}: {
+  connection?: WorkspaceConnectionState;
+  instanceStatus?: "starting" | "running" | "error" | null;
+  instanceError?: string | null;
+} = {}) {
+  return render(
+    <WorkspaceConnectingBanner
+      connection={connection}
+      instanceStatus={instanceStatus}
+      instanceError={instanceError}
+    />,
+  );
+}
+
+describe("WorkspaceConnectingBanner", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the starting state without an alert while the instance is starting", () => {
+    renderBanner({ instanceStatus: "starting" });
+
+    expect(screen.getByText("Starting workspace")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("treats a null instance status as starting", () => {
+    renderBanner({ instanceStatus: null });
+
+    expect(screen.getByText("Starting workspace")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("surfaces the startup failure as an alert with the instance error", () => {
+    renderBanner({
+      instanceStatus: "error",
+      instanceError: "Workspace startup timed out. Try restarting again.",
+    });
+
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("Failed to start");
+    expect(alert.textContent).toContain("Workspace startup timed out. Try restarting again.");
+  });
+
+  it("falls back to a generic message when the startup error is missing", () => {
+    renderBanner({ instanceStatus: "error", instanceError: null });
+
+    expect(screen.getByRole("alert").textContent).toContain("Unable to start the workspace");
+  });
+
+  it("surfaces a connection failure after startup as an alert with mapped copy", () => {
+    renderBanner({
+      connection: { status: "error", error: "unhealthy" },
+      instanceStatus: "running",
+    });
+
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("Connecting to OpenCode");
+    expect(alert.textContent).toContain("The workspace is not ready right now. Retrying...");
+  });
+
+  it("shows the connecting state without an alert while the connection is pending", () => {
+    renderBanner({
+      connection: { status: "connecting" },
+      instanceStatus: "running",
+    });
+
+    expect(screen.getByText("Connecting to OpenCode")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/apps/web/src/components/workspace/workspace-startup-screens.tsx
+++ b/apps/web/src/components/workspace/workspace-startup-screens.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { XCircle } from "@phosphor-icons/react";
+
 import type { InstanceStartupStatus } from "@/hooks/use-instance-startup";
 import type { WorkspaceConnectionState } from "@/lib/opencode/types";
 
@@ -34,10 +36,16 @@ export function WorkspaceConnectingBanner({
   instanceError,
 }: WorkspaceConnectingBannerProps) {
   const starting = instanceStatus === "starting" || instanceStatus === null;
+  const failed = instanceStatus === "error";
+  const connectionFailed = !starting && !failed && connection.status === "error";
 
   return (
     <div className="flex h-full min-h-0 flex-col items-center justify-center gap-3 px-6 text-center">
-      <ArcLoader />
+      {failed || connectionFailed ? (
+        <XCircle size={24} weight="fill" className="text-destructive/70" aria-hidden />
+      ) : (
+        <ArcLoader />
+      )}
       <div className="space-y-1">
         {starting ? (
           <>
@@ -46,22 +54,22 @@ export function WorkspaceConnectingBanner({
               Setting up your workspace…
             </p>
           </>
-        ) : instanceStatus === "error" ? (
-          <>
+        ) : failed ? (
+          <div role="alert">
             <h2 className="type-display text-base font-semibold text-destructive">Failed to start</h2>
             <p className="text-sm text-muted-foreground">
               {instanceError ?? "Unable to start the workspace"}
             </p>
-          </>
+          </div>
         ) : (
-          <>
+          <div role={connectionFailed ? "alert" : undefined}>
             <h2 className="type-display text-base font-semibold">Connecting to OpenCode</h2>
             <p className="text-sm text-muted-foreground">
-              {connection.status === "error"
+              {connectionFailed
                 ? getConnectionErrorText(connection.error)
                 : "Establishing connection..."}
             </p>
-          </>
+          </div>
         )}
       </div>
     </div>

--- a/apps/web/src/hooks/__tests__/use-instance-startup.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-instance-startup.test.tsx
@@ -1,9 +1,9 @@
 /** @vitest-environment jsdom */
 
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useInstanceStartup } from "@/hooks/use-instance-startup";
+import { INSTANCE_START_TIMEOUT_MS, useInstanceStartup } from "@/hooks/use-instance-startup";
 
 const ensureInstanceRunningActionMock = vi.hoisted(() => vi.fn());
 const routerReplaceMock = vi.hoisted(() => vi.fn());
@@ -98,7 +98,46 @@ describe("useInstanceStartup", () => {
 
     await waitFor(() => expect(routerReplaceMock).toHaveBeenCalledWith("/u/alice?setup=required"));
     // The setup redirect must not surface as an in-shell startup error.
-    expect(result.current.instanceStatus).toBeNull();
+    expect(result.current.instanceStatus).not.toBe("error");
     expect(result.current.instanceError).toBeNull();
+  });
+
+  it("arms the timeout before the server action resolves and ignores a late response", async () => {
+    let resolveAction!: (value: unknown) => void;
+    ensureInstanceRunningActionMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveAction = resolve;
+      }),
+    );
+
+    vi.useFakeTimers();
+
+    try {
+      const { result } = renderStartupHook("alice");
+
+      // "starting" is surfaced synchronously once the attempt is armed.
+      expect(result.current.instanceStatus).toBe("starting");
+
+      // The independent client timeout fires even though the server action is
+      // still pending.
+      act(() => {
+        vi.advanceTimersByTime(INSTANCE_START_TIMEOUT_MS);
+      });
+      expect(result.current.instanceStatus).toBe("error");
+      expect(result.current.instanceError).toBe(
+        "Workspace startup timed out. Try restarting again.",
+      );
+
+      // A late server response must not overwrite the timed-out state.
+      await act(async () => {
+        resolveAction({ status: "running" });
+      });
+      expect(result.current.instanceStatus).toBe("error");
+      expect(result.current.instanceError).toBe(
+        "Workspace startup timed out. Try restarting again.",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/web/src/hooks/use-instance-startup.ts
+++ b/apps/web/src/hooks/use-instance-startup.ts
@@ -6,7 +6,11 @@ import { useRouter } from "next/navigation";
 import { ensureInstanceRunningAction } from "@/actions/spawner";
 
 const INSTANCE_START_POLL_INTERVAL_MS = 2_000;
-const INSTANCE_START_TIMEOUT_MS = 120_000;
+
+// Client-side timeout that must exceed the server's ARCHE_START_TIMEOUT_MS
+// (default 120s) by a margin so the UI only surfaces an error when the server
+// action genuinely stalls, not while it is about to succeed.
+export const INSTANCE_START_TIMEOUT_MS = 150_000;
 
 function formatInstanceStartupError(error: string): string {
   if (error === "start_timeout") {
@@ -33,11 +37,15 @@ export function useInstanceStartup(slug: string): UseInstanceStartupReturn {
     routerRef.current = router;
   }, [router]);
 
-  const [instanceStatus, setInstanceStatus] = useState<InstanceStartupStatus>(null);
+  // Initialized to "starting" so the UI shows the startup state immediately and
+  // the timeout below is armed before the first awaited server action. The
+  // workspace shell treats null and "starting" identically.
+  const [instanceStatus, setInstanceStatus] = useState<InstanceStartupStatus>("starting");
   const [instanceError, setInstanceError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    let timedOut = false;
     let pollingTimer: ReturnType<typeof setInterval> | null = null;
     let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
     let checking = false;
@@ -54,22 +62,23 @@ export function useInstanceStartup(slug: string): UseInstanceStartupReturn {
     };
 
     const failStartup = (error: string) => {
+      timedOut = true;
       clearTimers();
       setInstanceStatus("error");
       setInstanceError(formatInstanceStartupError(error));
     };
 
     const checkInstanceStatus = async () => {
-      if (checking) return;
+      if (checking || timedOut || cancelled) return;
       checking = true;
 
       try {
         const result = await ensureInstanceRunningAction(slug);
-        if (cancelled) return;
+        if (cancelled || timedOut) return;
 
         if (result.status === "error") {
-          clearTimers();
           if (result.error === "setup_required") {
+            clearTimers();
             routerRef.current.replace(`/u/${slug}?setup=required`);
             return;
           }
@@ -87,22 +96,25 @@ export function useInstanceStartup(slug: string): UseInstanceStartupReturn {
         setInstanceStatus("starting");
 
         if (!pollingTimer) {
-          timeoutTimer = setTimeout(() => {
-            if (cancelled) return;
-            failStartup("start_timeout");
-          }, INSTANCE_START_TIMEOUT_MS);
-
           pollingTimer = setInterval(() => {
             void checkInstanceStatus();
           }, INSTANCE_START_POLL_INTERVAL_MS);
         }
       } catch {
-        if (cancelled) return;
+        if (cancelled || timedOut) return;
         failStartup("status_check_failed");
       } finally {
         checking = false;
       }
     };
+
+    // Arm an independent timeout BEFORE awaiting the server action, so a
+    // blocked action/proxy/network can no longer leave the UI spinning forever.
+    // Once the timeout fires, late responses for this attempt are ignored.
+    timeoutTimer = setTimeout(() => {
+      if (cancelled) return;
+      failStartup("start_timeout");
+    }, INSTANCE_START_TIMEOUT_MS);
 
     void checkInstanceStatus();
 

--- a/apps/web/src/lib/opencode/__tests__/client.test.ts
+++ b/apps/web/src/lib/opencode/__tests__/client.test.ts
@@ -192,4 +192,42 @@ describe('isInstanceHealthyWithPassword', () => {
     expect(mockGetInstanceUrl).toHaveBeenCalledWith('alice', 'http://10.88.0.12:4096')
     vi.unstubAllGlobals()
   })
+
+  it('aborts a never-resolving fetch at the per-request deadline', async () => {
+    mockGetInstanceUrl.mockReturnValue('http://opencode-alice:4096')
+    let fetchInit: RequestInit | undefined
+    vi.stubGlobal('fetch', vi.fn((_url: string, init?: RequestInit) => {
+      fetchInit = init
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true })
+      })
+    }))
+
+    const { isInstanceHealthyWithPassword } = await import('../client')
+    const result = await isInstanceHealthyWithPassword('alice', 'test-password', undefined, { timeoutMs: 30 })
+
+    expect(result).toEqual({ ok: false, detail: 'healthcheck_timeout' })
+    expect(fetchInit?.signal).toBeDefined()
+    vi.unstubAllGlobals()
+  })
+
+  it('returns healthcheck_timeout when an external signal cancels the request', async () => {
+    mockGetInstanceUrl.mockReturnValue('http://opencode-alice:4096')
+    const controller = new AbortController()
+    vi.stubGlobal('fetch', vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true })
+      })
+    }))
+
+    const { isInstanceHealthyWithPassword } = await import('../client')
+    const promise = isInstanceHealthyWithPassword('alice', 'test-password', undefined, {
+      timeoutMs: 1_000,
+      signal: controller.signal,
+    })
+    controller.abort()
+
+    await expect(promise).resolves.toEqual({ ok: false, detail: 'healthcheck_timeout' })
+    vi.unstubAllGlobals()
+  })
 })

--- a/apps/web/src/lib/opencode/client.ts
+++ b/apps/web/src/lib/opencode/client.ts
@@ -19,6 +19,16 @@ export type InstanceHealthResult =
   | { ok: true }
   | { ok: false; detail: string; message?: string }
 
+// Every /global/health request is bounded so no single probe can outlive its
+// deadline. Startup probes pass shorter remaining-budget deadlines; status
+// reads rely on this default to avoid a hanging transport-level wait.
+export const DEFAULT_HEALTH_TIMEOUT_MS = 5_000
+
+export type InstanceHealthOptions = {
+  timeoutMs?: number
+  signal?: AbortSignal
+}
+
 function getErrorMessage(error: unknown): string | undefined {
   if (error instanceof Error) {
     return error.message
@@ -84,14 +94,27 @@ export async function createInstanceClient(slug: string): Promise<OpencodeClient
 
 /**
  * Check if an OpenCode instance is healthy using explicit credentials.
+ *
+ * Every request carries an `AbortController` that fires at `timeoutMs`
+ * (default `DEFAULT_HEALTH_TIMEOUT_MS`), so a hanging or idle connection can
+ * never outlive the deadline. An external `options.signal` can additionally
+ * cancel the request from the caller (used to cancel the losing probe when a
+ * concurrent probe confirms health).
  */
 export async function isInstanceHealthyWithPassword(
   slug: string,
   password: string,
   overrideBaseUrl?: string,
+  options?: InstanceHealthOptions,
 ): Promise<InstanceHealthResult> {
   const baseUrl = resolveInstanceUrl(slug, overrideBaseUrl)
   const authHeader = `Basic ${Buffer.from(`opencode:${password}`).toString('base64')}`
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_HEALTH_TIMEOUT_MS
+
+  const controller = new AbortController()
+  const timeoutTimer = setTimeout(() => controller.abort(), timeoutMs)
+  const onExternalAbort = () => controller.abort()
+  options?.signal?.addEventListener('abort', onExternalAbort, { once: true })
 
   try {
     const response = await fetch(`${baseUrl}/global/health`, {
@@ -100,6 +123,7 @@ export async function isInstanceHealthyWithPassword(
         Accept: 'application/json',
       },
       cache: 'no-store',
+      signal: controller.signal,
     })
 
     if (!response.ok) {
@@ -123,7 +147,13 @@ export async function isInstanceHealthyWithPassword(
 
     return { ok: false, detail: 'unhealthy_response', message: JSON.stringify(data) }
   } catch (error) {
+    if (controller.signal.aborted) {
+      return { ok: false, detail: 'healthcheck_timeout' }
+    }
     return { ok: false, ...describeFetchError(error) }
+  } finally {
+    clearTimeout(timeoutTimer)
+    options?.signal?.removeEventListener('abort', onExternalAbort)
   }
 }
 

--- a/apps/web/src/lib/services/__tests__/instance.test.ts
+++ b/apps/web/src/lib/services/__tests__/instance.test.ts
@@ -8,6 +8,7 @@ const { mockGetRuntimeCapabilities, mockPrisma } = vi.hoisted(() => ({
     findMany: vi.fn(),
     upsert: vi.fn(),
     update: vi.fn(),
+    updateMany: vi.fn(),
     deleteMany: vi.fn(),
   },
 },
@@ -32,11 +33,13 @@ import {
   setContainerId,
   setError,
   setRunning,
+  setRunningIfCurrentContainer,
+  setErrorIfCurrentContainer,
+  correctToRunningIfCurrentContainer,
   setStopped,
   setStoppedNoContainer,
   setStoppedById,
   setProviderSyncState,
-  correctToRunning,
   touchActivity,
   deleteBySlug,
 } from '../instance'
@@ -216,6 +219,49 @@ describe('instanceService', () => {
     })
   })
 
+  describe('setRunningIfCurrentContainer', () => {
+    it('guards the transition by slug, starting status and containerId', async () => {
+      mockPrisma.instance.updateMany.mockResolvedValue({ count: 1 })
+      await setRunningIfCurrentContainer('alice', 'container-1', 'sha-abc')
+      expect(mockPrisma.instance.updateMany).toHaveBeenCalledWith({
+        where: { slug: 'alice', status: 'starting', containerId: 'container-1' },
+        data: expect.objectContaining({ status: 'running', appliedConfigSha: 'sha-abc' }),
+      })
+    })
+
+    it('returns zero affected rows for a mismatched containerId', async () => {
+      mockPrisma.instance.updateMany.mockResolvedValue({ count: 0 })
+      const result = await setRunningIfCurrentContainer('alice', 'stale-container', 'sha-abc')
+      expect(result).toEqual({ count: 0 })
+      expect(mockPrisma.instance.updateMany).toHaveBeenCalledWith({
+        where: { slug: 'alice', status: 'starting', containerId: 'stale-container' },
+        data: expect.objectContaining({ status: 'running' }),
+      })
+    })
+  })
+
+  describe('setErrorIfCurrentContainer', () => {
+    it('guards the error transition by slug, starting status and containerId', async () => {
+      mockPrisma.instance.updateMany.mockResolvedValue({ count: 1 })
+      await setErrorIfCurrentContainer('alice', 'container-1')
+      expect(mockPrisma.instance.updateMany).toHaveBeenCalledWith({
+        where: { slug: 'alice', status: 'starting', containerId: 'container-1' },
+        data: expect.objectContaining({ status: 'error', containerId: null }),
+      })
+    })
+  })
+
+  describe('correctToRunningIfCurrentContainer', () => {
+    it('guards the correction by slug, starting status and containerId', async () => {
+      mockPrisma.instance.updateMany.mockResolvedValue({ count: 1 })
+      await correctToRunningIfCurrentContainer('alice', 'container-1')
+      expect(mockPrisma.instance.updateMany).toHaveBeenCalledWith({
+        where: { slug: 'alice', status: 'starting', containerId: 'container-1' },
+        data: expect.objectContaining({ status: 'running', lastActivityAt: expect.any(Date) }),
+      })
+    })
+  })
+
   describe('setStopped', () => {
     it('clears containerId and sync state', async () => {
       mockPrisma.instance.update.mockResolvedValue({})
@@ -256,17 +302,6 @@ describe('instanceService', () => {
       expect(mockPrisma.instance.update).toHaveBeenCalledWith({
         where: { slug: 'alice' },
         data: { providerSyncHash: 'hash-123', providerSyncedAt: syncedAt },
-      })
-    })
-  })
-
-  describe('correctToRunning', () => {
-    it('sets running and touches lastActivityAt', async () => {
-      mockPrisma.instance.update.mockResolvedValue({})
-      await correctToRunning('alice')
-      expect(mockPrisma.instance.update).toHaveBeenCalledWith({
-        where: { slug: 'alice' },
-        data: { status: 'running', lastActivityAt: expect.any(Date) },
       })
     })
   })

--- a/apps/web/src/lib/services/instance.ts
+++ b/apps/web/src/lib/services/instance.ts
@@ -185,6 +185,53 @@ export function setError(slug: string) {
   })
 }
 
+// Race-safe variants: each transition is guarded by slug + status + containerId
+// so a stale startup attempt can never mutate the outcome of a newer one. They
+// return the affected row count so callers can detect a lost race.
+
+export function setRunningIfCurrentContainer(
+  slug: string,
+  containerId: string,
+  appliedConfigSha: string | null,
+): Promise<{ count: number }> {
+  return prisma.instance.updateMany({
+    where: { slug, status: 'starting', containerId },
+    data: {
+      status: 'running',
+      lastActivityAt: new Date(),
+      appliedConfigSha,
+    },
+  })
+}
+
+export function setErrorIfCurrentContainer(
+  slug: string,
+  containerId: string,
+): Promise<{ count: number }> {
+  return prisma.instance.updateMany({
+    where: { slug, status: 'starting', containerId },
+    data: {
+      status: 'error',
+      containerId: null,
+      providerSyncHash: null,
+      providerSyncedAt: null,
+    },
+  })
+}
+
+export function correctToRunningIfCurrentContainer(
+  slug: string,
+  containerId: string,
+): Promise<{ count: number }> {
+  return prisma.instance.updateMany({
+    where: { slug, status: 'starting', containerId },
+    data: {
+      status: 'running',
+      lastActivityAt: new Date(),
+    },
+  })
+}
+
 export function setRunning(slug: string, appliedConfigSha: string | null) {
   return prisma.instance.update({
     where: { slug },
@@ -249,16 +296,6 @@ export function invalidateProviderSyncStateForAllInstances() {
     data: {
       providerSyncHash: null,
       providerSyncedAt: null,
-    },
-  })
-}
-
-export function correctToRunning(slug: string) {
-  return prisma.instance.update({
-    where: { slug },
-    data: {
-      status: 'running',
-      lastActivityAt: new Date(),
     },
   })
 }

--- a/apps/web/src/lib/spawner/__tests__/core.test.ts
+++ b/apps/web/src/lib/spawner/__tests__/core.test.ts
@@ -25,10 +25,13 @@ vi.mock('@/lib/services', () => ({
     setContainerId: vi.fn(),
     setError: vi.fn(),
     setRunning: vi.fn(),
+    setRunningIfCurrentContainer: vi.fn(),
+    setErrorIfCurrentContainer: vi.fn(),
+    correctToRunningIfCurrentContainer: vi.fn(),
     setStopped: vi.fn(),
     setStoppedNoContainer: vi.fn(),
-    correctToRunning: vi.fn(),
     findStatusBySlug: vi.fn(),
+    findContainerStatusBySlug: vi.fn(),
     findActiveInstances: vi.fn(),
   },
   userService: {
@@ -49,6 +52,7 @@ vi.mock('@/lib/services', () => ({
 
 // Mock opencode client
 vi.mock('@/lib/opencode/client', () => ({
+  DEFAULT_HEALTH_TIMEOUT_MS: 5_000,
   getInstanceUrl: vi.fn((slug: string) => `http://opencode-${slug}:4096`),
   isInstanceHealthyWithPassword: vi.fn(),
 }))
@@ -169,6 +173,10 @@ beforeEach(async () => {
   mockHealth.mockResolvedValue({ ok: true })
   mockSync.mockResolvedValue({ ok: true })
   mockBuildMcpConfigForSlug.mockResolvedValue(null)
+  mockInstance.setRunningIfCurrentContainer.mockResolvedValue({ count: 1 })
+  mockInstance.setErrorIfCurrentContainer.mockResolvedValue({ count: 1 })
+  mockInstance.correctToRunningIfCurrentContainer.mockResolvedValue({ count: 1 })
+  mockInstance.findContainerStatusBySlug.mockResolvedValue(null)
 })
 
 afterEach(async () => {
@@ -223,7 +231,7 @@ describe('startInstance', () => {
       })
       mockInstance.upsertStarting.mockResolvedValue({} as never)
       mockInstance.setContainerId.mockResolvedValue({} as never)
-      mockInstance.setRunning.mockResolvedValue({} as never)
+      mockInstance.setRunningIfCurrentContainer.mockResolvedValue({ count: 1 })
       mockUser.findIdentityBySlug.mockResolvedValue(null)
       mockDocker.removeContainer.mockResolvedValue(undefined)
       mockDocker.createContainer.mockResolvedValue({ id: 'container-123' } as never)
@@ -249,7 +257,7 @@ describe('startInstance', () => {
     mockInstance.findBySlug.mockResolvedValue(null)
     mockInstance.upsertStarting.mockResolvedValue({} as never)
     mockInstance.setContainerId.mockResolvedValue({} as never)
-    mockInstance.setRunning.mockResolvedValue({} as never)
+    mockInstance.setRunningIfCurrentContainer.mockResolvedValue({ count: 1 })
     mockUser.findIdentityBySlug.mockResolvedValue({ id: 'owner-1', slug: 'alice', email: 'alice@example.com' })
     mockDocker.createContainer.mockResolvedValue({ id: 'container-123' } as never)
     mockDocker.startContainer.mockResolvedValue(undefined)
@@ -295,7 +303,7 @@ describe('startInstance', () => {
     })
     mockInstance.upsertStarting.mockResolvedValue({} as never)
     mockInstance.setContainerId.mockResolvedValue({} as never)
-    mockInstance.setRunning.mockResolvedValue({} as never)
+    mockInstance.setRunningIfCurrentContainer.mockResolvedValue({ count: 1 })
     mockDocker.removeContainer.mockResolvedValue(undefined)
     mockDocker.createContainer.mockResolvedValue({ id: 'container-123' } as never)
     mockDocker.startContainer.mockResolvedValue(undefined)
@@ -312,7 +320,7 @@ describe('startInstance', () => {
     mockInstance.findBySlug.mockResolvedValue(null)
     mockInstance.upsertStarting.mockResolvedValue({} as never)
     mockInstance.setContainerId.mockResolvedValue({} as never)
-    mockInstance.setRunning.mockResolvedValue({} as never)
+    mockInstance.setRunningIfCurrentContainer.mockResolvedValue({ count: 1 })
     mockDocker.createContainer.mockResolvedValue({ id: 'container-123' } as never)
     mockDocker.startContainer.mockResolvedValue(undefined)
     mockDocker.isContainerRunning.mockResolvedValue(true)
@@ -335,7 +343,7 @@ describe('startInstance', () => {
     })
     mockInstance.upsertStarting.mockResolvedValue({} as never)
     mockInstance.setContainerId.mockResolvedValue({} as never)
-    mockInstance.setRunning.mockResolvedValue({} as never)
+    mockInstance.setRunningIfCurrentContainer.mockResolvedValue({ count: 1 })
     mockDocker.removeContainer.mockRejectedValueOnce(new Error('not found'))
     mockDocker.createContainer.mockResolvedValue({ id: 'container-123' } as never)
     mockDocker.startContainer.mockResolvedValue(undefined)
@@ -351,7 +359,7 @@ describe('startInstance', () => {
     mockInstance.findBySlug.mockResolvedValue(null)
     mockInstance.upsertStarting.mockResolvedValue({} as never)
     mockInstance.setContainerId.mockResolvedValue({} as never)
-    mockInstance.setRunning.mockResolvedValue({} as never)
+    mockInstance.setRunningIfCurrentContainer.mockResolvedValue({ count: 1 })
     mockUser.findIdentityBySlug.mockResolvedValue({ id: 'owner-1', slug: 'alice', email: 'alice@example.com' })
     mockDocker.createContainer.mockResolvedValue({ id: 'container-123' } as never)
     mockDocker.startContainer.mockResolvedValue(undefined)
@@ -359,7 +367,7 @@ describe('startInstance', () => {
 
     let syncCalledBeforeRunning = false
     mockSync.mockImplementation(async () => {
-      syncCalledBeforeRunning = !mockInstance.setRunning.mock.calls.length
+      syncCalledBeforeRunning = !mockInstance.setRunningIfCurrentContainer.mock.calls.length
       return { ok: true }
     })
 
@@ -373,7 +381,7 @@ describe('startInstance', () => {
     mockInstance.findBySlug.mockResolvedValue(null)
     mockInstance.upsertStarting.mockResolvedValue({} as never)
     mockInstance.setContainerId.mockResolvedValue({} as never)
-    mockInstance.setRunning.mockResolvedValue({} as never)
+    mockInstance.setRunningIfCurrentContainer.mockResolvedValue({ count: 1 })
     mockUser.findIdentityBySlug.mockResolvedValue({ id: 'owner-1', slug: 'alice', email: 'alice@example.com' })
     mockDocker.createContainer.mockResolvedValue({ id: 'container-123' } as never)
     mockDocker.startContainer.mockResolvedValue(undefined)
@@ -393,7 +401,7 @@ describe('startInstance', () => {
       mockInstance.findBySlug.mockResolvedValue(null)
       mockInstance.upsertStarting.mockResolvedValue({} as never)
       mockInstance.setContainerId.mockResolvedValue({} as never)
-      mockInstance.setRunning.mockResolvedValue({} as never)
+      mockInstance.setRunningIfCurrentContainer.mockResolvedValue({ count: 1 })
       mockUser.findIdentityBySlug.mockResolvedValue(null)
       mockDocker.createContainer.mockResolvedValue({ id: 'container-123' } as never)
       mockDocker.startContainer.mockResolvedValue(undefined)
@@ -422,11 +430,86 @@ describe('startInstance', () => {
     }
   })
 
+  it('succeeds through DNS when the direct-IP probe hangs, and cancels the losing probe', async () => {
+    mockInstance.findBySlug.mockResolvedValue(null)
+    mockInstance.upsertStarting.mockResolvedValue({} as never)
+    mockInstance.setContainerId.mockResolvedValue({} as never)
+    mockInstance.setRunningIfCurrentContainer.mockResolvedValue({ count: 1 })
+    mockUser.findIdentityBySlug.mockResolvedValue(null)
+    mockDocker.createContainer.mockResolvedValue({ id: 'container-123' } as never)
+    mockDocker.startContainer.mockResolvedValue(undefined)
+    mockDocker.isContainerRunning.mockResolvedValue(true)
+
+    let directSignal: AbortSignal | undefined
+    mockHealth.mockImplementation(async (_slug, _password, baseUrl, options) => {
+      if (baseUrl === 'http://10.88.0.12:4096') {
+        directSignal = options?.signal
+        // Mirror the real client: a stuck request never settles on its own and
+        // only resolves once its signal is aborted.
+        await new Promise<void>((resolve) => {
+          if (options?.signal?.aborted) {
+            resolve()
+            return
+          }
+          options?.signal?.addEventListener('abort', () => resolve(), { once: true })
+        })
+        return { ok: false, detail: 'healthcheck_timeout' }
+      }
+
+      return { ok: true }
+    })
+
+    const result = await startInstance('alice', 'user-1')
+
+    expect(result).toEqual({ ok: true, status: 'running' })
+    // The DNS winner cancelled the stuck direct-IP request.
+    expect(directSignal?.aborted).toBe(true)
+    // Startup proceeded over the DNS hostname, not the stuck direct IP.
+    expect(mockSync).toHaveBeenCalledWith({
+      instance: { baseUrl: 'http://opencode-alice:4096', authHeader: expect.any(String) },
+      slug: 'alice',
+      userId: 'user-1',
+    })
+  })
+
+  it('bounds each health probe to the remaining startup budget', async () => {
+    mockInstance.findBySlug.mockResolvedValue(null)
+    mockInstance.upsertStarting.mockResolvedValue({} as never)
+    mockInstance.setContainerId.mockResolvedValue({} as never)
+    mockInstance.setErrorIfCurrentContainer.mockResolvedValue({ count: 1 })
+    mockUser.findIdentityBySlug.mockResolvedValue(null)
+    mockDocker.createContainer.mockResolvedValue({ id: 'container-123' } as never)
+    mockDocker.startContainer.mockResolvedValue(undefined)
+    mockDocker.isContainerRunning.mockResolvedValue(true)
+    mockDocker.stopContainer.mockResolvedValue(undefined)
+    mockDocker.removeContainer.mockResolvedValue(undefined)
+    mockHealth.mockResolvedValue({ ok: false, detail: 'dns_resolution_error' })
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    vi.stubEnv('ARCHE_START_TIMEOUT_MS', '100')
+
+    try {
+      const result = await startInstance('alice', 'user-1')
+
+      expect(result).toMatchObject({ ok: false, error: 'timeout' })
+
+      const probeTimeouts = mockHealth.mock.calls
+        .map((call) => call[3]?.timeoutMs)
+        .filter((value): value is number => typeof value === 'number')
+      expect(probeTimeouts.length).toBeGreaterThan(0)
+      for (const timeoutMs of probeTimeouts) {
+        expect(timeoutMs).toBeGreaterThanOrEqual(1)
+        expect(timeoutMs).toBeLessThanOrEqual(100)
+      }
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
   it('marks the workspace for restart when provider sync fails', async () => {
     mockInstance.findBySlug.mockResolvedValue(null)
     mockInstance.upsertStarting.mockResolvedValue({} as never)
     mockInstance.setContainerId.mockResolvedValue({} as never)
-    mockInstance.setRunning.mockResolvedValue({} as never)
+    mockInstance.setRunningIfCurrentContainer.mockResolvedValue({ count: 1 })
     mockUser.findIdentityBySlug.mockResolvedValue({ id: 'owner-1', slug: 'alice', email: 'alice@example.com' })
     mockDocker.createContainer.mockResolvedValue({ id: 'container-123' } as never)
     mockDocker.startContainer.mockResolvedValue(undefined)
@@ -444,7 +527,7 @@ describe('startInstance', () => {
     mockInstance.findBySlug.mockResolvedValue(null)
     mockInstance.upsertStarting.mockResolvedValue({} as never)
     mockInstance.setContainerId.mockResolvedValue({} as never)
-    mockInstance.setError.mockResolvedValue({} as never)
+    mockInstance.setErrorIfCurrentContainer.mockResolvedValue({ count: 1 })
     mockDocker.createContainer.mockResolvedValue({ id: 'container-123' } as never)
     mockDocker.startContainer.mockResolvedValue(undefined)
     mockDocker.isContainerRunning.mockResolvedValue(false)
@@ -458,7 +541,87 @@ describe('startInstance', () => {
     const result = await startInstance('alice', 'user-1')
 
     expect(result).toMatchObject({ ok: false, error: 'timeout' })
+    expect(mockInstance.setErrorIfCurrentContainer).toHaveBeenCalledWith('alice', 'container-123')
+    expect(mockDocker.stopContainer).toHaveBeenCalledWith('container-123')
+    expect(mockDocker.removeContainer).toHaveBeenCalledWith('container-123')
     vi.unstubAllEnvs()
+  })
+
+  it('does not tear down a container when another flow already confirmed it running', async () => {
+    mockInstance.findBySlug.mockResolvedValue(null)
+    mockInstance.upsertStarting.mockResolvedValue({} as never)
+    mockInstance.setContainerId.mockResolvedValue({} as never)
+    mockUser.findIdentityBySlug.mockResolvedValue(null)
+    mockDocker.createContainer.mockResolvedValue({ id: 'container-123' } as never)
+    mockDocker.startContainer.mockResolvedValue(undefined)
+    mockDocker.isContainerRunning.mockResolvedValue(true)
+    mockHealth.mockResolvedValue({ ok: false, detail: 'connection_refused' })
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    // Another flow already moved the same container to running: the conditional
+    // error transition affects zero rows and the DB still references our id.
+    mockInstance.setErrorIfCurrentContainer.mockResolvedValue({ count: 0 })
+    mockInstance.findContainerStatusBySlug.mockResolvedValue({ containerId: 'container-123', status: 'running' })
+    vi.stubEnv('ARCHE_START_TIMEOUT_MS', '100')
+
+    try {
+      const result = await startInstance('alice', 'user-1')
+
+      expect(result).toMatchObject({ ok: false, error: 'timeout' })
+      expect(mockDocker.stopContainer).not.toHaveBeenCalled()
+      expect(mockDocker.removeContainer).not.toHaveBeenCalled()
+      expect(mockInstance.setError).not.toHaveBeenCalled()
+      expect(mockInstance.setErrorIfCurrentContainer).toHaveBeenCalledWith('alice', 'container-123')
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it('removes only its own orphaned container when a newer attempt owns the instance', async () => {
+    mockInstance.findBySlug.mockResolvedValue(null)
+    mockInstance.upsertStarting.mockResolvedValue({} as never)
+    mockInstance.setContainerId.mockResolvedValue({} as never)
+    mockUser.findIdentityBySlug.mockResolvedValue(null)
+    mockDocker.createContainer.mockResolvedValue({ id: 'container-123' } as never)
+    mockDocker.startContainer.mockResolvedValue(undefined)
+    mockDocker.isContainerRunning.mockResolvedValue(true)
+    mockHealth.mockResolvedValue({ ok: false, detail: 'connection_refused' })
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    mockInstance.setErrorIfCurrentContainer.mockResolvedValue({ count: 0 })
+    // A newer attempt replaced this startup's container.
+    mockInstance.findContainerStatusBySlug.mockResolvedValue({ containerId: 'container-new', status: 'starting' })
+    vi.stubEnv('ARCHE_START_TIMEOUT_MS', '100')
+
+    try {
+      await startInstance('alice', 'user-1')
+
+      expect(mockDocker.stopContainer).toHaveBeenCalledWith('container-123')
+      expect(mockDocker.removeContainer).toHaveBeenCalledWith('container-123')
+      expect(mockDocker.removeContainer).not.toHaveBeenCalledWith('container-new')
+      expect(mockInstance.setError).not.toHaveBeenCalled()
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it('does not duplicate the audit event when a concurrent flow already published running', async () => {
+    mockInstance.findBySlug.mockResolvedValue(null)
+    mockInstance.upsertStarting.mockResolvedValue({} as never)
+    mockInstance.setContainerId.mockResolvedValue({} as never)
+    mockUser.findIdentityBySlug.mockResolvedValue(null)
+    mockDocker.createContainer.mockResolvedValue({ id: 'container-123' } as never)
+    mockDocker.startContainer.mockResolvedValue(undefined)
+    mockDocker.isContainerRunning.mockResolvedValue(true)
+    mockHealth.mockResolvedValue({ ok: true })
+    mockInstance.setRunningIfCurrentContainer.mockResolvedValue({ count: 0 })
+    mockInstance.findStatusBySlug.mockResolvedValue({
+      status: 'running', startedAt: new Date(), stoppedAt: null, lastActivityAt: new Date(), containerId: 'container-123',
+      serverPassword: 'enc',
+    })
+
+    const result = await startInstance('alice', 'user-1')
+
+    expect(result).toEqual({ ok: true, status: 'running' })
+    expect(mockAudit.createEvent).not.toHaveBeenCalled()
   })
 
   it('returns start_failed on docker error', async () => {
@@ -608,7 +771,7 @@ describe('getInstanceStatus', () => {
     expect(mockInstance.setStopped).toHaveBeenCalledWith('alice')
   })
 
-  it('corrects healthy starting instances to running', async () => {
+  it('keeps a recent starting instance as starting even when health responds', async () => {
     const now = new Date()
     mockInstance.findStatusBySlug.mockResolvedValue({
       status: 'starting', startedAt: now, stoppedAt: null, lastActivityAt: now, containerId: 'abc',
@@ -616,10 +779,43 @@ describe('getInstanceStatus', () => {
     })
     mockDocker.isContainerRunning.mockResolvedValue(true)
     mockHealth.mockResolvedValue({ ok: true })
-    mockInstance.correctToRunning.mockResolvedValue({} as never)
+
+    await expect(getInstanceStatus('alice')).resolves.toMatchObject({ status: 'starting', containerId: 'abc' })
+    expect(mockInstance.correctToRunningIfCurrentContainer).not.toHaveBeenCalled()
+  })
+
+  it('reconciles a stale starting instance to running when container, health and sync succeed', async () => {
+    const startedAt = new Date(Date.now() - 300_000)
+    mockInstance.findStatusBySlug.mockResolvedValue({
+      status: 'starting', startedAt, stoppedAt: null, lastActivityAt: startedAt, containerId: 'abc',
+      serverPassword: 'enc',
+    })
+    mockDocker.isContainerRunning.mockResolvedValue(true)
+    mockHealth.mockResolvedValue({ ok: true })
+    mockUser.findIdBySlug.mockResolvedValue({ id: 'owner-1' })
 
     await expect(getInstanceStatus('alice')).resolves.toMatchObject({ status: 'running', containerId: 'abc' })
-    expect(mockInstance.correctToRunning).toHaveBeenCalledWith('alice')
+
+    expect(mockUser.findIdBySlug).toHaveBeenCalledWith('alice')
+    expect(mockSync).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'alice', userId: 'owner-1', instance: expect.any(Object) }),
+    )
+    expect(mockInstance.correctToRunningIfCurrentContainer).toHaveBeenCalledWith('alice', 'abc')
+  })
+
+  it('does not publish running during reconciliation when provider sync fails', async () => {
+    const startedAt = new Date(Date.now() - 300_000)
+    mockInstance.findStatusBySlug.mockResolvedValue({
+      status: 'starting', startedAt, stoppedAt: null, lastActivityAt: startedAt, containerId: 'abc',
+      serverPassword: 'enc',
+    })
+    mockDocker.isContainerRunning.mockResolvedValue(true)
+    mockHealth.mockResolvedValue({ ok: true })
+    mockUser.findIdBySlug.mockResolvedValue({ id: 'owner-1' })
+    mockSync.mockResolvedValue({ ok: false, error: 'sync_failed' })
+
+    await expect(getInstanceStatus('alice')).resolves.toMatchObject({ status: 'starting', containerId: 'abc' })
+    expect(mockInstance.correctToRunningIfCurrentContainer).not.toHaveBeenCalled()
   })
 
   it('keeps running containers in starting state until OpenCode responds', async () => {
@@ -725,7 +921,7 @@ describe('startInstance - agent config transforms', () => {
     mockInstance.findBySlug.mockResolvedValue(null)
     mockInstance.upsertStarting.mockResolvedValue({} as never)
     mockInstance.setContainerId.mockResolvedValue({} as never)
-    mockInstance.setRunning.mockResolvedValue({} as never)
+    mockInstance.setRunningIfCurrentContainer.mockResolvedValue({ count: 1 })
     mockUser.findIdentityBySlug.mockResolvedValue({ id: 'owner-1', slug: 'bob', email: 'bob@example.com' })
     mockDocker.createContainer.mockResolvedValue({ id: 'container-456' } as never)
     mockDocker.startContainer.mockResolvedValue(undefined)

--- a/apps/web/src/lib/spawner/core.ts
+++ b/apps/web/src/lib/spawner/core.ts
@@ -1,5 +1,11 @@
-import { auditService, instanceService, providerService } from '@/lib/services'
-import { getInstanceUrl, isInstanceHealthyWithPassword, type InstanceHealthResult } from '@/lib/opencode/client'
+import { auditService, instanceService, providerService, userService } from '@/lib/services'
+import type { InstanceStatusDetails } from '@/lib/services/instance'
+import {
+  DEFAULT_HEALTH_TIMEOUT_MS,
+  getInstanceUrl,
+  isInstanceHealthyWithPassword,
+  type InstanceHealthResult,
+} from '@/lib/opencode/client'
 import { syncProviderAccessForInstance } from '@/lib/opencode/providers'
 import * as docker from './docker'
 import { decryptPassword, generatePassword, encryptPassword } from './crypto'
@@ -9,6 +15,10 @@ import {
   getWebProviderGatewayConfig,
   hashWorkspaceRuntimeArtifacts,
 } from './runtime-artifacts'
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
 
 export type StartResult =
   | { ok: true; status: 'running' }
@@ -42,6 +52,38 @@ function isStartingStillFresh(instance: { status: string; startedAt: Date | null
   if (instance.status !== 'starting' || !instance.startedAt) return false
 
   return Date.now() - instance.startedAt.getTime() <= getStartTimeoutMs() * 2
+}
+
+/**
+ * Tear down a failed startup attempt without ever destroying a container that
+ * this instance's current state still references.
+ *
+ * - Owns the transition (setErrorIfCurrentContainer matched the attempt):
+ *   stop/remove the container.
+ * - Lost the race but the DB still references the attempt's own containerId
+ *   (another flow already confirmed this container): do nothing.
+ * - The DB references a different containerId (superseded by a newer attempt):
+ *   remove only the attempt's own orphaned container, never the current one.
+ */
+async function handleFailedAttempt(slug: string, containerId: string | null): Promise<void> {
+  if (!containerId) {
+    await instanceService.setError(slug).catch(() => {})
+    return
+  }
+
+  const affected = await instanceService.setErrorIfCurrentContainer(slug, containerId)
+
+  if (affected.count > 0) {
+    await docker.stopContainer(containerId).catch(() => {})
+    await docker.removeContainer(containerId).catch(() => {})
+    return
+  }
+
+  const current = await instanceService.findContainerStatusBySlug(slug)
+  if (current && current.containerId !== containerId) {
+    await docker.stopContainer(containerId).catch(() => {})
+    await docker.removeContainer(containerId).catch(() => {})
+  }
 }
 
 export async function startInstance(slug: string, userId: string): Promise<StartResult> {
@@ -89,10 +131,7 @@ export async function startInstance(slug: string, userId: string): Promise<Start
         message: healthy.message,
         slug,
       })
-      await docker.stopContainer(container.id).catch(() => {})
-      await docker.removeContainer(container.id).catch(() => {})
-      containerId = null
-      await instanceService.setError(slug)
+      await handleFailedAttempt(slug, container.id)
       return { ok: false, error: 'timeout', detail: timeoutDetail }
     }
 
@@ -115,7 +154,17 @@ export async function startInstance(slug: string, userId: string): Promise<Start
       await providerService.clearWorkspaceRestartRequired(syncUserId)
     }
 
-    await instanceService.setRunning(slug, appliedConfigSha)
+    // Publish 'running' only if this attempt still owns the transition. If it
+    // lost the race, re-read and return the current state without a duplicate
+    // audit event.
+    const affected = await instanceService.setRunningIfCurrentContainer(slug, container.id, appliedConfigSha)
+    if (affected.count === 0) {
+      const current = await instanceService.findStatusBySlug(slug)
+      if (current && current.status === 'running') {
+        return { ok: true, status: 'running' }
+      }
+      return { ok: false, error: 'start_failed', detail: 'startup superseded by another attempt' }
+    }
 
     await auditService.createEvent({
       actorUserId: userId,
@@ -132,13 +181,7 @@ export async function startInstance(slug: string, userId: string): Promise<Start
       console.error('[spawner] startInstance failed: unknown error')
     }
 
-    // Clean up container if it was created to avoid orphans and name conflicts
-    if (containerId) {
-      await docker.stopContainer(containerId).catch(() => {})
-      await docker.removeContainer(containerId).catch(() => {})
-    }
-
-    await instanceService.setError(slug).catch(() => {})
+    await handleFailedAttempt(slug, containerId)
 
     return { ok: false, error: 'start_failed', detail }
   }
@@ -197,13 +240,23 @@ export async function getInstanceStatus(slug: string) {
 
     // Verify OpenCode is actually responding
     try {
+      // A recent 'starting' attempt stays 'starting' even if the process answers
+      // health; only the startup flow (or reconciliation of a stale attempt)
+      // publishes 'running'.
+      if (isStartingStillFresh(instance)) {
+        return instance
+      }
+
+      if (instance.status === 'starting') {
+        // Stale attempt: recover it through the reconciliation flow before
+        // reporting as running.
+        return await reconcileStartingInstance(slug, instance)
+      }
+
       const password = decryptPassword(instance.serverPassword)
       const health = await isInstanceHealthyWithPassword(slug, password)
 
       if (health.ok) {
-        if (instance.status !== 'running') {
-          await instanceService.correctToRunning(slug)
-        }
         return { ...instance, status: 'running' as const }
       }
 
@@ -213,11 +266,63 @@ export async function getInstanceStatus(slug: string) {
         return { ...instance, status: 'starting' as const }
       }
     } catch (err) {
-      console.error('[spawner] Failed to decrypt instance password', err)
+      console.error('[spawner] Failed to verify instance health', err)
     }
   }
 
   return instance
+}
+
+/**
+ * Recover a 'starting' instance whose startup attempt was interrupted (no
+ * longer fresh). Verifies health within the bounded deadline, syncs providers,
+ * then publishes 'running' only if this attempt still owns the transition
+ * (status 'starting' and containerId unchanged). If the attempt lost the race,
+ * re-read and return the current state.
+ */
+async function reconcileStartingInstance(
+  slug: string,
+  instance: InstanceStatusDetails,
+): Promise<InstanceStatusDetails> {
+  if (!instance.containerId) return instance
+
+  try {
+    const password = decryptPassword(instance.serverPassword)
+    const health = await isInstanceHealthyWithPassword(slug, password)
+    if (!health.ok) {
+      return instance
+    }
+
+    const owner = await userService.findIdBySlug(slug)
+    if (!owner?.id) {
+      return instance
+    }
+
+    const syncResult = await syncProviderAccessForInstance({
+      instance: {
+        baseUrl: getInstanceUrl(slug),
+        authHeader: `Basic ${Buffer.from(`opencode:${password}`).toString('base64')}`,
+      },
+      slug,
+      userId: owner.id,
+    })
+    if (!syncResult.ok) {
+      return instance
+    }
+
+    const affected = await instanceService.correctToRunningIfCurrentContainer(slug, instance.containerId)
+    if (affected.count > 0) {
+      return { ...instance, status: 'running' as const }
+    }
+
+    return (await instanceService.findStatusBySlug(slug)) ?? instance
+  } catch (err) {
+    console.error('[spawner] Failed to reconcile starting instance', {
+      slug,
+      error: err instanceof Error ? err.message : err,
+    })
+    return instance
+  }
 }
 
 export async function listActiveInstances() {
@@ -270,14 +375,13 @@ async function waitForHealthy(containerId: string, slug: string, password: strin
   const timeout = getStartTimeoutMs()
   const start = Date.now()
   let directBaseUrl: string | null | undefined
-  let directHealthy = false
   let lastHealth: InstanceHealthResult = { ok: false, detail: 'container_not_running' }
 
   while (Date.now() - start < timeout) {
     // First check if container is running
     const running = await docker.isContainerRunning(containerId)
     if (!running) {
-      await new Promise(r => setTimeout(r, 1000))
+      await sleep(1000)
       continue
     }
 
@@ -292,43 +396,87 @@ async function waitForHealthy(containerId: string, slug: string, password: strin
       }
     }
 
-    if (directBaseUrl && !directHealthy) {
-      const directHealth = await isInstanceHealthyWithPassword(slug, password, directBaseUrl)
-      if (directHealth.ok) {
-        directHealthy = true
-        console.log('[spawner] OpenCode responded on direct container IP', { containerId, slug })
-      } else {
-        lastHealth = directHealth
-      }
+    // Each probe is bounded by min(DEFAULT_HEALTH_TIMEOUT_MS, remaining budget)
+    // so the total flow still honors ARCHE_START_TIMEOUT_MS.
+    const remaining = timeout - (Date.now() - start)
+    const probeTimeout = Math.max(1, Math.min(DEFAULT_HEALTH_TIMEOUT_MS, remaining))
+
+    // Probe DNS hostname and the direct container IP concurrently so neither can
+    // stall the other; whichever confirms health cancels the losing request.
+    const outcome = await probeDnsAndDirect(slug, password, directBaseUrl, probeTimeout)
+
+    if (outcome.winner === 'dns') {
+      return { ok: true }
     }
 
-    // Then verify OpenCode is actually responding
-    const health = await isInstanceHealthyWithPassword(slug, password)
-    if (health.ok) return health
-    lastHealth = health
-
-    if (directHealthy) {
+    if (outcome.winner === 'direct') {
+      console.log('[spawner] OpenCode responded on direct container IP', { containerId, slug })
       console.warn('[spawner] DNS healthcheck unavailable after direct IP success; continuing startup', {
         containerId,
-        detail: health.detail,
+        detail: outcome.dnsResult && !outcome.dnsResult.ok ? outcome.dnsResult.detail : undefined,
         directBaseUrl,
-        message: health.message,
+        message: outcome.dnsResult && !outcome.dnsResult.ok ? outcome.dnsResult.message : undefined,
         slug,
       })
       return { ok: true, baseUrl: directBaseUrl ?? undefined }
     }
 
-    await new Promise(r => setTimeout(r, 1000))
-  }
-
-  if (directHealthy) {
-    console.warn('[spawner] DNS healthcheck timed out after direct IP success; continuing startup', {
-      containerId,
-      directBaseUrl,
-      slug,
-    })
-    return { ok: true, baseUrl: directBaseUrl ?? undefined }
+    lastHealth = outcome.dnsResult ?? outcome.directResult ?? { ok: false, detail: 'healthcheck timeout' }
+    await sleep(1000)
   }
 
   return lastHealth.ok ? { ok: false, detail: 'healthcheck timeout' } : lastHealth
+}
+
+type ProbeOutcome = {
+  winner: 'dns' | 'direct' | null
+  dnsResult?: InstanceHealthResult
+  directResult?: InstanceHealthResult
+}
+
+/**
+ * Run the DNS and (when available) direct-IP health probes concurrently, each
+ * bounded to `timeoutMs`. As soon as one confirms health, the other probe's
+ * request is aborted so a stuck connection cannot keep running. If neither
+ * confirms, both settled results are returned for diagnostics.
+ */
+async function probeDnsAndDirect(
+  slug: string,
+  password: string,
+  directBaseUrl: string | null,
+  timeoutMs: number,
+): Promise<ProbeOutcome> {
+  const dnsController = new AbortController()
+  const direct = directBaseUrl ? { controller: new AbortController() } : null
+  const results: { dns?: InstanceHealthResult; direct?: InstanceHealthResult } = {}
+
+  const runDns = async () => {
+    const result = await isInstanceHealthyWithPassword(slug, password, undefined, {
+      timeoutMs,
+      signal: dnsController.signal,
+    })
+    results.dns = result
+    if (result.ok) direct?.controller.abort()
+  }
+
+  const runDirect = direct
+    ? async () => {
+        const result = await isInstanceHealthyWithPassword(slug, password, directBaseUrl!, {
+          timeoutMs,
+          signal: direct.controller.signal,
+        })
+        results.direct = result
+        if (result.ok) dnsController.abort()
+      }
+    : null
+
+  if (direct) {
+    await Promise.all([runDns(), runDirect!()])
+  } else {
+    await runDns()
+  }
+
+  if (results.dns?.ok) return { winner: 'dns', dnsResult: results.dns, directResult: results.direct }
+  if (results.direct?.ok) return { winner: 'direct', dnsResult: results.dns, directResult: results.direct }
+  return { winner: null, dnsResult: results.dns, directResult: results.direct }
 }

--- a/openspec/changes/fix-workspace-startup/.openspec.yaml
+++ b/openspec/changes/fix-workspace-startup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/fix-workspace-startup/design.md
+++ b/openspec/changes/fix-workspace-startup/design.md
@@ -1,0 +1,73 @@
+## Context
+
+See proposal.md - Why for the two production failures: a blocking health check with no per-request timeout, and a startup race where a stale attempt destroys a container another flow already confirmed. The current state that shapes the approach:
+
+- `isInstanceHealthyWithPassword(slug, password, overrideBaseUrl?)` in `src/lib/opencode/client.ts` issues a `fetch()` with no `AbortSignal` or per-request timeout. It is also called from `getInstanceStatus()` (`core.ts:201`), so bounding it protects every call site, not just startup.
+- `waitForHealthy()` (`core.ts:295`) probes the direct container IP first and the DNS hostname second, sequentially, with the total-startup deadline checked only between loop iterations. A single hanging request therefore blocks the whole loop and is not bounded by `ARCHE_START_TIMEOUT_MS`.
+- Instance mutations (`setRunning`, `setError`, `correctToRunning`) update by `slug` unconditionally. `containerId` already exists and is set after container creation, so it can key race-safe transitions without a migration.
+- `use-instance-startup.ts` arms its 120 s timeout only after the first `ensureInstanceRunningAction()` resolves with `starting`; a hanging first call arms neither polling nor the timeout.
+- An existing deliberate behavior and test allow startup to continue on direct-IP success when the DNS hostname is unavailable. This design keeps that fallback but bounds it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every `/health` request has a hard per-request deadline enforced by aborting it.
+- Total startup health-check honors `ARCHE_START_TIMEOUT_MS`; no individual request outlives the remaining budget.
+- DNS and direct-IP probing cannot stall each other.
+- Instance state transitions and container cleanup are conditional on the attempt's `containerId`, so a stale request cannot corrupt or delete a newer attempt's result.
+- `running` is published only after health check + provider sync; a recent `starting` instance stays `starting` on reads.
+- The frontend shows an error instead of an infinite "Starting workspace" screen.
+
+**Non-Goals:**
+- Fixing stale Server Action bundles from a prior deployment (tracked separately).
+- Changing the desktop host path (`workspace-host-desktop.ts`), which has no container semantics.
+- Migration of persisted data: none needed.
+
+## Decisions
+
+### D1. Per-request timeout in the health client
+`isInstanceHealthyWithPassword()` gains an optional `{ timeoutMs }` option and creates an `AbortController` per `/global/health` request. On expiration it returns `{ ok: false, detail: 'healthcheck_timeout' }`. The default timeout is ~5s so the existing `getInstanceStatus()` call site is bounded too. Alternative considered: relying on a global fetch timeout, rejected because it cannot abort an already-established idle connection and cannot express per-attempt budgets.
+
+### D2. Bounded, non-blocking health probes in `waitForHealthy`
+Each probe receives a deadline of `min(perAttemptMs, remainingBudgetMs)` computed from the start of the startup. The loop no longer waits on a single unbounded request. The direct-IP probe is attempted first but with a hard per-attempt deadline, and the DNS probe runs with the same budget; if the direct-IP probe fails or times out, the DNS probe decides. The losing in-flight request (when probing in parallel) is cancelled once one confirms health.
+
+### D3. Preserve the direct-IP fallback (bounded)
+The current deliberate behavior — continue startup using the direct-IP address when DNS is unhealthy but direct IP responds — is kept, only now time-bounded. Alternative (fully gating `running` on DNS) was considered and rejected because the BFF already targets `opencode-${slug}` by DNS in the common path; changing the policy is a product decision out of scope here. The bounded fallback keeps the existing test green while removing the blocking.
+
+### D4. Conditional state transitions by `containerId`
+Add to `instance.ts`:
+- `setRunningIfCurrentContainer(slug, containerId, configSha)` → `updateMany({ where: { slug, status: 'starting', containerId }, data: { status: 'running', lastActivityAt, appliedConfigSha } })`
+- `setErrorIfCurrentContainer(slug, containerId)` → `updateMany({ where: { slug, status: 'starting', containerId }, data: { status: 'error', containerId: null, ... } })`
+- `correctToRunningIfCurrentContainer(slug, containerId)` for the reconciliation path.
+
+Each returns the affected-row count so callers can detect a lost race. `updateMany` was chosen over `update` because it can express the compound guard atomically.
+
+### D4. Guarded cleanup in `startInstance`
+The attempt captures its `containerId` at creation. On both the timeout path and the generic `catch` path, before `stopContainer`/`removeContainer`/`setError`:
+1. Run the conditional transition to `error`.
+2. Stop/remove the container **only if** the transition affected a row, **or** the current DB `containerId` no longer equals the attempt's own (in which case the attempt removes only its own now-orphaned container, never the current one).
+3. If the attempt lost the race for a still-current container (transition affected 0 rows and the DB still references the same `containerId`), do not touch the container; re-read and return the current state.
+
+This covers the scenario where the generic `catch` fires after another flow confirmed `running`.
+
+### D5. Do not publish `running` prematurely; reconcile interrupted startups
+`getInstanceStatus()` stops flipping a recent `starting` instance to `running` on health alone. Recovery moves into the reconciliation route: a status check on a `starting` instance whose attempt is no longer fresh performs container-verify → bounded health check → provider sync → `correctToRunningIfCurrentContainer`. This is the only non-`startInstance` path that may publish `running`.
+
+### D6. Frontend timeout armed before the server action
+`use-instance-startup.ts` marks the attempt `starting` and arms the timeout before awaiting the server action, tags the attempt with a local id, and when the timeout fires shows the error and ignores a late response for that attempt. The client timeout is set to `ARCHE_START_TIMEOUT_MS + margin` (not equal) so the client does not time out while the server is legitimately about to succeed.
+
+## Risks / Trade-offs
+
+- [Aborting a fetch that is mid-flight] → `AbortController` is the supported mechanism; the health client maps the abort to `healthcheck_timeout` and the test asserts no dangling promise.
+- [Parallel DNS/direct probes add concurrency complexity] → The bounded-sequential variant is preferred for the common path; parallel with cancel is an optimization, not a requirement.
+- [Removing premature `correctToRunning` changes status-read behavior] → Existing tests asserting that path are re-specified; the reconciliation route preserves recovery so workspaces are not stuck in `starting`.
+- [A lost-race attempt may orphan its own container] → The cleanup rule in D4 removes only the attempt's own container by id when the DB no longer references it; it never touches the current `containerId`.
+
+## Migration Plan
+
+- No DB migration: `containerId` already exists.
+- Behavior is deployable as a single release. Rollback: revert to the previous commit; the conditional transitions are additive and the health timeout default only makes requests fail faster, so no data migration or two-phase deploy is required.
+
+## Open Questions
+
+- (none that would change the spec, approach, or task breakdown; the direct-IP fallback policy and the client-timeout value were resolved as decisions above.)

--- a/openspec/changes/fix-workspace-startup/proposal.md
+++ b/openspec/changes/fix-workspace-startup/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Workspace startup can hang indefinitely and then destroy a working container:
+
+1. **Blocking healthcheck**: `isInstanceHealthyWithPassword()` issues a `fetch()` to `/global/health` with no per-request timeout or `AbortSignal`. In production a hanging request waited on Undici's internal timeout (~5 min) even though OpenCode was already listening. Because `waitForHealthy()` waits on the direct IP and then the DNS host sequentially, a single hanging request blocks the whole startup, and its deadline is only checked between loop iterations — so it is not bounded even by `ARCHE_START_TIMEOUT_MS`. `ensureInstanceRunningAction()` does not return while this is alive, so the client never activates its own polling/timeout.
+2. **Startup race**: while the first request is still blocked, a second query sees the container healthy and flips the instance from `starting` to `running` via `getInstanceStatus()`/`correctToRunning()`. When the first request finally fails, its cleanup (`stopContainer` + `removeContainer` + `setError(slug)`) is unconditional by slug, so it destroys the container the other flow already confirmed as working. This is the observed production behavior: reload opens the workspace, but the original in-flight request later shuts it down.
+
+The goal is to bound every health check, make the total startup honor its deadline, and make state transitions and cleanup safe against concurrent attempts.
+
+## What Changes
+
+- Bound each `/global/health` request with a per-request timeout (via `AbortSignal`) so no single health check can outlive its deadline.
+- Keep `ARCHE_START_TIMEOUT_MS` as the total startup budget and ensure no individual request exceeds the remaining time.
+- Stop blocking the startup cycle on a direct-IP health check: check DNS and direct IP so one cannot stall the other, and cancel the losing request when one confirms health.
+- Make instance state transitions conditional on the attempt's `containerId` so an old request can no longer mutate or delete the outcome of a newer one:
+  - `setRunningIfCurrentContainer`, `setErrorIfCurrentContainer`, and optionally `correctToRunningIfCurrentContainer`.
+  - On failure, only stop/remove the container when the attempt still owns it; otherwise re-read and return the current state.
+- Stop publishing `running` prematurely: `getInstanceStatus()` must keep a recent `starting` attempt as `starting` even when the process answers the health check. `running` is only published after the startup flow completes health check + provider sync. Add an explicit reconciliation route to recover an interrupted startup.
+- Add an independent frontend timeout in `use-instance-startup` that is armed before awaiting the server action, so a blocked server action/proxy/network can no longer leave the UI showing "Starting workspace" indefinitely, and a late response cannot overwrite a timed-out error.
+
+## Capabilities
+
+### New Capabilities
+- `workspace-startup`: Behavioral rules for the instance startup lifecycle — bounded health checks, total-startup deadline enforcement, DNS/direct-IP probing, race-safe state transitions keyed by `containerId`, and when `running` may be published. Covers the spawner core, the OpenCode health client, the instance service transitions, and the frontend startup hook.
+
+### Modified Capabilities
+- (none — this is the first capability under the repo's `openspec/specs/` tree.)
+
+## Impact
+
+- `apps/web/src/lib/opencode/client.ts` — `isInstanceHealthyWithPassword()` gains a per-request timeout; new `healthcheck_timeout` result.
+- `apps/web/src/lib/spawner/core.ts` — `waitForHealthy()` bounded, non-blocking direct-IP/DNS probing; `startInstance()` uses conditional transitions and guarded cleanup; `getInstanceStatus()` stops premature `running`.
+- `apps/web/src/lib/services/instance.ts` — conditional transitions keyed by `slug + status + containerId`.
+- `apps/web/src/hooks/use-instance-startup.ts` — independent client-side timeout that arms before the server action resolves.
+- New and updated tests in `src/lib/spawner/__tests__/core.test.ts`, `src/lib/opencode/__tests__/client.test.ts`, and `src/hooks/__tests__/use-instance-startup.test.tsx`.
+- No DB migration: `containerId` already exists and is unique per container creation.

--- a/openspec/changes/fix-workspace-startup/specs/workspace-startup/spec.md
+++ b/openspec/changes/fix-workspace-startup/specs/workspace-startup/spec.md
@@ -1,0 +1,72 @@
+## Purpose
+
+Defines the behavioral contract for starting an OpenCode workspace instance: health checks must be time-bounded, the total startup must honor its deadline, and instance state transitions must be safe against concurrent startup attempts so a stale request can never destroy a workspace another flow already confirmed.
+
+## ADDED Requirements
+
+### Requirement: Health checks are bounded by a per-request deadline
+The system SHALL cap each health-check request to a fixed, short timeout and SHALL return a stable `healthcheck_timeout` result when that deadline expires, rather than waiting on the transport's internal timeout. A request that expires SHALL be aborted so it cannot keep running after the deadline.
+
+#### Scenario: Health check never responds
+- **WHEN** a health check request to `/global/health` does not respond within its per-request deadline
+- **THEN** the health check returns `healthcheck_timeout` and the request is aborted
+
+#### Scenario: Health check responds within the deadline
+- **WHEN** a health check request responds with `healthy: true` before the per-request deadline
+- **THEN** the health check returns a healthy result
+
+### Requirement: Total startup does not exceed the startup deadline
+The system SHALL treat `ARCHE_START_TIMEOUT_MS` as the total budget for the startup health-check phase, and SHALL NOT allow any individual health check request to exceed the remaining time in that budget.
+
+#### Scenario: Startup deadline is reached
+- **WHEN** the elapsed startup time reaches the configured startup budget
+- **THEN** the startup health check terminates as a timeout within that budget
+
+### Requirement: DNS and direct-IP probing do not block startup
+The system SHALL probe the workspace by DNS hostname and by direct container IP so that neither check can block the other. The system SHALL NOT block startup on a direct-IP request: when the direct-IP probe fails or exceeds its deadline, startup continues with the DNS probe. When either probe confirms health, the losing in-flight request is cancelled.
+
+#### Scenario: Direct IP is blocked but DNS responds
+- **WHEN** the direct-IP health probe does not respond within its deadline
+- **AND** the DNS hostname health probe returns healthy
+- **THEN** the startup completes successfully
+
+#### Scenario: Direct IP responds but DNS does not
+- **WHEN** the direct-IP health probe returns healthy before its deadline
+- **AND** the DNS hostname probe does not respond within its deadline
+- **THEN** the startup continues using the direct-IP address as the workspace base URL
+
+### Requirement: State transitions are keyed to the startup attempt
+The system SHALL key instance state transitions to the `containerId` of the startup attempt that created the container. A state change from `starting` to `running` or `error` SHALL only take effect when the instance still references the same `containerId` and is still in `starting`.
+
+#### Scenario: Old attempt fails after another flow confirmed running
+- **WHEN** a startup attempt's health check fails after another flow has already moved the instance to `running` for the same `containerId`
+- **THEN** the failing attempt does not mark the instance as errored
+- **AND** the failing attempt does not stop or remove the container
+- **AND** the instance remains `running`
+
+#### Scenario: Old attempt targets a superseded container
+- **WHEN** a startup attempt's `containerId` no longer matches the current instance `containerId` because a newer attempt replaced it
+- **THEN** the older attempt does not change the instance state
+- **AND** the older attempt does not remove the newer container
+
+### Requirement: running is published only after a completed startup
+The system SHALL publish the instance as `running` only after the startup flow has completed both the health check and provider synchronization. While a startup attempt is recent and the instance is `starting`, status reads SHALL keep reporting `starting` even when the workspace process responds to a health check. An interrupted startup SHALL be recovered through an explicit reconciliation flow that verifies the container, checks health within a deadline, synchronizes providers, and only then transitions conditionally to `running`.
+
+#### Scenario: Health responds during an in-progress startup
+- **WHEN** an instance is `starting` within its startup freshness window
+- **AND** the workspace process responds to a health check
+- **THEN** a status read returns `starting`, not `running`
+
+#### Scenario: Interrupted startup is reconciled
+- **WHEN** an instance is `starting` but its startup attempt was interrupted
+- **AND** the container is running and the health check succeeds within a bounded deadline
+- **AND** provider synchronization succeeds
+- **THEN** the reconciliation flow transitions the instance conditionally to `running`
+
+### Requirement: The client does not wait on a blocked server action indefinitely
+The system SHALL arm an independent client-side timeout before awaiting the startup server action. When that timeout expires, the client SHALL surface an error and SHALL NOT allow a late server response to overwrite the timed-out state.
+
+#### Scenario: Startup server action never resolves
+- **WHEN** the client starts the workspace and the server action does not resolve within the client timeout
+- **THEN** the client shows an error state
+- **AND** when the server action later resolves, the client does not overwrite that error state

--- a/openspec/changes/fix-workspace-startup/tasks.md
+++ b/openspec/changes/fix-workspace-startup/tasks.md
@@ -1,0 +1,31 @@
+## 1. Bounded health check client
+
+- [ ] 1.1 Add an optional `{ timeoutMs }` option to `isInstanceHealthyWithPassword()` in `apps/web/src/lib/opencode/client.ts`, creating an `AbortController` per `/health` request and aborting on deadline. Default timeout ~5s. Verify: add a unit test in `src/lib/opencode/__tests__/client.test.ts` where a never-resolving `fetch` is aborted via the signal and returns `{ ok: false, detail: 'healthcheck_timeout' }` with no dangling promise.
+- [ ] 1.2 Map an abort (and the expired deadline) to the stable `healthcheck_timeout` result, keeping existing DNS/ECONNREFUSED/http-status/invalid-json detail mapping. Verify: existing `client.test.ts` cases still pass and the new timeout case returns `healthcheck_timeout`.
+
+## 2. Instance service conditional transitions
+
+- [ ] 2.1 Add `setRunningIfCurrentContainer(slug, containerId, configSha)` to `src/lib/services/instance.ts` using `updateMany` guarded by `{ slug, status: 'starting', containerId }`, returning the affected count. Verify: a focused unit test asserts the compound `where` and that a mismatched `containerId` yields zero affected rows.
+- [ ] 2.2 Add `setErrorIfCurrentContainer(slug, containerId)` and `correctToRunningIfCurrentContainer(slug, containerId)` with the same guard shape. Verify: unit tests assert the `where` clause and affected-row semantics.
+
+## 3. Spawner core startup changes
+
+- [ ] 3.1 Rework `waitForHealthy()` in `src/lib/spawner/core.ts` so each probe uses `min(perAttemptTimeoutMs, remainingBudgetMs)` and the loop honors `ARCHE_START_TIMEOUT_MS` as a hard total; direct-IP and DNS probes must not block each other (bounded sequential, with optional parallel + cancel). Verify: the new core tests in `src/lib/spawner/__tests__/core.test.ts` cover "direct IP blocked, DNS healthy" and "no health check responds" with a shortened `ARCHE_START_TIMEOUT_MS`.
+- [ ] 3.2 Capture the attempt's `containerId` in `startInstance()` and guard the failure/cleanup paths: run `setErrorIfCurrentContainer` first, then `stopContainer`/`removeContainer` only if the transition affected rows or the current DB `containerId` differs from the attempt's own; otherwise re-read and return the current state. Verify: new race tests assert no `stopContainer`/`removeContainer`/`setError` when another flow confirmed `running`, and no removal of the current `containerId` when a newer attempt owns it.
+- [ ] 3.3 On the success path, mark `running` only via `setRunningIfCurrentContainer`; if it affects zero rows, re-read and return the current status without a duplicate audit event. Verify: tests assert `running` is published only after the container is still current.
+- [ ] 3.4 Stop `getInstanceStatus()` from flipping a recent `starting` instance to `running` on health alone; keep returning `starting`. Verify: the `'corrects healthy starting instances to running'` core test is re-specified so a fresh `starting` instance returns `starting`.
+
+## 4. Reconciliation route for interrupted startups
+
+- [ ] 4.1 Add a reconciliation path that, for a `starting` instance whose attempt is no longer fresh, verifies the container, runs a bounded health check, syncs providers, and calls `correctToRunningIfCurrentContainer`. Wire it so status reads trigger it when the attempt is stale. Verify: a core test drives an interrupted `starting` instance through reconciliation to `running` when container, health, and provider sync all succeed.
+- [ ] 4.2 Ensure the reconciliation never publishes `running` before provider sync completes. Verify: a test asserts reconciliation leaves a syncing failure in `starting` (or the prior state) rather than `running`.
+
+## 5. Frontend startup timeout
+
+- [ ] 5.1 In `use-instance-startup.ts`, set the attempt to `starting` and arm the timeout before awaiting the server action, tag the attempt with a local id, and on timeout surface the error and ignore a late response for that attempt. Set the client timeout to `ARCHE_START_TIMEOUT_MS` plus a margin so the client does not time out before a legitimately finishing server. Verify: `src/hooks/__tests__/use-instance-startup.test.tsx` renders with a pending `ensureInstanceRunningAction`, enters `starting`, advances past the timeout, and asserts a late resolve does not overwrite the error.
+
+## 6. Test suite and lint
+
+- [ ] 6.1 Add regression tests for the incident scenarios (blocking direct-IP probe, total-deadline timeout, race with a second flow confirming `running`, a stale attempt not affecting a newer container). Verify: run `pnpm test` from `apps/web/` and confirm the new tests pass and pre-fix versions of the client/core/hook tests fail against the current code.
+- [ ] 6.2 Update existing mocks in `core.test.ts` for the new conditional service methods and any changed call signatures, and confirm the full suite passes. Verify: `pnpm test` and `pnpm lint` from `apps/web/` both pass.
+- [ ] 6.3 Build the workspace image locally to confirm no container-layer regressions. Verify: `bash scripts/check-podman-images.sh` from the repo root reports success.


### PR DESCRIPTION
- Add per-request health-check timeouts and enforce the total startup deadline
- Make startup transitions and cleanup conditional on the container ID
- Reconcile interrupted starts without marking containers prematurely running
- Arm an independent client-side startup timeout
- Update startup screens and add coverage for timeout and race scenarios