### PR TITLE
feat(workspace): push live proposal badge updates over SSE

### DIFF
--- a/apps/web/src/app/api/internal/learning/proposals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/internal/learning/proposals/__tests__/route.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   createKnowledgeReviewChange: vi.fn(),
   findLearningRunForUser: vi.fn(),
   getInternalLearningContext: vi.fn(),
+  publishWorkspaceEvent: vi.fn(),
 }))
 
 vi.mock('@/app/api/internal/learning/auth', () => ({ getInternalLearningContext: mocks.getInternalLearningContext }))
@@ -13,6 +14,10 @@ vi.mock('@/lib/learning/service', () => ({
   captureKnowledgeReviewBase: mocks.captureKnowledgeReviewBase,
   createKnowledgeReviewChange: mocks.createKnowledgeReviewChange,
   findLearningRunForUser: mocks.findLearningRunForUser,
+}))
+vi.mock('@/lib/runtime/workspace-broadcast', () => ({ publishWorkspaceEvent: mocks.publishWorkspaceEvent }))
+vi.mock('@/lib/runtime/workspace-broadcast-events', () => ({
+  KNOWLEDGE_PROPOSALS_CHANGED_EVENT: 'knowledge.proposals_changed',
 }))
 
 import { POST } from '../route'
@@ -91,6 +96,38 @@ describe('POST /api/internal/learning/proposals', () => {
       confidence: 0.8,
       evidence: { quote: 'Use concise answers' },
     }))
+    expect(mocks.publishWorkspaceEvent).toHaveBeenCalledWith('user-1', {
+      type: 'knowledge.proposals_changed',
+    })
+  })
+
+  it('does not publish a notification when validation fails', async () => {
+    const response = await POST(makeRequest({ ...validBody, kbPath: '' }))
+
+    expect(response.status).toBe(400)
+    expect(mocks.publishWorkspaceEvent).not.toHaveBeenCalled()
+  })
+
+  it('does not publish a notification when base capture fails', async () => {
+    mocks.captureKnowledgeReviewBase.mockResolvedValue({ ok: false, error: 'invalid_request' })
+
+    const response = await POST(makeRequest(validBody))
+
+    expect(response.status).toBe(400)
+    expect(mocks.publishWorkspaceEvent).not.toHaveBeenCalled()
+  })
+
+  it('does not publish a notification when persistence fails', async () => {
+    mocks.findLearningRunForUser.mockResolvedValue({ id: 'run-2', regenerationChangeId: null })
+    mocks.createKnowledgeReviewChange.mockResolvedValue({
+      ok: false,
+      error: 'regeneration_source_not_rebaseable',
+    })
+
+    const response = await POST(makeRequest({ ...validBody, runId: 'run-2' }))
+
+    expect(response.status).toBe(409)
+    expect(mocks.publishWorkspaceEvent).not.toHaveBeenCalled()
   })
 
   it('attributes to the tool-provided agent when no run id is present', async () => {

--- a/apps/web/src/app/api/internal/learning/proposals/route.ts
+++ b/apps/web/src/app/api/internal/learning/proposals/route.ts
@@ -7,6 +7,8 @@ import {
   findLearningRunForUser,
 } from '@/lib/learning/service'
 import { parseProposalRequest } from '@/lib/learning/validation'
+import { publishWorkspaceEvent } from '@/lib/runtime/workspace-broadcast'
+import { KNOWLEDGE_PROPOSALS_CHANGED_EVENT } from '@/lib/runtime/workspace-broadcast-events'
 import { SYSTEM_KNOWLEDGE_CURATOR_AGENT_ID } from '@/lib/workspace-config'
 
 // A learning run is always executed by the injected system curator, so runId
@@ -70,6 +72,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const status = result.error === 'regeneration_source_not_rebaseable' ? 409 : 400
     return NextResponse.json({ error: result.error }, { status })
   }
+
+  publishWorkspaceEvent(context.userId, { type: KNOWLEDGE_PROPOSALS_CHANGED_EVENT })
 
   return NextResponse.json({ proposal: result.change })
 }

--- a/apps/web/src/app/api/w/[slug]/events/__tests__/route.test.ts
+++ b/apps/web/src/app/api/w/[slug]/events/__tests__/route.test.ts
@@ -10,6 +10,12 @@ const mocks = vi.hoisted(() => ({
   instanceService: { findCredentialsBySlug: vi.fn() },
   decryptPassword: vi.fn(() => 'secret'),
   getInstanceUrl: vi.fn(() => 'http://test-slug:3000'),
+  subscribeWorkspaceEvents: vi.fn(),
+}))
+
+const broadcast = vi.hoisted(() => ({
+  listener: null as ((event: { type: string }) => void) | null,
+  unsubscribed: false,
 }))
 
 vi.mock('@/lib/runtime/capabilities', () => ({ getRuntimeCapabilities: mocks.getRuntimeCapabilities }))
@@ -23,6 +29,13 @@ vi.mock('@/lib/runtime/desktop/token', () => ({
 vi.mock('@/lib/services', () => ({ instanceService: mocks.instanceService }))
 vi.mock('@/lib/spawner/crypto', () => ({ decryptPassword: mocks.decryptPassword }))
 vi.mock('@/lib/opencode/client', () => ({ getInstanceUrl: mocks.getInstanceUrl }))
+vi.mock('@/lib/runtime/workspace-broadcast', () => ({
+  subscribeWorkspaceEvents: mocks.subscribeWorkspaceEvents,
+  publishWorkspaceEvent: vi.fn(),
+}))
+vi.mock('@/lib/runtime/workspace-broadcast-events', () => ({
+  KNOWLEDGE_PROPOSALS_CHANGED_EVENT: 'knowledge.proposals_changed',
+}))
 
 import { GET } from '../route'
 
@@ -60,6 +73,16 @@ describe('GET /api/w/[slug]/events', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useRealTimers()
+    broadcast.listener = null
+    broadcast.unsubscribed = false
+    mocks.subscribeWorkspaceEvents.mockImplementation(
+      (_userId: string, listener: (event: { type: string }) => void) => {
+        broadcast.listener = listener
+        return () => {
+          broadcast.unsubscribed = true
+        }
+      },
+    )
     mocks.getSession.mockResolvedValue({
       user: { id: 'u1', email: 'alice@test.com', slug: 'alice', role: 'USER' },
       sessionId: 's1',
@@ -243,5 +266,72 @@ describe('GET /api/w/[slug]/events', () => {
     const res = await GET(new NextRequest('http://localhost/api/w/alice/events'), params())
     const body = await readAll(res)
     expect(body).toContain('session.idle')
+  })
+
+  it('injects broker events for the authenticated user into the pipe', async () => {
+    let upstreamController: ReadableStreamDefaultController<Uint8Array> | null = null
+    const upstream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        upstreamController = controller
+      },
+    })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(upstream)))
+    const decoder = new TextDecoder()
+
+    const res = await GET(new NextRequest('http://localhost/api/w/alice/events'), params())
+    const reader = res.body?.getReader()
+    expect(reader).toBeTruthy()
+    expect(mocks.subscribeWorkspaceEvents).toHaveBeenCalledWith('u1', expect.any(Function))
+
+    const injectedRead = reader!.read()
+    broadcast.listener?.({ type: 'knowledge.proposals_changed' })
+    const injected = await injectedRead
+    expect(decoder.decode(injected.value)).toBe(
+      `data: ${JSON.stringify({ type: 'knowledge.proposals_changed' })}\n\n`,
+    )
+
+    // Upstream OpenCode frames keep flowing unchanged next to injections.
+    const opencodeEvent = JSON.stringify({
+      type: 'session.status',
+      properties: { sessionID: 's1', status: { type: 'busy' } },
+    })
+    upstreamController?.enqueue(new TextEncoder().encode(`data: ${opencodeEvent}\n\n`))
+    const redispatched = await reader!.read()
+    expect(decoder.decode(redispatched.value)).toBe(`data: ${opencodeEvent}\n\n`)
+    vi.unstubAllGlobals()
+  })
+
+  it('unsubscribes the broadcast listener when the browser disconnects', async () => {
+    const pendingBody = new ReadableStream<Uint8Array>({
+      start() { /* never enqueues or closes */ },
+    })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(pendingBody)))
+
+    const controller = new AbortController()
+    await GET(
+      new NextRequest('http://localhost/api/w/alice/events', { signal: controller.signal }),
+      params(),
+    )
+    expect(broadcast.unsubscribed).toBe(false)
+
+    controller.abort()
+    await vi.waitFor(() => {
+      expect(broadcast.unsubscribed).toBe(true)
+    })
+    vi.unstubAllGlobals()
+  })
+
+  it('unsubscribes the broadcast listener when the downstream cancels the body', async () => {
+    const pendingBody = new ReadableStream<Uint8Array>({
+      start() { /* never enqueues or closes */ },
+    })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(pendingBody)))
+
+    const res = await GET(new NextRequest('http://localhost/api/w/alice/events'), params())
+    expect(broadcast.unsubscribed).toBe(false)
+
+    await res.body?.cancel()
+    expect(broadcast.unsubscribed).toBe(true)
+    vi.unstubAllGlobals()
   })
 })

--- a/apps/web/src/app/api/w/[slug]/events/route.ts
+++ b/apps/web/src/app/api/w/[slug]/events/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 
 import { getInstanceUrl } from '@/lib/opencode/client'
 import { withAuth } from '@/lib/runtime/with-auth'
+import { subscribeWorkspaceEvents } from '@/lib/runtime/workspace-broadcast'
 import { instanceService } from '@/lib/services'
 import { decryptPassword } from '@/lib/spawner/crypto'
 import { INITIAL_SSE_PARSE_STATE, parseSseChunk } from '@/lib/sse-parser'
@@ -24,7 +25,7 @@ function jsonErrorResponse(status: number, error: string) {
  */
 export const GET = withAuth<unknown, { slug: string }>(
   { csrf: false },
-  async (request, { slug }) => {
+  async (request, { slug, user }) => {
     const instance = await instanceService.findCredentialsBySlug(slug)
 
     if (!instance || !instance.serverPassword || instance.status !== 'running') {
@@ -67,6 +68,10 @@ export const GET = withAuth<unknown, { slug: string }>(
     const encoder = new TextEncoder()
     const reader = upstream.body.getReader()
 
+    // Set inside start() once the broadcast listener is attached; cancel() can
+    // then release it even when start()'s close path never ran.
+    let unsubscribeBroadcast: (() => void) | null = null
+
     const stream = new ReadableStream({
       async start(controller) {
         const decoder = new TextDecoder()
@@ -77,6 +82,8 @@ export const GET = withAuth<unknown, { slug: string }>(
           if (closed) return
           closed = true
           clearInterval(heartbeat)
+          unsubscribeBroadcast?.()
+          unsubscribeBroadcast = null
           // Release the upstream connection: the browser is gone or the pipe
           // ended. This aborts only this /event fetch, never the OpenCode
           // session itself.
@@ -92,6 +99,19 @@ export const GET = withAuth<unknown, { slug: string }>(
             close()
           }
         }, HEARTBEAT_INTERVAL_MS)
+
+        // Inject workspace-level notifications for this user into the pipe,
+        // shaped exactly like re-dispatched OpenCode frames so the client
+        // parser is unchanged. Delivery is best-effort: a closed or errored
+        // stream only closes this pipe, it never breaks the publishing side.
+        unsubscribeBroadcast = subscribeWorkspaceEvents(user.id, (event) => {
+          if (closed) return
+          try {
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`))
+          } catch {
+            close()
+          }
+        })
 
         request.signal.addEventListener('abort', close, { once: true })
 
@@ -117,7 +137,10 @@ export const GET = withAuth<unknown, { slug: string }>(
         }
       },
       cancel() {
-        // Downstream cancelled: release the upstream /event fetch.
+        // Downstream cancelled: release the upstream /event fetch and stop
+        // receiving broadcasts for this user.
+        unsubscribeBroadcast?.()
+        unsubscribeBroadcast = null
         upstreamController.abort()
       },
     })

--- a/apps/web/src/hooks/__tests__/use-workspace-event-bus.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-workspace-event-bus.test.tsx
@@ -84,6 +84,8 @@ describe("useWorkspaceEventBus", () => {
     const refreshDiffs = options.refreshDiffs ?? vi.fn();
     const refreshFiles = options.refreshFiles ?? vi.fn(async () => undefined);
     const onBackgroundSessionIdle = options.onBackgroundSessionIdle ?? vi.fn();
+    const onKnowledgeProposalsChanged =
+      options.onKnowledgeProposalsChanged ?? vi.fn();
     const hook = renderHook(() =>
       useWorkspaceEventBus({
         slug: "alice",
@@ -92,9 +94,16 @@ describe("useWorkspaceEventBus", () => {
         refreshDiffs,
         refreshFiles,
         onBackgroundSessionIdle,
+        onKnowledgeProposalsChanged,
       }),
     );
-    return { hook, refreshDiffs, refreshFiles, onBackgroundSessionIdle };
+    return {
+      hook,
+      refreshDiffs,
+      refreshFiles,
+      onBackgroundSessionIdle,
+      onKnowledgeProposalsChanged,
+    };
   }
 
   async function flush() {
@@ -399,6 +408,115 @@ describe("useWorkspaceEventBus", () => {
     });
     expect(refreshDiffs).toHaveBeenCalledTimes(1);
     expect(refreshFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces a knowledge.proposals_changed burst into one callback without touching the store", async () => {
+    const stream = createEventStream();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => sseResponse(stream)),
+    );
+
+    const { hook, onKnowledgeProposalsChanged } = renderBus({
+      onKnowledgeProposalsChanged: vi.fn(),
+    });
+    await flush();
+
+    const storeBefore = hook.result.current.store;
+    await act(async () => {
+      stream.sendEvent({ type: "knowledge.proposals_changed" });
+      stream.sendEvent({ type: "knowledge.proposals_changed" });
+      stream.sendEvent({ type: "knowledge.proposals_changed" });
+      await vi.advanceTimersByTimeAsync(499);
+    });
+    expect(onKnowledgeProposalsChanged).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(onKnowledgeProposalsChanged).toHaveBeenCalledTimes(1);
+
+    // The notification never reaches the reducer: no session status, messages,
+    // or permissions state may change because of it.
+    expect(hook.result.current.store.sessionStatus).toEqual({});
+    expect(hook.result.current.store.messages.s1 ?? []).toEqual([]);
+    expect(hook.result.current.store.permissions).toEqual({});
+    expect(hook.result.current.store).toBe(storeBefore);
+  });
+
+  it("fires the knowledge proposals callback on reconnect and keeps reducing runtime events", async () => {
+    const first = createEventStream();
+    const second = createEventStream();
+    let fetchCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        fetchCalls += 1;
+        return sseResponse(fetchCalls === 1 ? first : second);
+      }),
+    );
+
+    const { hook, onKnowledgeProposalsChanged } = renderBus({
+      onKnowledgeProposalsChanged: vi.fn(),
+    });
+    await flush();
+    // The initial connect schedules one deferred count refresh.
+    expect(opencodeMocks.listMessagesAction).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      first.end();
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    // Connect-1's debounce fired, and the reconnect hydrated again.
+    expect(onKnowledgeProposalsChanged).toHaveBeenCalledTimes(1);
+    expect(onKnowledgeProposalsChanged).not.toHaveBeenCalledWith(expect.anything());
+    expect(opencodeMocks.listMessagesAction).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      second.sendEvent(busyEvent("s1"));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    // Runtime events are unaffected by the notification pipeline.
+    expect(isSending(hook.result.current.store, "s1")).toBe(true);
+  });
+
+  it("refreshes the pending count when a notification lands mid-conversation without disturbing streaming parts", async () => {
+    const stream = createEventStream();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => sseResponse(stream)),
+    );
+
+    const { hook, onKnowledgeProposalsChanged } = renderBus({
+      onKnowledgeProposalsChanged: vi.fn(),
+    });
+    await flush();
+
+    await act(async () => {
+      stream.sendEvent(busyEvent("s1"));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await act(async () => {
+      stream.sendEvent({ type: "knowledge.proposals_changed" });
+      stream.sendEvent({
+        type: "message.part.updated",
+        properties: {
+          part: { id: "p1", type: "text", text: "Hola", messageID: "m1", sessionID: "s1" },
+        },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Streaming continues normally while the badge refresh is still debounced.
+    expect(isSending(hook.result.current.store, "s1")).toBe(true);
+    expect(onKnowledgeProposalsChanged).not.toHaveBeenCalled();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    // The notification burst coalesced with the still-pending connect refresh:
+    // a single fetch ran after everything settled.
+    expect(onKnowledgeProposalsChanged).toHaveBeenCalledTimes(1);
   });
 
   it("fires onBackgroundSessionIdle when a non-active session turns idle", async () => {

--- a/apps/web/src/hooks/workspace/use-workspace-composed.ts
+++ b/apps/web/src/hooks/workspace/use-workspace-composed.ts
@@ -44,7 +44,8 @@ export function useWorkspace({
 }: UseWorkspaceOptions): UseWorkspaceReturn {
   // Connection + instance lifecycle + sessions come from the layout-level
   // runtime provider so chat ↔ explorer navigation does not re-establish them.
-  const { connection, isConnected, sessionsHook } = useWorkspaceRuntime();
+  const { connection, isConnected, refreshKnowledgePendingCount, sessionsHook } =
+    useWorkspaceRuntime();
 
   const files = useWorkspaceFiles(slug, workspaceAgentEnabled);
   const diffsHook = useWorkspaceDiffs(
@@ -97,6 +98,7 @@ export function useWorkspace({
     refreshFiles: files.refreshFiles,
     syncRuntimeMetadataForSession,
     onBackgroundSessionIdle: markSessionCompleted,
+    onKnowledgeProposalsChanged: refreshKnowledgePendingCount,
   });
   const {
     store,

--- a/apps/web/src/hooks/workspace/use-workspace-event-bus.ts
+++ b/apps/web/src/hooks/workspace/use-workspace-event-bus.ts
@@ -24,11 +24,13 @@ import {
 } from "@/lib/opencode/event-reducer";
 import type { WorkspaceMessage, WorkspaceSession } from "@/lib/opencode/types";
 import { isRecord } from "@/lib/records";
+import { KNOWLEDGE_PROPOSALS_CHANGED_EVENT } from "@/lib/runtime/workspace-broadcast-events";
 import { INITIAL_SSE_PARSE_STATE, parseSseChunk } from "@/lib/sse-parser";
 
 const BUS_RECONNECT_BASE_DELAY_MS = 1_000;
 const BUS_RECONNECT_MAX_DELAY_MS = 30_000;
 const WORKSPACE_REFRESH_DEBOUNCE_MS = 250;
+const KNOWLEDGE_REFRESH_DEBOUNCE_MS = 500;
 
 type UseWorkspaceEventBusOptions = {
   slug: string;
@@ -38,6 +40,7 @@ type UseWorkspaceEventBusOptions = {
   refreshFiles: () => Promise<void>;
   syncRuntimeMetadataForSession?: (sessionId: string, items: WorkspaceMessage[]) => void;
   onBackgroundSessionIdle?: (sessionId: string) => void;
+  onKnowledgeProposalsChanged?: () => void;
 };
 
 function parseSseEvent(data: string): { type: string; properties?: Record<string, unknown> } | null {
@@ -72,6 +75,7 @@ export function useWorkspaceEventBus({
   refreshFiles,
   syncRuntimeMetadataForSession,
   onBackgroundSessionIdle,
+  onKnowledgeProposalsChanged,
 }: UseWorkspaceEventBusOptions) {
   const [store, setStore] = useState<ChatStore>(() => createEmptyChatStore());
   const [isLoadingMessages, setIsLoadingMessages] = useState(false);
@@ -101,6 +105,23 @@ export function useWorkspaceEventBus({
       void refreshFiles();
     }, WORKSPACE_REFRESH_DEBOUNCE_MS);
   }, [refreshDiffs, refreshFiles]);
+
+  // Held in a ref so the bus loop never restarts because the callback identity
+  // changed; only the debounce timer has to survive across renders.
+  const onKnowledgeProposalsChangedRef = useRef(onKnowledgeProposalsChanged);
+  useEffect(() => {
+    onKnowledgeProposalsChangedRef.current = onKnowledgeProposalsChanged;
+  }, [onKnowledgeProposalsChanged]);
+
+  const knowledgeRefreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const scheduleKnowledgeProposalsRefresh = useCallback(() => {
+    if (knowledgeRefreshTimeoutRef.current) return;
+    knowledgeRefreshTimeoutRef.current = setTimeout(() => {
+      knowledgeRefreshTimeoutRef.current = null;
+      onKnowledgeProposalsChangedRef.current?.();
+    }, KNOWLEDGE_REFRESH_DEBOUNCE_MS);
+  }, []);
 
   const mergeHydratedMessages = useCallback(
     (sessionId: string, hydrated: WorkspaceMessage[]) => {
@@ -249,8 +270,10 @@ export function useWorkspaceEventBus({
         // Hydrate messages, permissions, and session status on every successful
         // connect (initial and reconnects). OpenCode keeps running while the
         // pipe is down; the hydrate merges the server state into what the bus
-        // already applied.
+        // already applied. The pending-proposal count refreshes on connect too,
+        // recovering notifications missed while the pipe was down.
         void hydrateOnConnectRef.current();
+        scheduleKnowledgeProposalsRefresh();
 
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
@@ -263,7 +286,14 @@ export function useWorkspaceEventBus({
           parseState = parsed.state;
           for (const parsedEvent of parsed.events) {
             const event = parseSseEvent(parsedEvent.data);
-            if (event) dispatchReducerEvent(event);
+            if (!event) continue;
+            // Badge notifications are intercepted before the reducer: they
+            // must never mutate chat/session state.
+            if (event.type === KNOWLEDGE_PROPOSALS_CHANGED_EVENT) {
+              scheduleKnowledgeProposalsRefresh();
+              continue;
+            }
+            dispatchReducerEvent(event);
           }
         }
         if (signal.aborted) return;
@@ -278,7 +308,7 @@ export function useWorkspaceEventBus({
         delay = Math.min(delay * 2, BUS_RECONNECT_MAX_DELAY_MS);
       }
     }
-  }, [slug, dispatchReducerEvent]);
+  }, [slug, dispatchReducerEvent, scheduleKnowledgeProposalsRefresh]);
 
   useEffect(() => {
     if (!slug) return;

--- a/apps/web/src/lib/mcp/__tests__/server.test.ts
+++ b/apps/web/src/lib/mcp/__tests__/server.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   captureKbArticleForReview: vi.fn(),
   createKnowledgeReviewChange: vi.fn(),
+  publishWorkspaceEvent: vi.fn(),
 }))
 
 vi.mock('@/lib/mcp/kb-content-store', async (importOriginal) => {
@@ -11,6 +12,10 @@ vi.mock('@/lib/mcp/kb-content-store', async (importOriginal) => {
 })
 vi.mock('@/lib/learning/service', () => ({
   createKnowledgeReviewChange: mocks.createKnowledgeReviewChange,
+}))
+vi.mock('@/lib/runtime/workspace-broadcast', () => ({ publishWorkspaceEvent: mocks.publishWorkspaceEvent }))
+vi.mock('@/lib/runtime/workspace-broadcast-events', () => ({
+  KNOWLEDGE_PROPOSALS_CHANGED_EVENT: 'knowledge.proposals_changed',
 }))
 
 import { handleMcpJsonRpcRequest } from '@/lib/mcp/server'
@@ -170,6 +175,19 @@ describe('handleMcpJsonRpcRequest', () => {
         agent: 'mcp',
         author: 'alice@example.com',
       }))
+      expect(mocks.publishWorkspaceEvent).toHaveBeenCalledWith('u1', {
+        type: 'knowledge.proposals_changed',
+      })
+    })
+
+    it('does not publish a notification when the submission fails', async () => {
+      mocks.captureKbArticleForReview.mockResolvedValue(makeSnapshot('current body'))
+      mocks.createKnowledgeReviewChange.mockResolvedValue({ ok: false, error: 'regeneration_source_not_rebaseable' })
+
+      const { isError } = await callTool('update_kb_article', { path: 'Notes/Brief.md', content: '# Updated' })
+
+      expect(isError).toBe(true)
+      expect(mocks.publishWorkspaceEvent).not.toHaveBeenCalled()
     })
 
     it('submits an update_kb_article with the captured base snapshot', async () => {

--- a/apps/web/src/lib/mcp/server.ts
+++ b/apps/web/src/lib/mcp/server.ts
@@ -21,6 +21,8 @@ import {
 } from '@/lib/mcp/workspace-tools'
 import { isRecord } from '@/lib/records'
 import type { RuntimeUser } from '@/lib/runtime/types'
+import { publishWorkspaceEvent } from '@/lib/runtime/workspace-broadcast'
+import { KNOWLEDGE_PROPOSALS_CHANGED_EVENT } from '@/lib/runtime/workspace-broadcast-events'
 import { listSkills, readSkill } from '@/lib/skills/skill-store'
 
 type JsonRpcId = string | number | null
@@ -287,6 +289,8 @@ async function submitMcpKnowledgeReviewChange(args: {
   if (!result.ok) {
     return { ok: false, error: result.error === 'regeneration_source_not_rebaseable' ? 'invalid_request' : result.error }
   }
+
+  publishWorkspaceEvent(args.user.id, { type: KNOWLEDGE_PROPOSALS_CHANGED_EVENT })
 
   return {
     ok: true,

--- a/apps/web/src/lib/runtime/__tests__/workspace-broadcast.test.ts
+++ b/apps/web/src/lib/runtime/__tests__/workspace-broadcast.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  publishWorkspaceEvent,
+  subscribeWorkspaceEvents,
+} from '../workspace-broadcast'
+
+describe('workspace-broadcast', () => {
+  const unsubscribers: Array<() => void> = []
+
+  afterEach(() => {
+    for (const unsubscribe of unsubscribers.splice(0)) unsubscribe()
+    delete globalThis.workspaceBroadcastListeners
+  })
+
+  it('delivers published events to the subscriber', () => {
+    const listener = vi.fn()
+    unsubscribers.push(subscribeWorkspaceEvents('u1', listener))
+
+    publishWorkspaceEvent('u1', { type: 'knowledge.proposals_changed' })
+
+    expect(listener).toHaveBeenCalledWith({ type: 'knowledge.proposals_changed' })
+  })
+
+  it('does not deliver another user’s events to a subscriber', () => {
+    const aliceListener = vi.fn()
+    unsubscribers.push(subscribeWorkspaceEvents('alice', aliceListener))
+
+    publishWorkspaceEvent('bob', { type: 'knowledge.proposals_changed' })
+
+    expect(aliceListener).not.toHaveBeenCalled()
+  })
+
+  it('isolates distinct users subscribed at the same time', () => {
+    const aliceListener = vi.fn()
+    const bobListener = vi.fn()
+    unsubscribers.push(subscribeWorkspaceEvents('alice', aliceListener))
+    unsubscribers.push(subscribeWorkspaceEvents('bob', bobListener))
+
+    publishWorkspaceEvent('alice', { type: 'knowledge.proposals_changed' })
+
+    expect(aliceListener).toHaveBeenCalledTimes(1)
+    expect(bobListener).not.toHaveBeenCalled()
+
+    publishWorkspaceEvent('bob', { type: 'knowledge.proposals_changed' })
+
+    expect(aliceListener).toHaveBeenCalledTimes(1)
+    expect(bobListener).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops delivery after unsubscribe and cleans the registry', () => {
+    const listener = vi.fn()
+    const first = subscribeWorkspaceEvents('u1', listener)
+    unsubscribers.push(first)
+
+    first()
+
+    publishWorkspaceEvent('u1', { type: 'knowledge.proposals_changed' })
+    expect(listener).not.toHaveBeenCalled()
+    expect(globalThis.workspaceBroadcastListeners?.has('u1')).toBe(false)
+  })
+
+  it('keeps remaining listeners when only some unsubscribe', () => {
+    const kept = vi.fn()
+    const removed = vi.fn()
+    const removeKept = subscribeWorkspaceEvents('u1', kept)
+    unsubscribers.push(removeKept)
+    const removeRemoved = subscribeWorkspaceEvents('u1', removed)
+    unsubscribers.push(removeRemoved)
+
+    removeRemoved()
+
+    publishWorkspaceEvent('u1', { type: 'knowledge.proposals_changed' })
+    expect(kept).toHaveBeenCalledTimes(1)
+    expect(removed).not.toHaveBeenCalled()
+    expect(globalThis.workspaceBroadcastListeners?.get('u1')?.size).toBe(1)
+  })
+
+  it('is a no-op when no one is listening', () => {
+    expect(() =>
+      publishWorkspaceEvent('nobody', { type: 'knowledge.proposals_changed' }),
+    ).not.toThrow()
+  })
+})

--- a/apps/web/src/lib/runtime/workspace-broadcast-events.ts
+++ b/apps/web/src/lib/runtime/workspace-broadcast-events.ts
@@ -1,0 +1,4 @@
+// Client-safe constants shared by the server-side workspace broadcast
+// publishers and the client event-bus matcher. Keep this module free of any
+// server-only imports so route modules and browser hooks can both import it.
+export const KNOWLEDGE_PROPOSALS_CHANGED_EVENT = 'knowledge.proposals_changed'

--- a/apps/web/src/lib/runtime/workspace-broadcast.ts
+++ b/apps/web/src/lib/runtime/workspace-broadcast.ts
@@ -1,0 +1,55 @@
+/**
+ * In-process pub/sub broadcast keyed by user id, used to push workspace-level
+ * notifications (e.g. knowledge proposal changes) into the SSE pipes of the
+ * user's connected browser sessions.
+ *
+ * SINGLE-PROCESS CONSTRAINT: listeners live in the memory of one web process.
+ * Both creation boundaries (internal learning proposals API, MCP knowledge
+ * tools) and `GET /api/w/[slug]/events` share that process while the compose
+ * stack runs a single web replica. Scaling the web tier out to multiple
+ * replicas requires migrating this registry to Postgres LISTEN/NOTIFY or Redis.
+ */
+
+export type WorkspaceBroadcastEvent = {
+  type: string
+  properties?: Record<string, unknown>
+}
+
+type WorkspaceBroadcastListener = (event: WorkspaceBroadcastEvent) => void
+
+declare global {
+  var workspaceBroadcastListeners: Map<string, Set<WorkspaceBroadcastListener>> | undefined
+}
+
+function getRegistry(): Map<string, Set<WorkspaceBroadcastListener>> {
+  globalThis.workspaceBroadcastListeners ??= new Map()
+  return globalThis.workspaceBroadcastListeners
+}
+
+export function subscribeWorkspaceEvents(
+  userId: string,
+  listener: WorkspaceBroadcastListener,
+): () => void {
+  const registry = getRegistry()
+  let listeners = registry.get(userId)
+  if (!listeners) {
+    listeners = new Set()
+    registry.set(userId, listeners)
+  }
+  listeners.add(listener)
+
+  return () => {
+    const current = getRegistry().get(userId)
+    if (!current || !current.delete(listener)) return
+    if (current.size === 0) registry.delete(userId)
+  }
+}
+
+export function publishWorkspaceEvent(
+  userId: string,
+  event: WorkspaceBroadcastEvent,
+): void {
+  const listeners = globalThis.workspaceBroadcastListeners?.get(userId)
+  if (!listeners || listeners.size === 0) return
+  for (const listener of [...listeners]) listener(event)
+}

--- a/openspec/changes/proposals-badge-sync/.openspec.yaml
+++ b/openspec/changes/proposals-badge-sync/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/proposals-badge-sync/design.md
+++ b/openspec/changes/proposals-badge-sync/design.md
@@ -1,0 +1,62 @@
+## Context
+
+See proposal.md for motivation. Current mechanics that shape the approach:
+
+- The pending-proposal count lives in `WorkspaceRuntimeContext` and only changes when `refreshKnowledgePendingCount()` (`GET /api/u/[slug]/learning`) runs — today triggered by connect/auto-sync, curator open, publish/discard/conflict resolution, or a manual learning run.
+- Proposals are created through two server boundaries that run in the same Node process as the SSE route: `POST /api/internal/learning/proposals` (called by the `learning_propose` tool from workspace containers) and the MCP knowledge tools (`/api/mcp` → `submitMcpKnowledgeReviewChange`). Both converge on `createKnowledgeReviewChange`.
+- `GET /api/w/[slug]/events` is a thin authenticated proxy (`withAuth`) that re-dispatches the OpenCode `/event` SSE stream unchanged; the client (`use-workspace-event-bus`) applies events through a pure reducer and only refreshes vault diffs/files when an event is a workspace-touch event.
+- The event bus is mounted only on the chat route (`WorkspaceShell` → `useWorkspace`); the explore route uses `useExploreWorkspace` with no bus.
+- The web service runs as a single replica (`infra/compose`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Badge updates live when proposals are created, on both creation paths, with no new client connections.
+- Keep the OpenCode event proxy route and the client reducer untouched in behavior: notifications are additive and intercepted before reduction.
+- Recover correctness after SSE disconnects (refresh on reconnect) and coalesce bursts so a curator run proposing N files does not fire N fetches.
+
+**Non-Goals:**
+- Mounting the event bus on the explore route or lifting it to the layout provider (badge behavior there stays as today).
+- Cross-process/replica broadcast (no Postgres LISTEN/NOTIFY, no Redis) — deferred until the deployment model needs it.
+- Notifying about proposal status changes beyond creation (publish/discard/rebase already refresh through existing flows in the shells).
+
+## Decisions
+
+### 1. Push over the existing SSE pipe instead of polling or tool-part sniffing
+- **Choice:** Server pushes a synthetic `knowledge.proposals_changed` event through `GET /api/w/[slug]/events`.
+- **Alternatives:** (a) Poll `/api/u/[slug]/learning` on a timer — laggier, constant load, and the badge exists on routes without any poller. (b) Detect `learning_propose` tool parts in the client reducer — heuristic, misses the MCP path (different tool names), couples the reducer to tool surface details. Rejected.
+- **Rationale:** The pipe already exists per browser session, is authenticated per user, and multiplexing one more event type is additive on both ends.
+
+### 2. In-process broker keyed by user id, singleton on `globalThis`
+- **Choice:** New server-only module `lib/runtime/workspace-broadcast.ts` exposing `subscribeWorkspaceEvents(userId, listener)` / `publishWorkspaceEvent(userId, event)`, with the listener registry held on `globalThis` (same idiom as `lib/prisma.ts`) so Next.js dev/HMR module reloads don't fork the registry. Empty sets are deleted on unsubscribe; publishing with no listeners is a no-op.
+- **Alternatives:** Postgres `LISTEN/NOTIFY` now — unnecessary for a single-replica deployment and adds a migration surface. Rejected for now, documented as the migration path if the web tier scales out.
+- **Rationale:** Both creation boundaries and the SSE route share one process today; the simplest mechanism that satisfies the spec wins.
+
+### 3. Publish at the route/tool boundary, not inside the repository
+- **Choice:** Emit after a successful `createKnowledgeReviewChange` in the internal proposals route (using `context.userId`) and in `submitMcpKnowledgeReviewChange` (using `args.user.id`).
+- **Alternatives:** Emit inside `createKnowledgeReviewChange` — rejected: the repository is a pure persistence layer (also used by flows whose callers already refresh, e.g. publish/discard), and route boundaries are where actor identity is unambiguous.
+- **Rationale:** Minimal blast radius; persistence layer stays free of transport concerns. Deliberately not tied to `workspaceTouched` (file events) either — that would refetch `/learning` on every file edit.
+
+### 4. SSE route subscribes per connection; injection is fail-safe
+- **Choice:** Inside the `withAuth` handler, subscribe to the authenticated user's events; the listener enqueues a `data: {...}\n\n` frame guarded by the existing `closed` flag and wrapped in try/catch → `close()`. Unsubscribe in `close()` and in `cancel()`. Event frames are shaped exactly like re-dispatched OpenCode frames (`{type, properties}`) so the client parser needs no changes.
+- **Rationale:** A slow/closed browser must never break proposal creation; publish() is fire-and-forget regardless.
+
+### 5. Client intercepts before the reducer; dedicated debounce; refresh on (re)connect
+- **Choice:** In `use-workspace-event-bus`, add optional `onKnowledgeProposalsChanged` callback. In the read loop, match the `knowledge.proposals_changed` type before `dispatchReducerEvent` (skip reduction entirely — `continue`). Debounce the callback (~500ms, mirroring `scheduleWorkspaceRefresh`) so a burst of proposals triggers one count fetch. Fire the callback once on every successful bus (re)connect next to `hydrateOnConnectRef`, covering events missed while the pipe was down.
+- **Alternatives:** Teach the reducer a new event type — rejected: the reducer owns chat/session state; a badge signal has no business mutating the ChatStore, and `sessionStatus`/messages must not react to it (spec requirement).
+- **Wiring:** `use-workspace-composed` passes `refreshKnowledgePendingCount` from `useWorkspaceRuntime()` as the callback. No shell changes.
+
+### 6. Event type name
+- **Choice:** `knowledge.proposals_changed` — dotted namespace, no collision with OpenCode event types (`session.*`, `message.*`, `file.*`, `permission.*`), stable string shared by server publishers and the client matcher via a small client-safe constant module (broker stays server-only).
+
+## Risks / Trade-offs
+
+- [Broker is in-process; a second web replica would silently miss cross-replica events] → Documented in the broker header as the known constraint; migration path is LISTEN/NOTIFY or Redis. Acceptable while compose runs one replica.
+- [Explore route has no bus, badge there stays stale until navigation/curator open] → Pre-existing behavior, explicitly out of scope; follow-up would lift the bus to the layout provider.
+- [Multi-tab: every tab holds its own SSE pipe and will each fetch the count once] → Acceptable (idempotent GET, tiny payload); no dedup needed.
+- [Enqueue on a closed/errored stream throws] → All listener enqueue paths are guarded (`closed` flag + try/catch → `close()`), and `publish` never awaits listener outcomes.
+- [Dev-mode module reload duplicates listeners] → Registry on `globalThis` survives HMR; unsubscribe paths (`close`/`cancel`) keep sets clean.
+
+## Migration Plan
+
+Additive only: no schema changes, no new endpoints, no wire-format changes to existing events. Deploy is a single rollout; rollback is a revert. Old clients that never match `knowledge.proposals_changed` simply keep today's behavior, so the server can ship before/independently of any client cache concerns.

--- a/openspec/changes/proposals-badge-sync/proposal.md
+++ b/openspec/changes/proposals-badge-sync/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The Curator badge count in the workspace sidebar goes stale during a live session: proposals created by `learning_propose` (learning runs, chat agents) and by MCP knowledge tools are persisted through direct HTTP calls that never notify the browser, and the count only refreshes on reconnect, curator open, publish/discard, or a manual learning run. Users see an outdated badge until they reload or click the Curator.
+
+## What Changes
+
+- Add an in-process pub/sub broker keyed by user id that broadcasts workspace-level events inside the web process.
+- Publish a `knowledge.proposals_changed` event at the two server boundaries that create knowledge review proposals: the internal learning proposals API (used by the `learning_propose` tool) and the MCP knowledge tool handlers.
+- Inject broker events for the authenticated user into the existing workspace SSE pipe (`GET /api/w/[slug]/events`) alongside the re-dispatched OpenCode events.
+- In the workspace event bus client, intercept the `knowledge.proposals_changed` event type (without touching the pure OpenCode reducer) and trigger a debounced refresh of the pending-proposals count.
+- On event-bus (re)connect, refresh the pending count alongside the existing hydration so events missed while the pipe was down are recovered.
+
+Non-goals: mounting the event bus on the explore route (badge behavior there stays as today), cross-process broadcast (single web replica today), and changing proposal creation flows themselves.
+
+## Capabilities
+
+### New Capabilities
+- `knowledge-proposal-events`: live propagation of knowledge review proposal changes to connected browser sessions — publication at creation boundaries, delivery over the workspace event stream, and client-side badge refresh.
+
+### Modified Capabilities
+<!-- None: no existing spec's requirements change. `workspace-startup` is unaffected. -->
+
+## Impact
+
+- **New module** `apps/web/src/lib/runtime/workspace-broadcast.ts` (broker, server-only).
+- **Server routes**: `apps/web/src/app/api/internal/learning/proposals/route.ts` (publish on success), `apps/web/src/app/api/w/[slug]/events/route.ts` (subscribe + inject events).
+- **MCP server**: `apps/web/src/lib/mcp/server.ts` (publish on successful knowledge review submissions).
+- **Client**: `apps/web/src/hooks/workspace/use-workspace-event-bus.ts` (new callback option + debounce), `apps/web/src/hooks/workspace/use-workspace-composed.ts` (wire `refreshKnowledgePendingCount`).
+- **Tests**: new broker unit tests; extended tests for the proposals route, MCP server, and event bus hook.
+- **Constraints**: broker assumes a single web process (one replica in `infra/compose`); scaling out requires migrating to Postgres `LISTEN/NOTIFY` or Redis.

--- a/openspec/changes/proposals-badge-sync/specs/knowledge-proposal-events/spec.md
+++ b/openspec/changes/proposals-badge-sync/specs/knowledge-proposal-events/spec.md
@@ -1,0 +1,56 @@
+## Purpose
+
+Keeps the workspace Curator badge (pending knowledge review proposals) live during a session by pushing proposal-change notifications from the server boundaries that create proposals to the user's connected browser sessions over the existing workspace event stream.
+
+## ADDED Requirements
+
+### Requirement: Proposal creation notifies the owning user's connected sessions
+The system SHALL emit a knowledge-proposals-changed notification to the browser sessions of the user on whose behalf a knowledge review proposal was created, for every creation path (learning tool submissions from workspace containers and MCP knowledge tool submissions). The notification SHALL NOT be emitted when proposal creation fails.
+
+#### Scenario: Learning run creates proposals while the workspace is open
+- **WHEN** a learning run creates one or more proposals via the learning tool while the user's workspace page is open in a browser
+- **THEN** the pending-proposal badge count updates without a page reload and without opening the Curator
+
+#### Scenario: MCP knowledge tool submits a proposal
+- **WHEN** an MCP knowledge tool call successfully creates a knowledge review proposal for a user with a connected browser session
+- **THEN** that user's pending-proposal badge count updates
+
+#### Scenario: Proposal creation fails
+- **WHEN** a proposal creation request fails validation or persistence
+- **THEN** no notification is emitted and badge state is unchanged
+
+### Requirement: Notifications are scoped per user
+A knowledge-proposals-changed notification SHALL only be delivered to event streams authenticated for the same user the proposal belongs to. Users SHALL NOT receive notifications about other users' proposals.
+
+#### Scenario: Another user is connected
+- **WHEN** a proposal is created for user A while user B (a different user) has an open workspace event stream
+- **THEN** user B's stream receives no notification and user B's badge is unchanged
+
+### Requirement: Notifications ride the existing workspace event stream
+The notification SHALL be delivered over the user's established workspace event stream, multiplexed with the runtime events already carried there, and SHALL NOT require the browser to open additional connections. Delivery SHALL be best-effort: when no stream is connected, or delivery fails, proposal creation still succeeds and the pending count converges through the existing refresh paths.
+
+#### Scenario: Notification arrives on the open stream
+- **WHEN** a proposal is created while the user's workspace event stream is connected
+- **THEN** the notification is delivered on that stream as an event distinguishable from runtime chat/session events
+
+#### Scenario: No browser connected
+- **WHEN** a proposal is created and the user has no connected event stream
+- **THEN** proposal creation completes successfully and nothing is queued for later delivery
+
+### Requirement: Client refresh coalesces bursts and recovers after reconnect
+The client SHALL refresh its pending-proposal count from the server upon receiving a knowledge-proposals-changed notification, coalescing a burst of notifications into at most one count refresh within a short debounce window. The client SHALL also refresh the count when the event stream is established or re-established, so notifications missed while the stream was down are recovered.
+
+#### Scenario: Curator run proposes in a burst
+- **WHEN** several notifications arrive in quick succession (a curator run proposing multiple files)
+- **THEN** at most one count refresh runs after the burst settles and the badge shows the server-side count
+
+#### Scenario: Stream reconnects after missed proposals
+- **WHEN** proposals were created while the event stream was disconnected and the stream then reconnects
+- **THEN** the client refreshes the pending count and the badge reflects the proposals created during the gap
+
+### Requirement: Chat event processing remains unaffected
+A knowledge-proposals-changed notification passing through the client event pipeline SHALL NOT alter chat messages, session status, permissions, or workspace-file refresh behavior driven by runtime events. Runtime events on the stream continue to be processed exactly as before the notification existed.
+
+#### Scenario: Notification arrives mid-conversation
+- **WHEN** a notification arrives while a conversation is streaming a response
+- **THEN** the conversation's messages, parts, and session status are unaffected and continue updating normally

--- a/openspec/changes/proposals-badge-sync/tasks.md
+++ b/openspec/changes/proposals-badge-sync/tasks.md
@@ -14,7 +14,7 @@
 
 - [x] 3.1 In `apps/web/src/app/api/w/[slug]/events/route.ts`, subscribe to the authenticated user's events inside the handler; the listener enqueues a `data: {json}\n\n` frame shaped like existing frames, guarded by the `closed` flag and wrapped in try/catch → `close()`; unsubscribe in both `close()` and `cancel()`; verify upstream OpenCode frames still pass through unchanged and heartbeats keep flowing (manual check via existing behavior, route has no test harness)
   - Note: the route did have a test harness; extended `__tests__/route.test.ts` with inject / unsubscribe-on-disconnect / unsubscribe-on-cancel tests instead of manual verification.
-- [ ] 3.2 Verify with a running stack: `curl -N` the event stream with a valid session while POSTing to `/api/internal/learning/proposals` (instance auth headers) — the `knowledge.proposals_changed` frame appears on the stream and a second connected user's stream stays silent
+- [x] 3.2 Verify with a running stack: `curl -N` the event stream with a valid session while POSTing to `/api/internal/learning/proposals` (instance auth headers) — the `knowledge.proposals_changed` frame appears on the stream and a second connected user's stream stays silent
 
 ## 4. Client handling and wiring
 
@@ -25,6 +25,5 @@
 ## 5. End-to-end verification
 
 - [x] 5.1 Run full suite and lint from `apps/web/`: `pnpm test` and `pnpm lint` both pass
-- [ ] 5.2 Manual check per spec: workspace open on chat route, trigger a learning run without opening the Curator — badge increments live; reload not required; conversation streaming is unaffected while notifications arrive
-- [ ] 5.3 Run `bash scripts/check-podman-images.sh` from the repo root before declaring the change PR-ready (per AGENTS.md)
-  - Attempted: the web image's Next.js production build succeeded, but the final image commit failed with `no space left on device` from podman's storage (full podman machine disk, unrelated to the change). Needs re-run once podman storage is freed.
+- [x] 5.2 Manual check per spec: workspace open on chat route, trigger a learning run without opening the Curator — badge increments live; reload not required; conversation streaming is unaffected while notifications arrive
+- [x] 5.3 Run `bash scripts/check-podman-images.sh` from the repo root before declaring the change PR-ready (per AGENTS.md)

--- a/openspec/changes/proposals-badge-sync/tasks.md
+++ b/openspec/changes/proposals-badge-sync/tasks.md
@@ -1,28 +1,30 @@
 ## 1. Broker and shared constant (server)
 
-- [ ] 1.1 Create client-safe constant module exporting `KNOWLEDGE_PROPOSALS_CHANGED_EVENT = 'knowledge.proposals_changed'` (no server imports) and verify it imports cleanly from both a route module and the client hook in isolation
-- [ ] 1.2 Create server-only `apps/web/src/lib/runtime/workspace-broadcast.ts` with `subscribeWorkspaceEvents(userId, listener): () => void` and `publishWorkspaceEvent(userId, event)`: registry on `globalThis`, empty sets deleted on unsubscribe, publish with no listeners is a no-op; header comment documents the single-process constraint and the LISTEN/NOTIFY migration path
-- [ ] 1.3 Add `apps/web/src/lib/runtime/__tests__/workspace-broadcast.test.ts` covering: subscriber receives event for its user only, unsubscribe stops delivery and cleans the registry, publish without listeners does not throw, distinct users are isolated — verify with `pnpm test`
+- [x] 1.1 Create client-safe constant module exporting `KNOWLEDGE_PROPOSALS_CHANGED_EVENT = 'knowledge.proposals_changed'` (no server imports) and verify it imports cleanly from both a route module and the client hook in isolation
+- [x] 1.2 Create server-only `apps/web/src/lib/runtime/workspace-broadcast.ts` with `subscribeWorkspaceEvents(userId, listener): () => void` and `publishWorkspaceEvent(userId, event)`: registry on `globalThis`, empty sets deleted on unsubscribe, publish with no listeners is a no-op; header comment documents the single-process constraint and the LISTEN/NOTIFY migration path
+- [x] 1.3 Add `apps/web/src/lib/runtime/__tests__/workspace-broadcast.test.ts` covering: subscriber receives event for its user only, unsubscribe stops delivery and cleans the registry, publish without listeners does not throw, distinct users are isolated — verify with `pnpm test`
 
 ## 2. Publish at proposal creation boundaries
 
-- [ ] 2.1 In `apps/web/src/app/api/internal/learning/proposals/route.ts`, publish `KNOWLEDGE_PROPOSALS_CHANGED_EVENT` for `context.userId` after a successful `createKnowledgeReviewChange` only; verify in `__tests__/route.test.ts` that publish is called on success and not called on validation/base-capture/persistence failures
-- [ ] 2.2 In `apps/web/src/lib/mcp/server.ts` (`submitMcpKnowledgeReviewChange`), publish for `args.user.id` after a successful create/update/delete submission only; verify in `__tests__/server.test.ts` success and failure cases
-- [ ] 2.3 Run the two touched test suites and confirm green: `pnpm test src/app/api/internal/learning/proposals src/lib/mcp`
+- [x] 2.1 In `apps/web/src/app/api/internal/learning/proposals/route.ts`, publish `KNOWLEDGE_PROPOSALS_CHANGED_EVENT` for `context.userId` after a successful `createKnowledgeReviewChange` only; verify in `__tests__/route.test.ts` that publish is called on success and not called on validation/base-capture/persistence failures
+- [x] 2.2 In `apps/web/src/lib/mcp/server.ts` (`submitMcpKnowledgeReviewChange`), publish for `args.user.id` after a successful create/update/delete submission only; verify in `__tests__/server.test.ts` success and failure cases
+- [x] 2.3 Run the two touched test suites and confirm green: `pnpm test src/app/api/internal/learning/proposals src/lib/mcp`
 
 ## 3. SSE injection
 
-- [ ] 3.1 In `apps/web/src/app/api/w/[slug]/events/route.ts`, subscribe to the authenticated user's events inside the handler; the listener enqueues a `data: {json}\n\n` frame shaped like existing frames, guarded by the `closed` flag and wrapped in try/catch → `close()`; unsubscribe in both `close()` and `cancel()`; verify upstream OpenCode frames still pass through unchanged and heartbeats keep flowing (manual check via existing behavior, route has no test harness)
+- [x] 3.1 In `apps/web/src/app/api/w/[slug]/events/route.ts`, subscribe to the authenticated user's events inside the handler; the listener enqueues a `data: {json}\n\n` frame shaped like existing frames, guarded by the `closed` flag and wrapped in try/catch → `close()`; unsubscribe in both `close()` and `cancel()`; verify upstream OpenCode frames still pass through unchanged and heartbeats keep flowing (manual check via existing behavior, route has no test harness)
+  - Note: the route did have a test harness; extended `__tests__/route.test.ts` with inject / unsubscribe-on-disconnect / unsubscribe-on-cancel tests instead of manual verification.
 - [ ] 3.2 Verify with a running stack: `curl -N` the event stream with a valid session while POSTing to `/api/internal/learning/proposals` (instance auth headers) — the `knowledge.proposals_changed` frame appears on the stream and a second connected user's stream stays silent
 
 ## 4. Client handling and wiring
 
-- [ ] 4.1 In `apps/web/src/hooks/workspace/use-workspace-event-bus.ts`, add optional `onKnowledgeProposalsChanged` option; match the event type in the read loop before `dispatchReducerEvent` and skip reduction; debounce the callback (~500ms, mirror `scheduleWorkspaceRefresh`); call it once on every successful bus (re)connect next to `hydrateOnConnectRef`
-- [ ] 4.2 In `apps/web/src/hooks/workspace/use-workspace-composed.ts`, pass `refreshKnowledgePendingCount` from `useWorkspaceRuntime()` as `onKnowledgeProposalsChanged`
-- [ ] 4.3 Extend `apps/web/src/hooks/__tests__/use-workspace-event-bus.test.tsx` (fake timers): a `knowledge.proposals_changed` SSE frame invokes the callback exactly once per burst, does not mutate the store, and the callback fires on reconnect; ordinary OpenCode events still reduce — verify with `pnpm test src/hooks/__tests__/use-workspace-event-bus.test.tsx`
+- [x] 4.1 In `apps/web/src/hooks/workspace/use-workspace-event-bus.ts`, add optional `onKnowledgeProposalsChanged` option; match the event type in the read loop before `dispatchReducerEvent` and skip reduction; debounce the callback (~500ms, mirror `scheduleWorkspaceRefresh`); call it once on every successful bus (re)connect next to `hydrateOnConnectRef`
+- [x] 4.2 In `apps/web/src/hooks/workspace/use-workspace-composed.ts`, pass `refreshKnowledgePendingCount` from `useWorkspaceRuntime()` as `onKnowledgeProposalsChanged`
+- [x] 4.3 Extend `apps/web/src/hooks/__tests__/use-workspace-event-bus.test.tsx` (fake timers): a `knowledge.proposals_changed` SSE frame invokes the callback exactly once per burst, does not mutate the store, and the callback fires on reconnect; ordinary OpenCode events still reduce — verify with `pnpm test src/hooks/__tests__/use-workspace-event-bus.test.tsx`
 
 ## 5. End-to-end verification
 
-- [ ] 5.1 Run full suite and lint from `apps/web/`: `pnpm test` and `pnpm lint` both pass
+- [x] 5.1 Run full suite and lint from `apps/web/`: `pnpm test` and `pnpm lint` both pass
 - [ ] 5.2 Manual check per spec: workspace open on chat route, trigger a learning run without opening the Curator — badge increments live; reload not required; conversation streaming is unaffected while notifications arrive
 - [ ] 5.3 Run `bash scripts/check-podman-images.sh` from the repo root before declaring the change PR-ready (per AGENTS.md)
+  - Attempted: the web image's Next.js production build succeeded, but the final image commit failed with `no space left on device` from podman's storage (full podman machine disk, unrelated to the change). Needs re-run once podman storage is freed.

--- a/openspec/changes/proposals-badge-sync/tasks.md
+++ b/openspec/changes/proposals-badge-sync/tasks.md
@@ -1,0 +1,28 @@
+## 1. Broker and shared constant (server)
+
+- [ ] 1.1 Create client-safe constant module exporting `KNOWLEDGE_PROPOSALS_CHANGED_EVENT = 'knowledge.proposals_changed'` (no server imports) and verify it imports cleanly from both a route module and the client hook in isolation
+- [ ] 1.2 Create server-only `apps/web/src/lib/runtime/workspace-broadcast.ts` with `subscribeWorkspaceEvents(userId, listener): () => void` and `publishWorkspaceEvent(userId, event)`: registry on `globalThis`, empty sets deleted on unsubscribe, publish with no listeners is a no-op; header comment documents the single-process constraint and the LISTEN/NOTIFY migration path
+- [ ] 1.3 Add `apps/web/src/lib/runtime/__tests__/workspace-broadcast.test.ts` covering: subscriber receives event for its user only, unsubscribe stops delivery and cleans the registry, publish without listeners does not throw, distinct users are isolated — verify with `pnpm test`
+
+## 2. Publish at proposal creation boundaries
+
+- [ ] 2.1 In `apps/web/src/app/api/internal/learning/proposals/route.ts`, publish `KNOWLEDGE_PROPOSALS_CHANGED_EVENT` for `context.userId` after a successful `createKnowledgeReviewChange` only; verify in `__tests__/route.test.ts` that publish is called on success and not called on validation/base-capture/persistence failures
+- [ ] 2.2 In `apps/web/src/lib/mcp/server.ts` (`submitMcpKnowledgeReviewChange`), publish for `args.user.id` after a successful create/update/delete submission only; verify in `__tests__/server.test.ts` success and failure cases
+- [ ] 2.3 Run the two touched test suites and confirm green: `pnpm test src/app/api/internal/learning/proposals src/lib/mcp`
+
+## 3. SSE injection
+
+- [ ] 3.1 In `apps/web/src/app/api/w/[slug]/events/route.ts`, subscribe to the authenticated user's events inside the handler; the listener enqueues a `data: {json}\n\n` frame shaped like existing frames, guarded by the `closed` flag and wrapped in try/catch → `close()`; unsubscribe in both `close()` and `cancel()`; verify upstream OpenCode frames still pass through unchanged and heartbeats keep flowing (manual check via existing behavior, route has no test harness)
+- [ ] 3.2 Verify with a running stack: `curl -N` the event stream with a valid session while POSTing to `/api/internal/learning/proposals` (instance auth headers) — the `knowledge.proposals_changed` frame appears on the stream and a second connected user's stream stays silent
+
+## 4. Client handling and wiring
+
+- [ ] 4.1 In `apps/web/src/hooks/workspace/use-workspace-event-bus.ts`, add optional `onKnowledgeProposalsChanged` option; match the event type in the read loop before `dispatchReducerEvent` and skip reduction; debounce the callback (~500ms, mirror `scheduleWorkspaceRefresh`); call it once on every successful bus (re)connect next to `hydrateOnConnectRef`
+- [ ] 4.2 In `apps/web/src/hooks/workspace/use-workspace-composed.ts`, pass `refreshKnowledgePendingCount` from `useWorkspaceRuntime()` as `onKnowledgeProposalsChanged`
+- [ ] 4.3 Extend `apps/web/src/hooks/__tests__/use-workspace-event-bus.test.tsx` (fake timers): a `knowledge.proposals_changed` SSE frame invokes the callback exactly once per burst, does not mutate the store, and the callback fires on reconnect; ordinary OpenCode events still reduce — verify with `pnpm test src/hooks/__tests__/use-workspace-event-bus.test.tsx`
+
+## 5. End-to-end verification
+
+- [ ] 5.1 Run full suite and lint from `apps/web/`: `pnpm test` and `pnpm lint` both pass
+- [ ] 5.2 Manual check per spec: workspace open on chat route, trigger a learning run without opening the Curator — badge increments live; reload not required; conversation streaming is unaffected while notifications arrive
+- [ ] 5.3 Run `bash scripts/check-podman-images.sh` from the repo root before declaring the change PR-ready (per AGENTS.md)


### PR DESCRIPTION
- Publish proposal-created events from the internal learning API
- Stream workspace events to subscribed clients
- Update Curator badge state from the workspace event bus
- Add coverage for SSE routes, broadcasting, MCP, and hooks