### PR TITLE
chore(infra): prune dangling podman images before image check builds

### DIFF
--- a/scripts/check-podman-images.sh
+++ b/scripts/check-podman-images.sh
@@ -22,6 +22,14 @@ if [[ -z "$OPENCODE_VERSION" ]]; then
   exit 1
 fi
 
+printf '==> Pruning dangling images\n'
+podman image prune -f
+
+if [[ "${ARCHE_PODMAN_PRUNE_ALL:-}" == "1" ]]; then
+  printf '==> Pruning all unused Podman data (ARCHE_PODMAN_PRUNE_ALL=1)\n'
+  podman system prune -af
+fi
+
 printf '==> Building web image\n'
 podman build \
   --build-arg GIT_SHA=podman-check \


### PR DESCRIPTION
## What

- `scripts/check-podman-images.sh` now runs `podman image prune -f` (dangling images only) before building the `arche-web` and `arche-workspace` images.
- Adds an opt-in aggressive prune via `ARCHE_PODMAN_PRUNE_ALL=1` (`podman system prune -af`) for manual rescue runs when the podman machine disk is full. It never runs by default, so the build cache is preserved and builds stay fast.

## Why

Every run of the check re-tags `arche-web:podman-check` and `arche-workspace:podman-check`, orphaning the previous images. With the check being a PR-ready requirement (per AGENTS.md), dangling images accumulate (~1 GB+ per run) until the podman machine disk fills and builds start failing.

## Verification

- `bash scripts/check-podman-images.sh` passes (`==> Podman image validation passed`), with the prune step running before both builds.
- Dangling-only prune is safe on shared podman hosts (it never removes tagged images in use by other projects).