### PR TITLE
fix(workspace): re-hydrate session messages after an accepted prompt

### DIFF
--- a/apps/web/src/hooks/__tests__/use-workspace-message-actions.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-workspace-message-actions.test.tsx
@@ -40,6 +40,7 @@ describe("useWorkspaceMessageActions", () => {
     const commitStore = (updater: ChatStore | ((prev: ChatStore) => ChatStore)) => {
       current = typeof updater === "function" ? updater(current) : updater;
     };
+    const refreshMessages = vi.fn(async () => undefined);
 
     const hook = renderHook(() =>
       useWorkspaceMessageActions({
@@ -49,6 +50,7 @@ describe("useWorkspaceMessageActions", () => {
         createSession: vi.fn(),
         models: [],
         primaryAgentId: null,
+        refreshMessages,
         sessionSelectionStateRef: { current: {} },
         getStore,
         commitStore,
@@ -56,12 +58,12 @@ describe("useWorkspaceMessageActions", () => {
       }),
     );
 
-    return { hook, getStore, commitStore };
+    return { hook, getStore, commitStore, refreshMessages };
   }
 
   it("does not insert a local user message; the bus is the source of truth", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => new Response("", { status: 202 })));
-    const { hook, getStore } = renderActions();
+    const { hook, getStore, refreshMessages } = renderActions();
 
     let sent = false;
     await act(async () => {
@@ -71,6 +73,9 @@ describe("useWorkspaceMessageActions", () => {
     expect(sent).toBe(true);
     expect(getStore().messages.s1 ?? []).toHaveLength(0);
     expect(getStore().sessionStatus.s1).toBe("busy");
+    // The accepted prompt asks the server for the persisted messages instead
+    // of grafting a local bubble; missed bus events cannot blank the chat.
+    expect(refreshMessages).toHaveBeenCalledWith("s1");
   });
 
   it("keeps sessionStatus busy when prompt returns 409", async () => {

--- a/apps/web/src/hooks/__tests__/use-workspace.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-workspace.test.tsx
@@ -572,6 +572,129 @@ vi.stubGlobal(
     });
   });
 
+  it("re-hydrates messages after an accepted prompt even when its events were missed", async () => {
+    // Regression: the prompt POST travels out-of-band while the event pipe may
+    // not be forwarding (cold route, reconnect backoff). Runtime events
+    // emitted in that window are never re-delivered, so without a post-send
+    // hydration the conversation stayed empty forever.
+    let promptAccepted = false;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input) === "/api/u/alice/agents") {
+          return {
+            ok: true,
+            json: async () => ({
+              agents: [
+                {
+                  id: "assistant",
+                  displayName: "Assistant",
+                  model: "openai/gpt-5.4",
+                  isPrimary: true,
+                },
+              ],
+            }),
+          };
+        }
+
+        if (String(input) === "/api/u/alice/providers") {
+          return {
+            ok: true,
+            json: async () => ({
+              providers: [{ providerId: "openai", status: "enabled" }],
+            }),
+          };
+        }
+
+        // Hanging event pipe: connected, but no runtime events ever arrive.
+        if (String(input) === "/api/w/alice/events") {
+          return {
+            ok: true,
+            body: {
+              getReader() {
+                return {
+                  read: () => new Promise<ReadableStreamReadResult<Uint8Array>>(() => {}),
+                  cancel: async () => undefined,
+                };
+              },
+            },
+          };
+        }
+
+        if (String(input) === "/api/w/alice/chat/prompt") {
+          void init;
+          promptAccepted = true;
+          return {
+            ok: true,
+            status: 202,
+            json: async () => ({ ok: true }),
+          };
+        }
+
+        throw new Error(`Unexpected fetch: ${String(input)}`);
+      })
+    );
+
+    opencodeMocks.listMessagesAction.mockImplementation(async (_slug: string, sessionId: string) => {
+      if (sessionId !== "s1" || !promptAccepted) {
+        return { ok: true, messages: [] };
+      }
+
+      return {
+        ok: true,
+        messages: [
+          {
+            id: "server-m1",
+            sessionId: "s1",
+            role: "user",
+            content: "hello",
+            timestamp: "now",
+            parts: [],
+            pending: false,
+          },
+          {
+            id: "server-m2",
+            sessionId: "s1",
+            role: "assistant",
+            content: "E2E_OK: hello",
+            timestamp: "now",
+            agentId: "assistant",
+            model: { providerId: "openai", modelId: "gpt-5.2" },
+            parts: [],
+            pending: false,
+          },
+        ],
+      };
+    });
+
+    const { result } = renderWorkspaceHook(
+      () => useWorkspace({ slug: "alice", pollInterval: 0 }),
+      undefined,
+      { initialSessionId: "s1" }
+    );
+
+    await waitFor(() => {
+      expect(result.current.activeSessionId).toBe("s1");
+      expect(result.current.messages).toHaveLength(0);
+    });
+
+    let accepted = false;
+    await act(async () => {
+      accepted = await result.current.sendMessage("hello");
+    });
+
+    expect(accepted).toBe(true);
+    expect(promptAccepted).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.messages.map((message: WorkspaceMessage) => message.id)).toEqual([
+        "server-m1",
+        "server-m2",
+      ]);
+    });
+  });
+
   it("restores idle when prompt fails (502) and never inserts a local user message", async () => {
     let promptCalls = 0;
 

--- a/apps/web/src/hooks/workspace/use-workspace-composed.ts
+++ b/apps/web/src/hooks/workspace/use-workspace-composed.ts
@@ -146,6 +146,7 @@ export function useWorkspace({
       createSession,
       models,
       primaryAgentId,
+      refreshMessages,
       sessionSelectionStateRef,
       getStore,
       commitStore,

--- a/apps/web/src/hooks/workspace/use-workspace-message-actions.ts
+++ b/apps/web/src/hooks/workspace/use-workspace-message-actions.ts
@@ -22,6 +22,7 @@ type UseWorkspaceMessageActionsOptions = {
   createSession: (title?: string) => Promise<WorkspaceSession | null>;
   models: AvailableModel[];
   primaryAgentId: string | null;
+  refreshMessages: (sessionIdOverride?: string) => Promise<void>;
   sessionSelectionStateRef: MutableRefObject<Record<string, SessionSelectionState>>;
   getStore: () => ChatStore;
   commitStore: (store: SetStateAction<ChatStore>) => void;
@@ -52,6 +53,7 @@ export function useWorkspaceMessageActions({
   createSession,
   models,
   primaryAgentId,
+  refreshMessages,
   sessionSelectionStateRef,
   getStore,
   commitStore,
@@ -151,6 +153,13 @@ export function useWorkspaceMessageActions({
         return false;
       }
 
+      // The prompt travels out-of-band while the event pipe may still be
+      // connecting or mid-reconnect; runtime events emitted in that window are
+      // never re-delivered, and no other trigger refreshes messages after a
+      // send. Re-hydrating once the prompt is accepted keeps the sent message
+      // visible even when its events were missed.
+      void refreshMessages(sessionId);
+
       return true;
     },
     [
@@ -162,6 +171,7 @@ export function useWorkspaceMessageActions({
       models,
       onStartingNewSessionChange,
       primaryAgentId,
+      refreshMessages,
       sessionSelectionStateRef,
       slug,
     ],


### PR DESCRIPTION
## Root cause of the flaky Desktop chat-pdf E2E (and a real product bug)

**Investigation chain** (from PR #490's failing `Desktop - E2E Smoke`):

1. The client sends prompts **out-of-band** (`POST /api/w/{slug}/chat/prompt`) while messages reach the UI only through the SSE event pipe.
2. The `/events` BFF route is a **per-client pipe with no replay** ("the client reconnects on its own; the BFF never retries") and the runtime broadcasts to **current subscribers only**.
3. The client hydrates messages **only** on bus connect/reconnect (`hydrateOnConnect`) or on active-session change (`useWorkspaceActiveSessionEffects`) — and `sendMessage` never inserts the user message locally. The polling effect refreshes sessions, never messages.
4. So when a send lands in an event-pipe gap, its events are lost forever and **nothing ever re-hydrates**: the conversation stays permanently blank.

**Why CI hit it and local runs didn't:** on a cold `macos-14` runner, `next dev` compiles the heavy `/events` route on demand; the prompt completed inside that compile window, so the runtime broadcast had no subscriber. Warm machines (and the CI retry, thanks to the `.next` compile cache) connect in milliseconds → 10/10 green locally, deterministic-ish failure on cold CI. Verified by reproducing the full desktop E2E locally.

**Fix (minimal, at the correct seam):** once the prompt POST is accepted, re-hydrate the session messages (`refreshMessages(sessionId)`). Idempotent merge when events did arrive; self-healing when they were missed. This also fixes the same blank-conversation window in production (reconnect backoff is 1s→30s).

## Verification
- New regression test fails without the fix (timeout waiting for messages — the exact symptom) and passes with it
- `pnpm test`: 5272 passed (+1)
- Desktop E2E locally: 3/3 green with the fix
- `pnpm lint`: 0 errors; `tsc`: no new errors
- `scripts/check-podman-images.sh`: passed