### PR TITLE
test(workspace): pin the clock in sessions-panel date-bucket test

### DIFF
--- a/apps/web/src/components/workspace/__tests__/sessions-panel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/sessions-panel.test.tsx
@@ -109,13 +109,23 @@ describe("SessionsPanel", () => {
   });
 
   it("groups sessions by date buckets", () => {
-    const now = Date.now();
-    const dayMs = 86_400_000;
-    renderPanel([
-      { id: "today-session", title: "Today chat", status: "idle", updatedAt: "now", updatedAtRaw: now },
-      { id: "yesterday-session", title: "Yesterday chat", status: "idle", updatedAt: "1d", updatedAtRaw: now - dayMs },
-      { id: "old-session", title: "Old chat", status: "idle", updatedAt: "30d", updatedAtRaw: now - 30 * dayMs },
-    ]);
+    // Pin the clock: `now - 30d` must land in the previous calendar month so
+    // it buckets as "Older" regardless of when the suite runs. A real clock
+    // fails on month-boundary days (e.g. on the 31st, 30d back stays in-month
+    // and groups as "This month" instead).
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-06-17T12:00:00Z"));
+      const now = Date.now();
+      const dayMs = 86_400_000;
+      renderPanel([
+        { id: "today-session", title: "Today chat", status: "idle", updatedAt: "now", updatedAtRaw: now },
+        { id: "yesterday-session", title: "Yesterday chat", status: "idle", updatedAt: "1d", updatedAtRaw: now - dayMs },
+        { id: "old-session", title: "Old chat", status: "idle", updatedAt: "30d", updatedAtRaw: now - 30 * dayMs },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
 
     expect(screen.getByText("Today")).toBeTruthy();
     expect(screen.getByText("Yesterday")).toBeTruthy();

--- a/openspec/changes/deterministic-session-date-buckets/.openspec.yaml
+++ b/openspec/changes/deterministic-session-date-buckets/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-31
+skip_specs: true

--- a/openspec/changes/deterministic-session-date-buckets/proposal.md
+++ b/openspec/changes/deterministic-session-date-buckets/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+The `sessions-panel` test "groups sessions by date buckets" broke in CI on 2026-08-31 (and fails locally on the same date) with no code change: its "old" fixture is `Date.now() - 30 days`, and `groupByDateBucket` has a "This month" tier, so whenever `now - 30 days` is still inside the current calendar month — every 31st — the fixture groups as "This month" and the `Older` header never renders. The test depends on the wall calendar instead of being deterministic.
+
+## What Changes
+
+- Pin the clock in that single test with `vi.useFakeTimers()` / `vi.setSystemTime()` at a fixed mid-month instant (2026-06-17T12:00Z) so the three fixtures deterministically land in Today, Yesterday, and Older; restore real timers in a `finally`.
+- No product, library, or spec-level behavior changes — test-only, so the change opts out of specs (`skip_specs: true`).
+
+## Capabilities
+
+### New Capabilities
+- (none — no behavior changes.)
+
+### Modified Capabilities
+- (none.)
+
+## Impact
+
+- `apps/web/src/components/workspace/__tests__/sessions-panel.test.tsx` — one test made calendar-independent.
+- Verified the test passes under `UTC`, `Pacific/Kiritimati` (UTC+14), and `America/New_York`, and on the failure-prone date; suite-wide behavior unchanged.

--- a/openspec/changes/deterministic-session-date-buckets/tasks.md
+++ b/openspec/changes/deterministic-session-date-buckets/tasks.md
@@ -1,0 +1,9 @@
+## 1. Deterministic test
+
+- [x] 1.1 In `apps/web/src/components/workspace/__tests__/sessions-panel.test.tsx`, pin the clock for "groups sessions by date buckets" via `vi.useFakeTimers()` + `vi.setSystemTime()` (2026-06-17T12:00:00Z), keeping render inside the fake-clock scope and restoring real timers in `finally`.
+
+## 2. Verification
+
+- [x] 2.1 Run the file under `UTC`, `Pacific/Kiritimati` (UTC+14), and `America/New_York` — passes in all.
+- [x] 2.2 Run the sessions-panel and lib test files — green.
+- [ ] 2.3 Run `bash scripts/check-podman-images.sh` from the repo root — unaffected by this change.


### PR DESCRIPTION
## Summary

Unblocks #497: the `Verify Web Coverage Badges` check currently fails **on `main`** (and therefore on any PR branch) because `sessions-panel.test.tsx > groups sessions by date buckets` is calendar-dependent — no code change involved.

**Root cause:** the test's "Older" fixture is `Date.now() - 30 days`, but `groupByDateBucket` (`src/lib/date-buckets.ts`) has a **"This month"** tier. Whenever `now − 30d` is still inside the current calendar month, the fixture groups as "This month" and the `Older` header never renders. That happens on the 31st of every month — which is why the suite passed on Aug 30 and failed on **Aug 31** (today) in CI with an identical tree.

**Fix:** pin the clock in that one test (`vi.useFakeTimers()` + `vi.setSystemTime(2026-06-17T12:00:00Z)`, real timers restored in `finally`) so Today / Yesterday / Older are deterministic on any date and in any timezone. Chose a mid-month instant so the 30-day fixture always lands in the previous month.

## OpenSpec

`deterministic-session-date-buckets` change doc included with `skip_specs: true` — test-only, no behavior changes (`openspec/changes/deterministic-session-date-buckets/`).

## Test plan

- [x] Fails on today's date before the fix, passes after
- [x] Passes under `TZ=UTC`, `TZ=Pacific/Kiritimati` (UTC+14), `TZ=America/New_York`
- [x] Full sessions-panel + lib test files green (488 passed, 0 failed)

## Merge order

Merge this first, then rebase/merge #497 — its coverage-badge check is red only because of this shared-main test.