### PR TITLE
feat(avatars): add deterministic generative disc avatars

### DIFF
--- a/apps/desktop/e2e/chat-pdf.spec.ts
+++ b/apps/desktop/e2e/chat-pdf.spec.ts
@@ -2,6 +2,11 @@ import { expect, test, waitForWorkspaceReady } from './fixtures/desktop'
 
 const PDF_TOKEN = 'ARCHE_E2E_PDF_TOKEN'
 
+// Uploads land in a runtime shared across retries, so a re-run of this test
+// finds "sample.pdf" already stored and the upload endpoint deduplicates the
+// filename ("sample (1).pdf"). Accept any deduplicated suffix.
+const SAMPLE_PDF_CHIP = /sample( \(\d+\))?\.pdf/
+
 test('uploads a PDF in desktop and gets the extracted token back', async ({ page, samplePdfPath, ensureFakeOpenAiProvider }) => {
   await waitForWorkspaceReady(page)
 
@@ -15,10 +20,15 @@ test('uploads a PDF in desktop and gets the extracted token back', async ({ page
   await expect(page.getByPlaceholder('Type a message...')).toBeVisible({ timeout: 60_000 })
 
   await page.locator('input[type="file"]').setInputFiles(samplePdfPath)
-  await expect(page.getByText('sample.pdf')).toBeVisible({ timeout: 60_000 })
+  await expect(page.getByText(SAMPLE_PDF_CHIP)).toBeVisible({ timeout: 60_000 })
 
   await page.getByPlaceholder('Type a message...').fill('What token is in this PDF?')
   await page.getByLabel('Send message').click()
+
+  // Fail here, not at the token wait, when the sent message never renders:
+  // an empty conversation surfaces as a missing user bubble instead of a
+  // blind PDF_OK timeout.
+  await expect(page.getByText('What token is in this PDF?', { exact: true })).toBeVisible({ timeout: 60_000 })
 
   await expect(page.getByText(`PDF_OK: ${PDF_TOKEN}`, { exact: true })).toBeVisible({ timeout: 60_000 })
 })

--- a/apps/web/e2e/glyph-avatars.spec.ts
+++ b/apps/web/e2e/glyph-avatars.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test'
+
+import { adminSlug } from './support/test-data'
+
+// Covers the "generative disc avatars" PRD: agent and human surfaces render
+// their deterministic disc avatar. The avatar is a <canvas> whose backing
+// store is only sized once the draw effect runs, so a non-zero width
+// attribute proves the disc was actually drawn, not just mounted.
+
+test('renders a drawn disc avatar on each agent card in the catalog', async ({ page }) => {
+  await page.goto(`/w/${adminSlug}?catalog=agents`)
+
+  const avatar = page.locator('canvas.rounded-full').first()
+  await expect(avatar).toBeVisible({ timeout: 120_000 })
+  await expect(avatar).toHaveAttribute('width', /^\d+$/, { timeout: 120_000 })
+})
+
+test('renders a drawn disc avatar on each team member row', async ({ page }) => {
+  await page.goto(`/w/${adminSlug}?settings=team`)
+
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible({ timeout: 120_000 })
+
+  const avatar = dialog.locator('canvas.rounded-full').first()
+  await expect(avatar).toBeVisible()
+  await expect(avatar).toHaveAttribute('width', /^\d+$/, { timeout: 120_000 })
+})

--- a/apps/web/src/app/w/[slug]/layout.tsx
+++ b/apps/web/src/app/w/[slug]/layout.tsx
@@ -136,6 +136,7 @@ export default async function WorkspaceLayout({
       >
         <WorkspaceAppChrome
           slug={slug}
+          currentUserId={session.user.id}
           currentVault={desktopVault ? { id: desktopVault.vaultId, name: desktopVault.vaultName, path: desktopVault.vaultPath } : null}
           macDesktopWindowInset={macDesktopWindowInset}
         >

--- a/apps/web/src/components/agents/agent-card.tsx
+++ b/apps/web/src/components/agents/agent-card.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 
+import { GlyphAvatar } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
@@ -53,11 +54,9 @@ export function AgentCard({
       ) : null}
 
       <CardHeader>
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted/70 text-sm font-semibold text-muted-foreground">
-            {displayName.slice(0, 1).toUpperCase()}
-          </div>
-          <div className="space-y-0.5">
+        <div className="flex min-w-0 items-center gap-3">
+          <GlyphAvatar seed={agentId} kind="agent" size={40} />
+          <div className="min-w-0 space-y-0.5">
             <CardTitle className="text-base font-semibold">{displayName}</CardTitle>
             <p className="text-xs text-muted-foreground">ID: {agentId}</p>
           </div>

--- a/apps/web/src/components/team/team-page-client.tsx
+++ b/apps/web/src/components/team/team-page-client.tsx
@@ -7,6 +7,7 @@ import { CreateUserDialog } from '@/components/team/create-user-dialog'
 import { EditUserDialog } from '@/components/team/edit-user-dialog'
 import { getTeamErrorMessage } from '@/components/team/error-messages'
 import type { TeamUser } from '@/components/team/types'
+import { GlyphAvatar } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 
@@ -219,14 +220,17 @@ export function TeamPageClient({
           <div className="divide-y divide-border/60">
             {sortedUsers.map((user) => (
               <div key={user.id} className="flex flex-wrap items-center justify-between gap-3 py-3 first:pt-0 last:pb-0">
-                <div className="min-w-0 space-y-1">
-                  <p className="truncate text-sm font-semibold text-foreground">{user.email}</p>
-                  <p className="text-xs text-muted-foreground">
-                    /{user.slug} - created {formatCreatedAt(user.createdAt)}
-                  </p>
+                <div className="flex min-w-0 items-center gap-3">
+                  <GlyphAvatar seed={user.id} kind="human" size={32} />
+                  <div className="min-w-0 space-y-1">
+                    <p className="truncate text-sm font-semibold text-foreground">{user.email}</p>
+                    <p className="text-xs text-muted-foreground">
+                      /{user.slug} - created {formatCreatedAt(user.createdAt)}
+                    </p>
+                  </div>
                 </div>
 
-                <div className="flex items-center gap-2">
+                <div className="flex shrink-0 items-center gap-2">
                   <Badge variant={user.role === 'ADMIN' ? 'default' : 'secondary'}>{user.role}</Badge>
                   {user.id === currentUserId ? <Badge variant="outline">You</Badge> : null}
                   {isAdmin ? (

--- a/apps/web/src/components/ui/__tests__/avatar.test.tsx
+++ b/apps/web/src/components/ui/__tests__/avatar.test.tsx
@@ -1,0 +1,191 @@
+/** @vitest-environment jsdom */
+
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+
+import { DISC_ALPHAS } from "@/lib/avatar-disc";
+
+const INK = "rgb(24, 24, 27)";
+
+type MountProps = {
+  seed: string;
+  kind: "agent" | "human";
+  size?: number;
+  active?: boolean;
+  label?: string;
+};
+
+type CanvasLog = {
+  clearRect: Mock;
+  arc: Mock;
+  fill: Mock;
+  /** globalAlpha registrada en cada fill(). */
+  alphas: number[];
+  /** fillStyle vigente en cada fill(). */
+  fillStyles: string[];
+};
+
+/**
+ * jsdom no implementa getContext: se sustituye por un registro que apunta
+ * las llamadas de dibujo del componente.
+ */
+function stubCanvasContext(): CanvasLog {
+  const log: CanvasLog = {
+    clearRect: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    alphas: [],
+    fillStyles: [],
+  };
+  const context = {
+    fillStyle: "",
+    globalAlpha: 1,
+    clearRect: log.clearRect,
+    beginPath: vi.fn(),
+    arc: log.arc,
+    fill: () => {
+      log.alphas.push(context.globalAlpha);
+      log.fillStyles.push(context.fillStyle);
+      log.fill();
+    },
+  };
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+    context as unknown as CanvasRenderingContext2D,
+  );
+  return log;
+}
+
+function installStubs(options: { reduced?: boolean } = {}) {
+  // Sin invocar el callback: el ticker compartido quedaría en bucle síncrono.
+  const raf = vi.fn(() => 1);
+  vi.stubGlobal("requestAnimationFrame", raf);
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({
+    matches: options.reduced ?? false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+  vi.spyOn(window, "getComputedStyle").mockReturnValue({ color: INK } as CSSStyleDeclaration);
+  const log = stubCanvasContext();
+  return { log, raf };
+}
+
+function getCanvas(container: HTMLElement): HTMLCanvasElement {
+  const canvas = container.querySelector("canvas");
+  expect(canvas).not.toBeNull();
+  return canvas as HTMLCanvasElement;
+}
+
+async function mountAvatar(props: MountProps) {
+  // Módulo fresco por test: el ticker y el observador de tema son estado
+  // a nivel de módulo y no deben sangrar entre pruebas.
+  const { GlyphAvatar } = await import("@/components/ui/avatar");
+  return render(<GlyphAvatar {...props} />);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  document.documentElement.className = "";
+});
+
+describe("GlyphAvatar", () => {
+  it("es decorativo sin label y accesible con label", async () => {
+    installStubs();
+
+    const { container } = await mountAvatar({ seed: "agent-1", kind: "agent" });
+    const canvas = getCanvas(container);
+    expect(canvas.getAttribute("aria-hidden")).toBe("true");
+    expect(canvas.getAttribute("role")).toBeNull();
+    expect(canvas.getAttribute("aria-label")).toBeNull();
+
+    const { container: labeled } = await mountAvatar({
+      seed: "agent-1",
+      kind: "agent",
+      label: "Research analyst",
+    });
+    const named = getCanvas(labeled);
+    expect(named.getAttribute("role")).toBe("img");
+    expect(named.getAttribute("aria-label")).toBe("Research analyst");
+    expect(named.getAttribute("aria-hidden")).toBeNull();
+  });
+
+  it("fija el tamaño por CSS y distingue agente de humano por la tinta", async () => {
+    installStubs();
+
+    const { container: agent } = await mountAvatar({ seed: "agent-1", kind: "agent", size: 40 });
+    const agentCanvas = getCanvas(agent);
+    expect(agentCanvas.style.width).toBe("40px");
+    expect(agentCanvas.style.height).toBe("40px");
+    expect(agentCanvas.className).toContain("text-primary");
+    expect(agentCanvas.className).toContain("rounded-full");
+
+    const { container: human } = await mountAvatar({ seed: "user-1", kind: "human", size: 32 });
+    const humanCanvas = getCanvas(human);
+    expect(humanCanvas.style.width).toBe("32px");
+    expect(humanCanvas.className).toContain("text-foreground");
+    expect(humanCanvas.className).not.toContain("text-primary");
+  });
+
+  it("dibuja el fotograma de identidad al montar", async () => {
+    const { log } = installStubs();
+
+    const { container } = await mountAvatar({ seed: "agent-1", kind: "agent", size: 48 });
+    const canvas = getCanvas(container);
+
+    // Resolución canónica a 48px: 256 puntos de disco.
+    expect(canvas.width).toBe(48);
+    expect(canvas.height).toBe(48);
+    expect(log.clearRect).toHaveBeenCalledWith(0, 0, 48, 48);
+    expect(log.arc).toHaveBeenCalledTimes(256);
+    expect(log.fill).toHaveBeenCalledTimes(256);
+
+    // La tinta se lee una vez del computed style y se usa en cada punto.
+    expect(new Set(log.fillStyles)).toEqual(new Set([INK]));
+    for (const alpha of log.alphas) {
+      expect(DISC_ALPHAS).toContain(alpha);
+    }
+  });
+
+  it("no anima en reposo", async () => {
+    const { raf } = installStubs();
+
+    await mountAvatar({ seed: "agent-1", kind: "agent", size: 48 });
+
+    expect(raf).not.toHaveBeenCalled();
+  });
+
+  it("no anima con active si el usuario pide movimiento reducido", async () => {
+    const { raf } = installStubs({ reduced: true });
+
+    await mountAvatar({ seed: "agent-1", kind: "agent", size: 48, active: true });
+
+    expect(raf).not.toHaveBeenCalled();
+  });
+
+  it("arranca el ticker compartido solo con active", async () => {
+    const { raf } = installStubs();
+
+    await mountAvatar({ seed: "agent-1", kind: "agent", size: 48, active: true });
+
+    expect(raf).toHaveBeenCalledTimes(1);
+  });
+
+  it("redibuja cuando cambia el tema", async () => {
+    const { log } = installStubs();
+
+    await mountAvatar({ seed: "agent-1", kind: "agent", size: 48 });
+    expect(log.clearRect).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      document.documentElement.classList.add("dark");
+    });
+
+    // El MutationObserver invalida el color cacheado y el efecto vuelve a
+    // dibujar el fotograma de identidad.
+    await vi.waitFor(() => {
+      expect(log.clearRect).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/web/src/components/ui/avatar.tsx
+++ b/apps/web/src/components/ui/avatar.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useRef, useSyncExternalStore } from "react";
+
+import {
+  DISC_ALPHAS,
+  DISC_LEVELS,
+  fieldFor,
+  levelOf,
+  resolutionForSize,
+  sampleField,
+  squareLattice,
+  type AvatarKind,
+  type DiscField,
+} from "@/lib/avatar-disc";
+import { cn } from "@/lib/utils";
+
+/* ---------- suscripción al cambio de tema ---------- */
+
+let themeVersion = 0;
+const themeListeners = new Set<() => void>();
+let observer: MutationObserver | null = null;
+
+function subscribeToTheme(onChange: () => void) {
+  themeListeners.add(onChange);
+
+  if (!observer && typeof document !== "undefined") {
+    observer = new MutationObserver(() => {
+      themeVersion += 1;
+      themeListeners.forEach((listener) => listener());
+    });
+    observer.observe(document.documentElement, {
+      attributeFilter: ["class"],
+      attributes: true,
+    });
+  }
+
+  return () => {
+    themeListeners.delete(onChange);
+    if (themeListeners.size === 0) {
+      observer?.disconnect();
+      observer = null;
+    }
+  };
+}
+
+function useThemeVersion() {
+  return useSyncExternalStore(
+    subscribeToTheme,
+    () => themeVersion,
+    () => 0,
+  );
+}
+
+/* ---------- ticker compartido ---------- */
+
+type Animated = { draw: (t: number) => void; start: number };
+
+const animated = new Set<Animated>();
+let frame = 0;
+
+function startTicker() {
+  if (frame) return;
+  const step = (ts: number) => {
+    animated.forEach((entry) => {
+      if (!entry.start) entry.start = ts;
+      entry.draw((ts - entry.start) / 1000);
+    });
+    frame = animated.size ? requestAnimationFrame(step) : 0;
+  };
+  frame = requestAnimationFrame(step);
+}
+
+/* ---------- componente ---------- */
+
+type GlyphAvatarProps = {
+  /** Identificador estable: user.id o agent.id. Nunca el nombre. */
+  seed: string;
+  kind: AvatarKind;
+  /** Lado del cuadro en píxeles CSS. Por defecto 24. */
+  size?: number;
+  /** true mientras la entidad está trabajando: el campo se pone en marcha. */
+  active?: boolean;
+  /**
+   * Nombre para lectores de pantalla. Pásalo solo cuando el avatar aparezca
+   * sin el nombre al lado; si el nombre ya está en el DOM contiguo, omítelo y
+   * el avatar quedará marcado como decorativo.
+   */
+  label?: string;
+  className?: string;
+};
+
+export function GlyphAvatar({
+  seed,
+  kind,
+  size = 24,
+  active = false,
+  label,
+  className,
+}: GlyphAvatarProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const version = useThemeVersion();
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const context = canvas.getContext("2d");
+    if (!context) return;
+
+    const resolution = resolutionForSize(size);
+    const points = squareLattice(resolution);
+    const field: DiscField = fieldFor(seed);
+    const ratio = Math.min(window.devicePixelRatio || 1, 2);
+    const pixels = Math.round(size * ratio);
+
+    canvas.width = pixels;
+    canvas.height = pixels;
+
+    // Se resuelve una vez por montaje y por cambio de tema, nunca por frame.
+    const color = window.getComputedStyle(canvas).color;
+    const radius = pixels / 2;
+
+    const draw = (t: number) => {
+      context.clearRect(0, 0, pixels, pixels);
+      context.fillStyle = color;
+
+      for (const point of points) {
+        const level = levelOf(sampleField(field, point.rad, point.th, t), DISC_LEVELS);
+        const alpha = DISC_ALPHAS[level];
+        if (alpha <= 0.001) continue;
+
+        context.globalAlpha = alpha;
+        context.beginPath();
+        context.arc(
+          radius + point.x * radius * 0.94,
+          radius + point.y * radius * 0.94,
+          (point.size * radius * 0.94) / 2,
+          0,
+          Math.PI * 2,
+        );
+        context.fill();
+      }
+
+      context.globalAlpha = 1;
+    };
+
+    draw(0);
+
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (!active || reduced) return;
+
+    const entry: Animated = { draw, start: 0 };
+    animated.add(entry);
+    startTicker();
+
+    return () => {
+      animated.delete(entry);
+    };
+    // `kind` entra en las dependencias porque decide la clase de color, y el
+    // color se lee del DOM dentro de este efecto.
+  }, [seed, size, active, kind, version]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={cn(
+        "block shrink-0 select-none rounded-full",
+        kind === "agent" ? "text-primary" : "text-foreground",
+        className,
+      )}
+      style={{ height: size, width: size }}
+      aria-hidden={label ? undefined : true}
+      role={label ? "img" : undefined}
+      aria-label={label}
+    />
+  );
+}

--- a/apps/web/src/components/workspace/__tests__/workspace-account-menu.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/workspace-account-menu.test.tsx
@@ -65,6 +65,7 @@ function renderMenu(
 ) {
   const props = {
     slug: "local",
+    currentUserId: "user-1",
     currentVault,
     status: "active",
     onNavigateConnectors: vi.fn(),

--- a/apps/web/src/components/workspace/__tests__/workspace-app-chrome.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/workspace-app-chrome.test.tsx
@@ -71,7 +71,7 @@ vi.mock("@/components/workspace/workspace-sidebar", () => ({
 function renderChrome(children: React.ReactNode) {
   return render(
     <WorkspaceRuntimeProvider slug="alice" persistenceScope="alice">
-      <WorkspaceAppChrome slug="alice">
+      <WorkspaceAppChrome slug="alice" currentUserId="user-1">
         {children}
       </WorkspaceAppChrome>
     </WorkspaceRuntimeProvider>

--- a/apps/web/src/components/workspace/chat-panel.tsx
+++ b/apps/web/src/components/workspace/chat-panel.tsx
@@ -36,6 +36,7 @@ import { ChatPanelSessionHeader } from "@/components/workspace/chat-panel/sessio
 import type { SessionTabInfo } from "@/components/workspace/chat-panel/types";
 import { WorkspaceChatEmptyComposer } from "@/components/workspace/workspace-chat-empty-composer";
 import { StatusIndicator } from "@/components/workspace/bitmap-status-indicator";
+import { GlyphAvatar } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -141,13 +142,6 @@ const EMPTY_MODELS: AvailableModel[] = [];
 const EMPTY_PERMISSIONS: WorkspacePermission[] = [];
 const EMPTY_SESSION_TABS: SessionTabInfo[] = [];
 const EMPTY_SKILLS: SkillListItem[] = [];
-
-function getAgentInitials(name: string): string {
-  const parts = name.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return "?";
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-}
 
 function getAttachmentErrorMessage(error: string): string {
   switch (error) {
@@ -1458,7 +1452,12 @@ export function ChatPanel({
                         }}
                         className={cn("gap-3 rounded-md px-3 py-2", isSelected && "bg-primary/10 text-primary")}
                       >
-                        <span className={cn("flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[11px] font-semibold uppercase tracking-wide", isSelected ? "bg-primary text-primary-foreground" : "bg-foreground/10 text-foreground/70")}>{getAgentInitials(agent.displayName)}</span>
+                        <GlyphAvatar
+                          seed={agent.id}
+                          kind="agent"
+                          size={28}
+                          active={isSending && agent.id === selectedExpertId}
+                        />
                         <span className="min-w-0 flex-1 truncate text-sm">{agent.displayName}</span>
                         {isSelected ? <Check size={14} weight="bold" /> : null}
                       </DropdownMenuItem>

--- a/apps/web/src/components/workspace/workspace-account-menu.tsx
+++ b/apps/web/src/components/workspace/workspace-account-menu.tsx
@@ -12,7 +12,6 @@ import {
   Plugs,
   Plus,
   Sun,
-  UserCircle,
   Vault,
 } from '@phosphor-icons/react'
 
@@ -24,6 +23,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { GlyphAvatar } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
 import { useWorkspaceTheme } from '@/contexts/workspace-theme-context'
 import type { SyncKbResult } from '@/app/api/instances/[slug]/sync-kb/route'
@@ -54,6 +54,7 @@ type ProviderSummary = {
 
 type WorkspaceAccountMenuProps = {
   slug: string
+  currentUserId: string
   currentVault?: DesktopVaultSummary | null
   status: 'active' | 'provisioning' | 'offline'
   collapsed?: boolean
@@ -108,6 +109,7 @@ async function fetchIntegrationSummaries(slug: string): Promise<{
 
 export function WorkspaceAccountMenu({
   slug,
+  currentUserId,
   currentVault = null,
   status = 'active',
   collapsed = false,
@@ -279,10 +281,23 @@ export function WorkspaceAccountMenu({
           aria-label="Workspace account menu"
         >
           {collapsed ? (
-            <UserCircle size={18} weight="fill" className="shrink-0 text-muted-foreground" />
+            <GlyphAvatar
+              seed={currentUserId}
+              kind="human"
+              size={20}
+              className="bg-foreground/10 text-primary"
+            />
           ) : (
             <>
-              <span className="max-w-[6rem] truncate font-medium sm:max-w-none">{accountMenuLabel}</span>
+              <span className="flex min-w-0 flex-1 items-center gap-1.5">
+                <GlyphAvatar
+                  seed={currentUserId}
+                  kind="human"
+                  size={20}
+                  className="bg-foreground/10 text-primary"
+                />
+                <span className="min-w-0 max-w-[6rem] truncate font-medium sm:max-w-none">{accountMenuLabel}</span>
+              </span>
               <CaretUp
                 size={13}
                 weight="bold"

--- a/apps/web/src/components/workspace/workspace-app-chrome.tsx
+++ b/apps/web/src/components/workspace/workspace-app-chrome.tsx
@@ -18,6 +18,7 @@ import { WorkspaceSidebar } from './workspace-sidebar'
 
 type WorkspaceAppChromeProps = {
   children: ReactNode
+  currentUserId: string
   currentVault?: {
     id: string
     name: string
@@ -29,6 +30,7 @@ type WorkspaceAppChromeProps = {
 
 export function WorkspaceAppChrome({
   children,
+  currentUserId,
   currentVault = null,
   macDesktopWindowInset = false,
   slug,
@@ -183,6 +185,7 @@ export function WorkspaceAppChrome({
       accountMenu={(collapsed) => (
         <WorkspaceAccountMenu
           slug={slug}
+          currentUserId={currentUserId}
           currentVault={currentVault}
           status="active"
           collapsed={collapsed}

--- a/apps/web/src/components/workspace/workspace-chat-empty-composer.tsx
+++ b/apps/web/src/components/workspace/workspace-chat-empty-composer.tsx
@@ -11,6 +11,7 @@ import {
   Robot,
 } from '@phosphor-icons/react'
 
+import { GlyphAvatar } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -437,13 +438,6 @@ function KnowledgePanel({
   )
 }
 
-function getAgentInitials(name: string): string {
-  const parts = name.trim().split(/\s+/).filter(Boolean)
-  if (parts.length === 0) return '?'
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
-  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
-}
-
 function ExpertsPanel({
   agents,
   selected,
@@ -460,7 +454,6 @@ function ExpertsPanel({
     <ul role="none" className="max-h-72 overflow-y-auto scrollbar-custom">
       {agents.map((agent) => {
         const isSelected = selected === agent.id
-        const initials = getAgentInitials(agent.displayName)
         return (
           <li role="none" key={agent.id}>
             <button
@@ -482,17 +475,7 @@ function ExpertsPanel({
                   isSelected ? 'opacity-100' : 'opacity-0',
                 )}
               />
-              <span
-                aria-hidden="true"
-                className={cn(
-                  'flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[11px] font-semibold uppercase tracking-wide transition-colors',
-                  isSelected
-                    ? 'bg-primary text-primary-foreground'
-                    : 'bg-foreground/10 text-foreground/70 group-hover:bg-foreground/15',
-                )}
-              >
-                {initials}
-              </span>
+              <GlyphAvatar seed={agent.id} kind="agent" size={28} />
               <span className="min-w-0 flex-1">
                 <span
                   className={cn(

--- a/apps/web/src/lib/__tests__/avatar-disc.test.ts
+++ b/apps/web/src/lib/__tests__/avatar-disc.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DISC_LEVELS,
+  DISC_RESOLUTION,
+  fieldFor,
+  hashSeed,
+  levelOf,
+  resolutionForSize,
+  sampleField,
+  squareLattice,
+} from "@/lib/avatar-disc";
+
+const NAMES = [
+  "research-analyst", "content-writer", "data-engineer", "seo-specialist",
+  "customer-support", "legal-reviewer", "sales-outreach", "bug-triage",
+  "docs-curator", "finance-ops", "recruiter", "translator",
+  "qa-runner", "security-auditor", "product-manager", "brand-designer",
+  "growth-marketer", "bookkeeper", "scheduler", "knowledge-curator",
+  "slack-concierge", "email-triage", "meeting-notes", "invoice-parser",
+];
+
+/** Huella perceptual: el campo muestreado en la retícula canónica. */
+function fingerprint(seed: string): number[] {
+  const field = fieldFor(seed);
+  return squareLattice(DISC_RESOLUTION).map((p) =>
+    levelOf(sampleField(field, p.rad, p.th, 0), DISC_LEVELS),
+  );
+}
+
+function distance(a: number[], b: number[]): number {
+  const total = a.reduce((sum, value, i) => sum + Math.abs(value - b[i]), 0);
+  return total / (a.length * (DISC_LEVELS - 1));
+}
+
+describe("avatar-disc", () => {
+  it("produce el mismo campo para la misma semilla", () => {
+    expect(fieldFor("research-analyst")).toEqual(fieldFor("research-analyst"));
+    expect(fieldFor("research-analyst")).not.toEqual(fieldFor("content-writer"));
+  });
+
+  it("mantiene la retícula dentro del disco", () => {
+    for (const point of squareLattice(DISC_RESOLUTION)) {
+      expect(Math.hypot(point.x, point.y)).toBeLessThanOrEqual(1.02);
+    }
+  });
+
+  it("cuantiza siempre a un nivel válido", () => {
+    for (const v of [-5, -1, -0.3, 0, 0.3, 1, 5]) {
+      const level = levelOf(v);
+      expect(level).toBeGreaterThanOrEqual(0);
+      expect(level).toBeLessThan(DISC_LEVELS);
+    }
+  });
+
+  it("reparte los brillos sin agolparlos en el centro", () => {
+    const counts = new Array(DISC_LEVELS).fill(0);
+    let total = 0;
+
+    for (const name of NAMES) {
+      for (const level of fingerprint(name)) {
+        counts[level] += 1;
+        total += 1;
+      }
+    }
+
+    // Con contraste 2.1 los extremos suman 48,9%. Sin expandir se quedan en
+    // 14,7%, que es exactamente el fallo que este test vigila.
+    const extremes = (counts[0] + counts[DISC_LEVELS - 1]) / total;
+    expect(extremes).toBeGreaterThan(0.35);
+  });
+
+  it("mantiene los agentes distinguibles entre sí", () => {
+    const prints = NAMES.map(fingerprint);
+    let min = Infinity;
+
+    for (let i = 0; i < prints.length; i += 1) {
+      for (let j = i + 1; j < prints.length; j += 1) {
+        min = Math.min(min, distance(prints[i], prints[j]));
+      }
+    }
+
+    // El valor real es 16,5%, entre "legal-reviewer" y "docs-curator".
+    // El umbral está a la mitad para dejar margen sin volverse decorativo.
+    expect(min).toBeGreaterThan(0.08);
+  });
+
+  it("baja de detalle en las superficies pequeñas", () => {
+    expect(resolutionForSize(64)).toBe(DISC_RESOLUTION);
+    expect(resolutionForSize(24)).toBe(8);
+    // Nunca por debajo de ~1.8px por punto.
+    for (const size of [16, 20, 24, 28, 32, 48, 96]) {
+      expect(size / resolutionForSize(size)).toBeGreaterThan(1.8);
+    }
+  });
+
+  it("produce exactamente 256 puntos en la resolución canónica", () => {
+    // Valor cerrado del contrato: un disco de 18 tiene 256 puntos.
+    expect(squareLattice(DISC_RESOLUTION)).toHaveLength(256);
+  });
+
+  it("hashea con FNV-1a de 32 bits", () => {
+    // Vectores conocidos de FNV-1a. Cambiar el hash cambia el avatar de
+    // todas las entidades existentes.
+    expect(hashSeed("")).toBe(0x811c9dc5);
+    expect(hashSeed("a")).toBe(0xe40c292c);
+    expect(hashSeed("foobar")).toBe(0xbf9cf968);
+    expect(hashSeed("foobar")).not.toBe(hashSeed("Foobar"));
+  });
+
+  it("satura los niveles fuera de rango", () => {
+    // La expansión de contraste puede empujar v fuera de [-1, 1];
+    // levelOf debe aplastar contra los extremos, nunca salirse.
+    expect(levelOf(-2)).toBe(0);
+    expect(levelOf(-1)).toBe(0);
+    expect(levelOf(2)).toBe(DISC_LEVELS - 1);
+    expect(levelOf(1)).toBe(DISC_LEVELS - 1);
+  });
+
+  it("cumple el reparto de brillos verificado (21/23/28/28)", () => {
+    const counts = new Array(DISC_LEVELS).fill(0);
+    let total = 0;
+
+    for (const name of NAMES) {
+      for (const level of fingerprint(name)) {
+        counts[level] += 1;
+        total += 1;
+      }
+    }
+
+    // Medido sobre los 24 nombres: 20,6 / 22,8 / 28,3 / 28,3. Una
+    // desviación de ±3 puntos por nivel delata un cambio del contrato.
+    const expected = [0.21, 0.23, 0.28, 0.28];
+    for (let level = 0; level < DISC_LEVELS; level += 1) {
+      expect(counts[level] / total).toBeGreaterThan(expected[level] - 0.03);
+      expect(counts[level] / total).toBeLessThan(expected[level] + 0.03);
+    }
+  });
+
+  it("deja los brillos extremos en el 48,9% medido", () => {
+    const counts = new Array(DISC_LEVELS).fill(0);
+    let total = 0;
+
+    for (const name of NAMES) {
+      for (const level of fingerprint(name)) {
+        counts[level] += 1;
+        total += 1;
+      }
+    }
+
+    // Con contraste 2.1 los extremos suman 48,9%. Sin expandir quedan en
+    // 14,7% y con más contraste se disparan: el margen vigila ambos lados.
+    const extremes = (counts[0] + counts[DISC_LEVELS - 1]) / total;
+    expect(extremes).toBeGreaterThan(0.45);
+    expect(extremes).toBeLessThan(0.53);
+  });
+
+  it("deja la distancia mínima entre agentes en el 16,5% medido", () => {
+    const prints = NAMES.map(fingerprint);
+    let min = Infinity;
+
+    for (let i = 0; i < prints.length; i += 1) {
+      for (let j = i + 1; j < prints.length; j += 1) {
+        min = Math.min(min, distance(prints[i], prints[j]));
+      }
+    }
+
+    // El valor real es 16,54% (entre "legal-reviewer" y "docs-curator").
+    // Ventana estrecha: si baja, los discos se parecen demasiado; si sube,
+    // alguien tocó el muestreo del campo.
+    expect(min).toBeGreaterThan(0.16);
+    expect(min).toBeLessThan(0.17);
+  });
+
+  it("anima el campo con el tiempo sin tocar el fotograma de identidad", () => {
+    const field = fieldFor("research-analyst");
+    const point = squareLattice(DISC_RESOLUTION)[0];
+
+    const identity = sampleField(field, point.rad, point.th, 0);
+    expect(sampleField(field, point.rad, point.th, 0)).toBe(identity);
+
+    // Con t > 0 el campo se mueve (los w no son cero por construcción).
+    let moved = false;
+    for (const p of squareLattice(DISC_RESOLUTION)) {
+      if (sampleField(field, p.rad, p.th, 1.7) !== sampleField(field, p.rad, p.th, 0)) {
+        moved = true;
+        break;
+      }
+    }
+    expect(moved).toBe(true);
+  });
+});

--- a/apps/web/src/lib/avatar-disc.ts
+++ b/apps/web/src/lib/avatar-disc.ts
@@ -1,0 +1,190 @@
+const TAU = Math.PI * 2;
+
+/** Resolución canónica: puntos de diámetro del disco. */
+export const DISC_RESOLUTION = 18;
+
+/** Niveles de brillo del punto, del apagado al encendido. */
+export const DISC_LEVELS = 4;
+
+/**
+ * Expansión de contraste aplicada antes de cuantizar.
+ *
+ * El campo es una suma de cosenos, así que sus valores tienden a una
+ * gaussiana centrada. Sin expandir, el reparto de brillos es 7/36/49/7 -- el
+ * 85% de los puntos en los dos niveles centrales -- y los discos salen
+ * lavados y parecidos entre sí. Con 2.1 el reparto queda en 21/23/28/28 y la
+ * distancia mínima entre agentes sube del 9,6% al 16,5%.
+ */
+export const DISC_CONTRAST = 2.1;
+
+/** Opacidad de cada nivel de brillo. */
+export const DISC_ALPHAS = [0.06, 0.28, 0.55, 0.86] as const;
+
+export type AvatarKind = "agent" | "human";
+
+export type DiscField = {
+  m1: number; m2: number; m4: number;
+  freq: number; twist: number;
+  phi1: number; phi2: number; psi: number;
+  a1: number; a2: number; a3: number; a4: number;
+  falloff: number; bias: number;
+  w1: number; w3: number; w4: number;
+  norm: number;
+};
+
+export type LatticePoint = {
+  /** Posición en un disco de radio 1 centrado en el origen. */
+  x: number;
+  y: number;
+  /** Radio normalizado 0..1 y ángulo en radianes. */
+  rad: number;
+  th: number;
+  /** Diámetro del punto, en las mismas unidades que x/y. */
+  size: number;
+};
+
+/** FNV-1a de 32 bits. */
+export function hashSeed(seed: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < seed.length; i += 1) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/** mulberry32: flujo determinista de números a partir del hash. */
+function rngFrom(seedInt: number): () => number {
+  let a = seedInt >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Deriva el campo de una identidad.
+ *
+ * IMPORTANTE: el orden de las llamadas a r() es parte del contrato. Reordenar
+ * dos líneas cambia el avatar de todas las entidades existentes. Si alguna vez
+ * hay que tocar esto, es un cambio con migración visual, no un refactor.
+ */
+export function fieldFor(seed: string): DiscField {
+  const r = rngFrom(hashSeed(seed));
+
+  // Órdenes angulares enteros: de ahí sale la simetría rotacional sin
+  // necesidad de imponerla.
+  const m1 = 2 + Math.floor(r() * 7);
+  const m2 = 1 + Math.floor(r() * 5);
+  const m4 = 1 + Math.floor(r() * 6);
+
+  const freq = 1.2 + r() * 3.4;          // anillos por unidad de radio
+  const twist = (r() * 2 - 1) * 4.5;     // sentido y fuerza de la espiral
+
+  const phi1 = r() * TAU;
+  const phi2 = r() * TAU;
+  const psi = r() * TAU;
+
+  // Reparto de energía entre los cuatro términos.
+  const a1 = 0.35 + r() * 0.75;
+  const a2 = r() * 0.65;
+  const a3 = 0.2 + r() * 0.8;
+  const a4 = r() * 0.8;
+
+  // La energía cae hacia el borde: el disco tiene centro, no es un tapiz
+  // recortado en redondo.
+  const falloff = 0.25 + r() * 0.85;
+  const bias = -0.35 + r() * 0.7;
+
+  // Velocidades de animación con signo: unos giran a derechas y otros no.
+  const w1 = (r() < 0.5 ? -1 : 1) * (0.15 + r() * 0.5);
+  const w3 = (r() < 0.5 ? -1 : 1) * (0.3 + r() * 0.9);
+  const w4 = (r() < 0.5 ? -1 : 1) * (0.2 + r() * 0.6);
+
+  return {
+    m1, m2, m4, freq, twist, phi1, phi2, psi,
+    a1, a2, a3, a4, falloff, bias, w1, w3, w4,
+    norm: a1 + a2 + a3 + a4 || 1,
+  };
+}
+
+/**
+ * Evalúa el campo en un punto.
+ *
+ *   v(r, θ) = A1·cos(m1·θ + φ1)        armónico angular  -> pétalos
+ *           + A2·cos(m2·θ + φ2)        segundo armónico  -> rompe la simetría
+ *           + A3·cos(2π·f·r + ψ)       término radial    -> anillos
+ *           + A4·cos(m4·θ + k·r·2π)    término acoplado  -> espiral
+ *
+ * `t` es el tiempo en segundos; con t = 0 se obtiene el fotograma de
+ * identidad, que es el que se dibuja en reposo.
+ */
+export function sampleField(f: DiscField, rad: number, th: number, t: number): number {
+  let v =
+    f.a1 * Math.cos(f.m1 * th + f.phi1 + t * f.w1) +
+    f.a2 * Math.cos(f.m2 * th + f.phi2 - t * f.w1 * 0.6) +
+    f.a3 * Math.cos(TAU * f.freq * rad + f.psi + t * f.w3) +
+    f.a4 * Math.cos(f.m4 * th + f.twist * rad * TAU + t * f.w4);
+
+  v = v / f.norm;                        // -1..1
+  v *= 1 - f.falloff * rad * rad;        // caída hacia el borde
+  return v + f.bias;
+}
+
+/** Cuantiza el valor del campo a un nivel de brillo. */
+export function levelOf(
+  v: number,
+  levels: number = DISC_LEVELS,
+  gain: number = DISC_CONTRAST,
+): number {
+  let n = (v + 1) / 2;
+  n = (n - 0.5) * gain + 0.5;
+  if (n < 0) n = 0;
+  else if (n > 1) n = 1;
+  const l = Math.floor(n * levels);
+  return l >= levels ? levels - 1 : l;
+}
+
+const latticeCache = new Map<number, readonly LatticePoint[]>();
+
+/**
+ * Retícula cuadrada de n×n recortada al círculo. Los puntos fuera del disco
+ * sencillamente no existen: no son puntos apagados.
+ */
+export function squareLattice(n: number): readonly LatticePoint[] {
+  const cached = latticeCache.get(n);
+  if (cached) return cached;
+
+  const step = 2 / n;
+  const size = step * 0.78;              // el hueco entre puntos es el 22%
+  const points: LatticePoint[] = [];
+
+  for (let gy = 0; gy < n; gy += 1) {
+    for (let gx = 0; gx < n; gx += 1) {
+      const x = -1 + step * (gx + 0.5);
+      const y = -1 + step * (gy + 0.5);
+      const rad = Math.sqrt(x * x + y * y);
+      if (rad > 1.02) continue;
+      points.push({ x, y, rad: Math.min(rad, 1), th: Math.atan2(y, x), size });
+    }
+  }
+
+  latticeCache.set(n, points);
+  return points;
+}
+
+/**
+ * Nivel de detalle. 18 puntos es la resolución canónica, pero por debajo de
+ * ~1.8px por punto el campo se vuelve papilla, así que las superficies
+ * pequeñas bajan de detalle. La identidad no cambia: es el mismo campo
+ * muestreado más grueso.
+ */
+export function resolutionForSize(px: number): number {
+  if (px >= 44) return DISC_RESOLUTION;
+  if (px >= 32) return 14;
+  if (px >= 26) return 12;
+  return 8;
+}


### PR DESCRIPTION
- Add hash-seeded continuous disc field sampling and responsive lattices
- Render avatars across agent cards, team pages, and workspace chat
- Add component, sampling, and end-to-end avatar coverage