### PR TITLE
feat(zendesk): unify action permission handling

### DIFF
--- a/apps/web/src/app/api/u/[slug]/connectors/[id]/tool-permissions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/u/[slug]/connectors/[id]/tool-permissions/__tests__/route.test.ts
@@ -288,4 +288,53 @@ describe('/api/u/[slug]/connectors/[id]/tool-permissions', () => {
     expect(res.status).toBe(404)
     await expect(res.json()).resolves.toEqual({ error: 'connector_not_found' })
   })
+
+  describe('zendesk connectors', () => {
+    const ZENDESK_CONNECTOR = { id: 'c1', type: 'zendesk', config: 'encrypted', enabled: true }
+
+    beforeEach(() => {
+      mocks.connectorService.findByIdAndUserId.mockResolvedValue(ZENDESK_CONNECTOR)
+      mocks.decryptConfig.mockReturnValue({
+        subdomain: 'test',
+        email: 'a@b.com',
+        apiToken: 'tok',
+        permissions: {
+          allowRead: true,
+          allowCreateTickets: true,
+          allowUpdateTickets: true,
+          allowPublicComments: false,
+          allowInternalComments: true,
+        },
+      })
+    })
+
+    it('GET projects the normalized canonical actions instead of stored tool permissions', async () => {
+      const res = await GET(makeGetRequest(), params())
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.policyConfigured).toBe(true)
+      expect(body.tools).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'create_ticket_public', permission: 'deny' }),
+          expect.objectContaining({ name: 'create_ticket_internal', permission: 'allow' }),
+          expect.objectContaining({ name: 'search_tickets', permission: 'allow' }),
+        ])
+      )
+      expect(body.tools).toHaveLength(8)
+    })
+
+    it('PATCH rejects writes so no independent Zendesk policy state can be created', async () => {
+      const res = await PATCH(
+        makePatchRequest({ permissions: { create_ticket_public: 'allow' } }),
+        params(),
+      )
+      const body = await res.json()
+
+      expect(res.status).toBe(409)
+      expect(body.error).toBe('unsupported_connector')
+      expect(mocks.encryptConfig).not.toHaveBeenCalled()
+      expect(mocks.connectorService.updateManyByIdAndUserId).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/apps/web/src/app/api/u/[slug]/connectors/[id]/tool-permissions/route.ts
+++ b/apps/web/src/app/api/u/[slug]/connectors/[id]/tool-permissions/route.ts
@@ -15,6 +15,13 @@ import {
 } from '@/lib/connectors/tool-permissions'
 import type { ConnectorType } from '@/lib/connectors/types'
 import { validateConnectorConfig, validateConnectorType } from '@/lib/connectors/validators'
+import {
+  normalizeZendeskActionPermissions,
+} from '@/lib/connectors/zendesk'
+import {
+  ZENDESK_ACTION_KEYS,
+  type ZendeskActionName,
+} from '@/lib/connectors/zendesk-types'
 import { requireCapability } from '@/lib/runtime/require-capability'
 import { withAuth } from '@/lib/runtime/with-auth'
 import { connectorService, userService } from '@/lib/services'
@@ -43,6 +50,28 @@ function fallbackToolsFromStoredPermissions(
     name,
     title: name,
   }))
+}
+
+function toZendeskActionTitle(name: string): string {
+  const formatted = name.replace(/_/g, ' ').trim()
+  return formatted ? formatted.charAt(0).toUpperCase() + formatted.slice(1) : name
+}
+
+// Zendesk policies are canonical action state, not generic tool-permission
+// state: the read path projects the normalized actions so the response can
+// never disagree with Zendesk settings, and writes are rejected so a second,
+// independently editable policy surface cannot exist.
+function buildZendeskToolPermissionsResponse(
+  config: Record<string, unknown>
+): ConnectorToolPermissionsResponse {
+  const actions = normalizeZendeskActionPermissions(config)
+  const tools: ConnectorToolPermissionEntry[] = ZENDESK_ACTION_KEYS.map((action: ZendeskActionName) => ({
+    name: action,
+    title: toZendeskActionTitle(action),
+    permission: actions[action],
+  }))
+
+  return { tools, policyConfigured: true }
 }
 
 async function buildToolPermissionsResponse(input: {
@@ -135,6 +164,10 @@ export const GET = withAuth<
   const context = await getConnectorContext(slug, id)
   if (!context.ok) return context.response
 
+  if (context.connectorType === 'zendesk') {
+    return NextResponse.json(buildZendeskToolPermissionsResponse(context.config))
+  }
+
   return NextResponse.json(
     await buildToolPermissionsResponse({
       connectorType: context.connectorType,
@@ -152,6 +185,16 @@ export const PATCH = withAuth<
 
   const context = await getConnectorContext(slug, id)
   if (!context.ok) return context.response
+
+  if (context.connectorType === 'zendesk') {
+    return NextResponse.json(
+      {
+        error: 'unsupported_connector',
+        message: 'Zendesk tool permissions are managed through Zendesk settings.',
+      },
+      { status: 409 },
+    )
+  }
 
   let body: UpdateConnectorToolPermissionsRequest
   try {

--- a/apps/web/src/app/api/u/[slug]/connectors/[id]/zendesk-settings/__tests__/route.test.ts
+++ b/apps/web/src/app/api/u/[slug]/connectors/[id]/zendesk-settings/__tests__/route.test.ts
@@ -11,9 +11,6 @@ const mocks = vi.hoisted(() => ({
   auditEvent: vi.fn(),
   decryptConfig: vi.fn(),
   encryptConfig: vi.fn(),
-  parseZendeskConnectorConfig: vi.fn(),
-  parseZendeskConnectorPermissions: vi.fn(),
-  getZendeskConnectorPermissionsConstraintMessage: vi.fn(() => null),
   connectorService: {
     findByIdAndUserId: vi.fn(),
     updateManyByIdAndUserId: vi.fn(),
@@ -35,17 +32,13 @@ vi.mock('@/lib/connectors/crypto', () => ({
   decryptConfig: mocks.decryptConfig,
   encryptConfig: mocks.encryptConfig,
 }))
-vi.mock('@/lib/connectors/zendesk', () => ({
-  parseZendeskConnectorConfig: mocks.parseZendeskConnectorConfig,
-  parseZendeskConnectorPermissions: mocks.parseZendeskConnectorPermissions,
-  getZendeskConnectorPermissionsConstraintMessage: mocks.getZendeskConnectorPermissionsConstraintMessage,
-}))
 vi.mock('@/lib/services', () => ({
   connectorService: mocks.connectorService,
   userService: mocks.userService,
 }))
 
 import { GET, PATCH } from '../route'
+import { DEFAULT_ZENDESK_ACTION_PERMISSIONS } from '@/lib/connectors/zendesk-types'
 
 const SESSION = {
   user: { id: 'u1', email: 'admin@test.com', slug: 'admin', role: 'ADMIN' },
@@ -54,13 +47,16 @@ const SESSION = {
 
 const CONNECTOR = { id: 'c1', type: 'zendesk', config: 'encrypted', enabled: true }
 
-const PARSED_CONFIG = {
-  ok: true as const,
-  value: {
-    subdomain: 'test',
-    email: 'a@b.com',
-    apiToken: 'tok',
-    permissions: { tickets: { read: true, write: false } },
+const LEGACY_CONFIG = {
+  subdomain: 'test',
+  email: 'a@b.com',
+  apiToken: 'tok',
+  permissions: {
+    allowRead: true,
+    allowCreateTickets: true,
+    allowUpdateTickets: true,
+    allowPublicComments: true,
+    allowInternalComments: true,
   },
 }
 
@@ -86,14 +82,39 @@ describe('GET /api/u/[slug]/connectors/[id]/zendesk-settings', () => {
     mocks.getSession.mockResolvedValue(SESSION)
     mocks.userService.findIdBySlug.mockResolvedValue({ id: 'u1' })
     mocks.connectorService.findByIdAndUserId.mockResolvedValue(CONNECTOR)
-    mocks.decryptConfig.mockReturnValue({ subdomain: 'test' })
-    mocks.parseZendeskConnectorConfig.mockReturnValue(PARSED_CONFIG)
+    mocks.decryptConfig.mockReturnValue({ ...LEGACY_CONFIG })
   })
 
-  it('returns permissions on success', async () => {
+  it('returns legacy permissions and normalized canonical actions', async () => {
     const res = await GET(makeGetRequest(), params())
     const body = await res.json()
-    expect(body.permissions).toEqual({ tickets: { read: true, write: false } })
+    expect(body.permissions).toEqual(LEGACY_CONFIG.permissions)
+    expect(body.zendeskActionPermissions).toEqual({
+      version: 1,
+      actions: DEFAULT_ZENDESK_ACTION_PERMISSIONS,
+    })
+  })
+
+  it('normalizes disabled legacy booleans in memory without a save', async () => {
+    mocks.decryptConfig.mockReturnValue({
+      ...LEGACY_CONFIG,
+      permissions: { ...LEGACY_CONFIG.permissions, allowPublicComments: false },
+    })
+    const res = await GET(makeGetRequest(), params())
+    const body = await res.json()
+    expect(body.zendeskActionPermissions.actions.create_ticket_public).toBe('deny')
+    expect(body.zendeskActionPermissions.actions.create_ticket_internal).toBe('allow')
+  })
+
+  it('returns stored canonical actions when present', async () => {
+    const actions = { ...DEFAULT_ZENDESK_ACTION_PERMISSIONS, update_ticket_fields: 'ask' as const }
+    mocks.decryptConfig.mockReturnValue({
+      ...LEGACY_CONFIG,
+      zendeskActionPermissions: { version: 1, actions },
+    })
+    const res = await GET(makeGetRequest(), params())
+    const body = await res.json()
+    expect(body.zendeskActionPermissions).toEqual({ version: 1, actions })
   })
 
   it('returns 404 when user not found', async () => {
@@ -121,7 +142,7 @@ describe('GET /api/u/[slug]/connectors/[id]/zendesk-settings', () => {
   })
 
   it('returns 500 when config parsing fails', async () => {
-    mocks.parseZendeskConnectorConfig.mockReturnValue({ ok: false, missing: ['subdomain'] })
+    mocks.decryptConfig.mockReturnValue({ subdomain: 'test' })
     const res = await GET(makeGetRequest(), params())
     expect(res.status).toBe(500)
   })
@@ -133,27 +154,117 @@ describe('PATCH /api/u/[slug]/connectors/[id]/zendesk-settings', () => {
     mocks.getSession.mockResolvedValue(SESSION)
     mocks.userService.findIdBySlug.mockResolvedValue({ id: 'u1' })
     mocks.connectorService.findByIdAndUserId.mockResolvedValue(CONNECTOR)
-    mocks.decryptConfig.mockReturnValue({ subdomain: 'test' })
-    mocks.parseZendeskConnectorConfig.mockReturnValue(PARSED_CONFIG)
-    mocks.parseZendeskConnectorPermissions.mockReturnValue({
-      ok: true,
-      value: { tickets: { read: true, write: true } },
-    })
-    mocks.getZendeskConnectorPermissionsConstraintMessage.mockReturnValue(null)
+    mocks.decryptConfig.mockReturnValue({ ...LEGACY_CONFIG })
     mocks.encryptConfig.mockReturnValue('new-encrypted')
     mocks.connectorService.updateManyByIdAndUserId.mockResolvedValue({ count: 1 })
   })
 
-  it('updates permissions and audits', async () => {
+  it('persists canonical actions and dual-writes the legacy projection in one update', async () => {
+    const actions = {
+      ...DEFAULT_ZENDESK_ACTION_PERMISSIONS,
+      create_ticket_public: 'deny' as const,
+      update_ticket_with_internal_note: 'ask' as const,
+    }
     const res = await PATCH(
-      makePatchRequest({ permissions: { tickets: { read: true, write: true } } }),
+      makePatchRequest({ zendeskActionPermissions: { version: 1, actions } }),
       params(),
     )
+    expect(res.status).toBe(200)
     const body = await res.json()
-    expect(body.permissions).toEqual({ tickets: { read: true, write: true } })
+    expect(body.zendeskActionPermissions).toEqual({ version: 1, actions })
+
+    const written = mocks.encryptConfig.mock.calls[0][0] as Record<string, unknown>
+    expect(written.zendeskActionPermissions).toEqual({ version: 1, actions })
+    expect(written.permissions).toEqual({
+      allowRead: true,
+      allowCreateTickets: false,
+      allowUpdateTickets: true,
+      allowPublicComments: false,
+      allowInternalComments: true,
+    })
+    expect(written.mcpToolPermissions).toEqual({
+      search_tickets: 'allow',
+      get_ticket: 'allow',
+      list_ticket_comments: 'allow',
+      create_ticket: 'deny',
+      update_ticket: 'ask',
+    })
+    expect(mocks.connectorService.updateManyByIdAndUserId).toHaveBeenCalledTimes(1)
     expect(mocks.auditEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ action: 'connector.zendesk_settings_updated' }),
+      expect.objectContaining({
+        action: 'connector.zendesk_settings_updated',
+        metadata: expect.objectContaining({ connectorId: 'c1', zendeskActionPermissions: { version: 1, actions } }),
+      }),
     )
+  })
+
+  it('normalizes a legacy boolean request into canonical actions', async () => {
+    const res = await PATCH(
+      makePatchRequest({
+        permissions: {
+          allowRead: true,
+          allowCreateTickets: true,
+          allowUpdateTickets: true,
+          allowPublicComments: false,
+          allowInternalComments: true,
+        },
+      }),
+      params(),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.zendeskActionPermissions.actions.create_ticket_public).toBe('deny')
+    expect(body.zendeskActionPermissions.actions.create_ticket_internal).toBe('allow')
+
+    const written = mocks.encryptConfig.mock.calls[0][0] as Record<string, unknown>
+    expect(written.zendeskActionPermissions).toEqual(body.zendeskActionPermissions)
+  })
+
+  it('preserves unrelated stored tool-permission entries when projecting', async () => {
+    mocks.decryptConfig.mockReturnValue({
+      ...LEGACY_CONFIG,
+      mcpToolPermissions: { custom_entry: 'deny' },
+    })
+    await PATCH(
+      makePatchRequest({ zendeskActionPermissions: { version: 1, actions: DEFAULT_ZENDESK_ACTION_PERMISSIONS } }),
+      params(),
+    )
+    const written = mocks.encryptConfig.mock.calls[0][0] as Record<string, unknown>
+    expect(written.mcpToolPermissions).toEqual(
+      expect.objectContaining({ custom_entry: 'deny', create_ticket: 'allow', update_ticket: 'allow' })
+    )
+  })
+
+  it('preserves credentials in the updated config', async () => {
+    await PATCH(
+      makePatchRequest({ zendeskActionPermissions: { version: 1, actions: DEFAULT_ZENDESK_ACTION_PERMISSIONS } }),
+      params(),
+    )
+    const written = mocks.encryptConfig.mock.calls[0][0] as Record<string, unknown>
+    expect(written.subdomain).toBe('test')
+    expect(written.email).toBe('a@b.com')
+    expect(written.apiToken).toBe('tok')
+  })
+
+  it('returns 400 for an invalid canonical payload', async () => {
+    const res = await PATCH(
+      makePatchRequest({ zendeskActionPermissions: { version: 1, actions: { search_tickets: 'allow' } } }),
+      params(),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for an invalid legacy permissions payload', async () => {
+    const res = await PATCH(
+      makePatchRequest({ permissions: { allowRead: 'yes' } }),
+      params(),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when neither shape is provided', async () => {
+    const res = await PATCH(makePatchRequest({}), params())
+    expect(res.status).toBe(400)
   })
 
   it('returns 400 for invalid JSON', async () => {
@@ -166,48 +277,33 @@ describe('PATCH /api/u/[slug]/connectors/[id]/zendesk-settings', () => {
     expect(res.status).toBe(400)
   })
 
-  it('returns 400 when permissions validation fails', async () => {
-    mocks.parseZendeskConnectorPermissions.mockReturnValue({
-      ok: false,
-      message: 'invalid field',
-    })
-    const res = await PATCH(makePatchRequest({ permissions: {} }), params())
-    expect(res.status).toBe(400)
-  })
-
-  it('returns 400 when constraint message exists', async () => {
-    mocks.getZendeskConnectorPermissionsConstraintMessage.mockReturnValue('At least one must be enabled')
-    const res = await PATCH(makePatchRequest({ permissions: {} }), params())
-    expect(res.status).toBe(400)
-  })
-
   it('returns 404 when update affects 0 rows', async () => {
     mocks.connectorService.updateManyByIdAndUserId.mockResolvedValue({ count: 0 })
-    const res = await PATCH(makePatchRequest({ permissions: {} }), params())
+    const res = await PATCH(makePatchRequest({ zendeskActionPermissions: { version: 1, actions: DEFAULT_ZENDESK_ACTION_PERMISSIONS } }), params())
     expect(res.status).toBe(404)
   })
 
   it('returns 400 when encryption fails', async () => {
     mocks.encryptConfig.mockImplementation(() => { throw new Error('too large') })
-    const res = await PATCH(makePatchRequest({ permissions: {} }), params())
+    const res = await PATCH(makePatchRequest({ zendeskActionPermissions: { version: 1, actions: DEFAULT_ZENDESK_ACTION_PERMISSIONS } }), params())
     expect(res.status).toBe(400)
   })
 
   it('returns 404 when user is not found', async () => {
     mocks.userService.findIdBySlug.mockResolvedValue(null)
-    const res = await PATCH(makePatchRequest({ permissions: {} }), params())
+    const res = await PATCH(makePatchRequest({ zendeskActionPermissions: { version: 1, actions: DEFAULT_ZENDESK_ACTION_PERMISSIONS } }), params())
     expect(res.status).toBe(404)
   })
 
   it('returns 404 when connector is not found', async () => {
     mocks.connectorService.findByIdAndUserId.mockResolvedValue(null)
-    const res = await PATCH(makePatchRequest({ permissions: {} }), params())
+    const res = await PATCH(makePatchRequest({ zendeskActionPermissions: { version: 1, actions: DEFAULT_ZENDESK_ACTION_PERMISSIONS } }), params())
     expect(res.status).toBe(404)
   })
 
   it('returns 400 when connector is not zendesk', async () => {
     mocks.connectorService.findByIdAndUserId.mockResolvedValue({ ...CONNECTOR, type: 'linear' })
-    const res = await PATCH(makePatchRequest({ permissions: {} }), params())
+    const res = await PATCH(makePatchRequest({ zendeskActionPermissions: { version: 1, actions: DEFAULT_ZENDESK_ACTION_PERMISSIONS } }), params())
     expect(res.status).toBe(400)
   })
 
@@ -218,13 +314,7 @@ describe('PATCH /api/u/[slug]/connectors/[id]/zendesk-settings', () => {
 
   it('returns 500 when decryption fails', async () => {
     mocks.decryptConfig.mockImplementation(() => { throw new Error('bad') })
-    const res = await PATCH(makePatchRequest({ permissions: {} }), params())
-    expect(res.status).toBe(500)
-  })
-
-  it('returns 500 when existing config parsing fails', async () => {
-    mocks.parseZendeskConnectorConfig.mockReturnValue({ ok: false, message: 'invalid config' })
-    const res = await PATCH(makePatchRequest({ permissions: {} }), params())
+    const res = await PATCH(makePatchRequest({ zendeskActionPermissions: { version: 1, actions: DEFAULT_ZENDESK_ACTION_PERMISSIONS } }), params())
     expect(res.status).toBe(500)
   })
 })

--- a/apps/web/src/app/api/u/[slug]/connectors/[id]/zendesk-settings/route.ts
+++ b/apps/web/src/app/api/u/[slug]/connectors/[id]/zendesk-settings/route.ts
@@ -3,21 +3,38 @@ import { NextRequest, NextResponse } from 'next/server'
 import { auditEvent } from '@/lib/auth'
 import { decryptConfig, encryptConfig } from '@/lib/connectors/crypto'
 import {
-  getZendeskConnectorPermissionsConstraintMessage,
+  getStoredConnectorToolPermissions,
+} from '@/lib/connectors/tool-permissions'
+import {
+  buildLegacyProjectionFromActionPermissions,
+  mergeLegacyToolPermissions,
+  normalizeZendeskActionPermissions,
+  parseZendeskActionPermissionsConfig,
   parseZendeskConnectorConfig,
   parseZendeskConnectorPermissions,
-  type ZendeskConnectorPermissions,
+  type ZendeskActionPermissions,
 } from '@/lib/connectors/zendesk'
+import {
+  ZENDESK_ACTION_PERMISSIONS_CONFIG_KEY,
+  ZENDESK_ACTION_PERMISSIONS_VERSION,
+} from '@/lib/connectors/zendesk-types'
 import { requireCapability } from '@/lib/runtime/require-capability'
 import { withAuth } from '@/lib/runtime/with-auth'
 import { connectorService, userService } from '@/lib/services'
 
+type ZendeskActionPermissionsPayload = {
+  version: typeof ZENDESK_ACTION_PERMISSIONS_VERSION
+  actions: ZendeskActionPermissions
+}
+
 type ZendeskConnectorSettingsResponse = {
-  permissions: ZendeskConnectorPermissions
+  permissions: Record<string, unknown>
+  zendeskActionPermissions: ZendeskActionPermissionsPayload
 }
 
 type UpdateZendeskConnectorSettingsRequest = {
   permissions?: unknown
+  zendeskActionPermissions?: unknown
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
@@ -66,8 +83,42 @@ export const GET = withAuth<
     )
   }
 
-  return NextResponse.json({ permissions: parsedConfig.value.permissions })
+  return NextResponse.json({
+    permissions: parsedConfig.value.permissions,
+    zendeskActionPermissions: {
+      version: ZENDESK_ACTION_PERMISSIONS_VERSION,
+      actions: normalizeZendeskActionPermissions(config),
+    },
+  })
 })
+
+function buildUpdatedConfig(input: {
+  config: Record<string, unknown>
+  parsedConfig: Extract<ReturnType<typeof parseZendeskConnectorConfig>, { ok: true }>['value']
+  actions: ZendeskActionPermissions
+}): {
+  config: Record<string, unknown>
+  permissions: Record<string, unknown>
+} {
+  const projection = buildLegacyProjectionFromActionPermissions(input.actions)
+
+  return {
+    config: {
+      ...input.config,
+      ...input.parsedConfig,
+      permissions: projection.permissions,
+      mcpToolPermissions: mergeLegacyToolPermissions(
+        getStoredConnectorToolPermissions(input.config),
+        projection.legacyToolPermissions
+      ),
+      [ZENDESK_ACTION_PERMISSIONS_CONFIG_KEY]: {
+        version: ZENDESK_ACTION_PERMISSIONS_VERSION,
+        actions: input.actions,
+      },
+    },
+    permissions: projection.permissions,
+  }
+}
 
 export const PATCH = withAuth<
   ZendeskConnectorSettingsResponse | { error: string; message?: string },
@@ -108,20 +159,30 @@ export const PATCH = withAuth<
     )
   }
 
-  const parsedPermissions = parseZendeskConnectorPermissions(body.permissions, { requireAll: true })
-  if (!parsedPermissions.ok) {
+  let update:
+    | { kind: 'canonical'; actions: ZendeskActionPermissions }
+    | { kind: 'legacy'; permissions: Record<string, unknown> }
+  if (body.zendeskActionPermissions !== undefined) {
+    const parsedActions = parseZendeskActionPermissionsConfig(body.zendeskActionPermissions)
+    if (!parsedActions.ok) {
+      return NextResponse.json(
+        { error: 'invalid_permissions', message: parsedActions.message },
+        { status: 400 }
+      )
+    }
+    update = { kind: 'canonical', actions: parsedActions.value.actions }
+  } else if (body.permissions !== undefined) {
+    const parsedPermissions = parseZendeskConnectorPermissions(body.permissions, { requireAll: true })
+    if (!parsedPermissions.ok) {
+      return NextResponse.json(
+        { error: 'invalid_permissions', message: parsedPermissions.message },
+        { status: 400 }
+      )
+    }
+    update = { kind: 'legacy', permissions: parsedPermissions.value }
+  } else {
     return NextResponse.json(
-      { error: 'invalid_permissions', message: parsedPermissions.message },
-      { status: 400 }
-    )
-  }
-
-  const permissionsMessage = getZendeskConnectorPermissionsConstraintMessage(
-    parsedPermissions.value
-  )
-  if (permissionsMessage) {
-    return NextResponse.json(
-      { error: 'invalid_permissions', message: permissionsMessage },
+      { error: 'invalid_permissions', message: 'permissions or zendeskActionPermissions is required' },
       { status: 400 }
     )
   }
@@ -147,15 +208,20 @@ export const PATCH = withAuth<
     )
   }
 
-  const updatedConfig = {
-    ...config,
-    ...parsedConfig.value,
-    permissions: parsedPermissions.value,
-  }
+  // A legacy boolean request is normalized into canonical actions before it is
+  // persisted, so both request shapes converge on the same stored state.
+  const actions = update.kind === 'canonical'
+    ? update.actions
+    : normalizeZendeskActionPermissions({
+        ...config,
+        permissions: update.permissions,
+      })
+
+  const updated = buildUpdatedConfig({ config, parsedConfig: parsedConfig.value, actions })
 
   let encryptedConfig: string
   try {
-    encryptedConfig = encryptConfig(updatedConfig)
+    encryptedConfig = encryptConfig(updated.config)
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to encrypt config'
     return NextResponse.json({ error: 'invalid_config', message }, { status: 400 })
@@ -173,9 +239,19 @@ export const PATCH = withAuth<
     action: 'connector.zendesk_settings_updated',
     metadata: {
       connectorId: id,
-      permissions: parsedPermissions.value,
+      permissions: updated.permissions,
+      zendeskActionPermissions: {
+        version: ZENDESK_ACTION_PERMISSIONS_VERSION,
+        actions,
+      },
     },
   })
 
-  return NextResponse.json({ permissions: parsedPermissions.value })
+  return NextResponse.json({
+    permissions: updated.permissions,
+    zendeskActionPermissions: {
+      version: ZENDESK_ACTION_PERMISSIONS_VERSION,
+      actions,
+    },
+  })
 })

--- a/apps/web/src/components/connectors/__tests__/zendesk-connector-settings-dialog.test.tsx
+++ b/apps/web/src/components/connectors/__tests__/zendesk-connector-settings-dialog.test.tsx
@@ -4,22 +4,49 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ZendeskConnectorSettingsDialog } from '@/components/connectors/zendesk-connector-settings-dialog'
+import {
+  DEFAULT_ZENDESK_ACTION_PERMISSIONS,
+  ZENDESK_ACTION_KEYS,
+  type ZendeskActionName,
+  type ZendeskActionPermissions,
+  type ZendeskActionPolicy,
+} from '@/lib/connectors/zendesk-types'
 
-function getPermissionSwitch(label: string): HTMLButtonElement {
+const mocks = vi.hoisted(() => ({
+  notifyWorkspaceConfigChanged: vi.fn(),
+}))
+
+vi.mock('@/lib/runtime/config-status-events', () => ({
+  notifyWorkspaceConfigChanged: mocks.notifyWorkspaceConfigChanged,
+}))
+
+function getActionButtons(label: string): HTMLButtonElement[] {
   const labelElement = screen.getByText(label)
   const field = labelElement.parentElement?.parentElement
-  const switchElement = field?.querySelector('[role="switch"]')
+  const buttons = Array.from(field?.querySelectorAll('button') ?? [])
 
-  if (!(switchElement instanceof HTMLButtonElement)) {
-    throw new Error(`Switch not found for ${label}`)
+  if (buttons.length !== 3) {
+    throw new Error(`Policy selector not found for ${label}`)
   }
 
-  return switchElement
+  return buttons as HTMLButtonElement[]
+}
+
+function settingsResponse(actions: ZendeskActionPermissions) {
+  return {
+    permissions: {},
+    zendeskActionPermissions: { version: 1, actions },
+  }
+}
+
+function actionsWith(overrides: Partial<Record<ZendeskActionName, ZendeskActionPolicy>>): ZendeskActionPermissions {
+  return { ...DEFAULT_ZENDESK_ACTION_PERMISSIONS, ...overrides }
 }
 
 describe('ZendeskConnectorSettingsDialog', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    mocks.notifyWorkspaceConfigChanged.mockClear()
   })
 
   afterEach(() => {
@@ -80,8 +107,13 @@ describe('ZendeskConnectorSettingsDialog', () => {
     const saveButton = screen.getByRole('button', { name: 'Save settings' }) as HTMLButtonElement
     expect(saveButton.disabled).toBe(true)
 
-    for (const switchElement of screen.getAllByRole('switch')) {
-      expect((switchElement as HTMLButtonElement).disabled).toBe(true)
+    for (const selectorLabel of [
+      'Search tickets',
+      'Create tickets with a public comment',
+    ]) {
+      for (const button of getActionButtons(selectorLabel)) {
+        expect(button.disabled).toBe(true)
+      }
     }
 
     fireEvent.click(saveButton)
@@ -91,26 +123,11 @@ describe('ZendeskConnectorSettingsDialog', () => {
     })
   })
 
-  it('prevents enabling ticket creation without an allowed comment type', async () => {
+  it('renders a Deny/Ask/Allow selector for all eight actions without a generic tool section', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: true,
-      json: async () => ({
-        permissions: {
-          allowRead: true,
-          allowCreateTickets: false,
-          allowUpdateTickets: true,
-          allowPublicComments: false,
-          allowInternalComments: false,
-        },
-      }),
-    }).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        tools: [],
-        policyConfigured: false,
-      }),
+      json: async () => settingsResponse(DEFAULT_ZENDESK_ACTION_PERMISSIONS),
     })
-
     vi.stubGlobal('fetch', fetchMock)
 
     render(
@@ -124,63 +141,73 @@ describe('ZendeskConnectorSettingsDialog', () => {
     )
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
     })
 
-    expect(screen.getByText('Enable public comments or internal notes before allowing ticket creation.')).toBeTruthy()
-
-    const createTicketsSwitch = getPermissionSwitch('Create tickets')
-    expect(createTicketsSwitch.disabled).toBe(true)
-
-    fireEvent.click(getPermissionSwitch('Public comments'))
-
-    expect(getPermissionSwitch('Public comments').getAttribute('aria-checked')).toBe('true')
-    expect(getPermissionSwitch('Create tickets').disabled).toBe(false)
-
-    fireEvent.click(getPermissionSwitch('Create tickets'))
-
-    expect(getPermissionSwitch('Create tickets').getAttribute('aria-checked')).toBe('true')
-    expect(getPermissionSwitch('Public comments').disabled).toBe(true)
-    expect(
-      screen.getByText(
-        'Ticket creation needs at least one comment option. Disable ticket creation first to turn off the last enabled comment type.'
-      )
-    ).toBeTruthy()
+    const labels = [
+      'Search tickets',
+      'Read ticket details',
+      'List ticket comments',
+      'Update ticket fields',
+      'Create tickets with a public comment',
+      'Update tickets with a public comment',
+      'Create tickets with an internal note',
+      'Update tickets with an internal note',
+    ]
+    for (const label of labels) {
+      const [deny, ask, allow] = getActionButtons(label)
+      expect(deny.textContent).toBe('Deny')
+      expect(ask.textContent).toBe('Ask')
+      expect(allow.textContent).toBe('Allow')
+    }
+    expect(screen.queryByText('Tool permissions')).toBeNull()
   })
 
-  it('saves loaded permissions and closes the dialog', async () => {
+  it('accepts all-denied creation actions without cross-field constraints', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => settingsResponse(DEFAULT_ZENDESK_ACTION_PERMISSIONS),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <ZendeskConnectorSettingsDialog
+        open
+        slug="alice"
+        connectorId="conn-zendesk-1"
+        connectorName="Zendesk"
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.click(getActionButtons('Create tickets with a public comment')[0])
+    fireEvent.click(getActionButtons('Create tickets with an internal note')[0])
+    fireEvent.click(getActionButtons('Update tickets with a public comment')[0])
+    fireEvent.click(getActionButtons('Update tickets with an internal note')[0])
+
+    const saveButton = screen.getByRole('button', { name: 'Save settings' }) as HTMLButtonElement
+    expect(saveButton.disabled).toBe(false)
+    expect(screen.queryByText(/Ticket creation requires/)).toBeNull()
+  })
+
+  it('loads, edits, saves the complete canonical map, and closes the dialog', async () => {
     const onOpenChange = vi.fn()
+    const loaded = actionsWith({
+      create_ticket_public: 'ask',
+      update_ticket_fields: 'deny',
+    })
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({
-          permissions: {
-            allowRead: true,
-            allowCreateTickets: false,
-            allowUpdateTickets: true,
-            allowPublicComments: true,
-            allowInternalComments: false,
-          },
-        }),
+        json: async () => settingsResponse(loaded),
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({
-          tools: [],
-          policyConfigured: false,
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          permissions: {
-            allowRead: false,
-            allowCreateTickets: false,
-            allowUpdateTickets: true,
-            allowPublicComments: true,
-            allowInternalComments: false,
-          },
-        }),
+        json: async () => settingsResponse(loaded),
       })
 
     vi.stubGlobal('fetch', fetchMock)
@@ -196,27 +223,30 @@ describe('ZendeskConnectorSettingsDialog', () => {
     )
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
     })
 
-    fireEvent.click(getPermissionSwitch('Read tickets'))
+    fireEvent.click(getActionButtons('List ticket comments')[0])
+
     fireEvent.click(screen.getByRole('button', { name: 'Save settings' }))
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(3)
+      expect(fetchMock).toHaveBeenCalledTimes(2)
     })
-    const [, patchRequest] = fetchMock.mock.calls[2] as [string, RequestInit]
+    const [, patchRequest] = fetchMock.mock.calls[1] as [string, RequestInit]
     expect(patchRequest.method).toBe('PATCH')
     expect(JSON.parse(String(patchRequest.body))).toEqual({
-      permissions: {
-        allowRead: false,
-        allowCreateTickets: false,
-        allowUpdateTickets: true,
-        allowPublicComments: true,
-        allowInternalComments: false,
+      zendeskActionPermissions: {
+        version: 1,
+        actions: actionsWith({
+          create_ticket_public: 'ask',
+          update_ticket_fields: 'deny',
+          list_ticket_comments: 'deny',
+        }),
       },
     })
     expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(mocks.notifyWorkspaceConfigChanged).toHaveBeenCalledOnce()
   })
 
   it('shows save errors without closing the dialog', async () => {
@@ -224,22 +254,7 @@ describe('ZendeskConnectorSettingsDialog', () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({
-          permissions: {
-            allowRead: true,
-            allowCreateTickets: false,
-            allowUpdateTickets: true,
-            allowPublicComments: true,
-            allowInternalComments: false,
-          },
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          tools: [],
-          policyConfigured: false,
-        }),
+        json: async () => settingsResponse(DEFAULT_ZENDESK_ACTION_PERMISSIONS),
       })
       .mockResolvedValueOnce({
         ok: false,
@@ -259,12 +274,75 @@ describe('ZendeskConnectorSettingsDialog', () => {
     )
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
     })
 
+    fireEvent.click(getActionButtons('Search tickets')[0])
     fireEvent.click(screen.getByRole('button', { name: 'Save settings' }))
 
     expect(await screen.findByText('Failed to save connector changes.')).toBeTruthy()
     expect(onOpenChange).not.toHaveBeenCalled()
+    expect(mocks.notifyWorkspaceConfigChanged).not.toHaveBeenCalled()
+  })
+
+  it('preserves loaded policies across every action when saving unchanged state', async () => {
+    const onOpenChange = vi.fn()
+    const loaded = actionsWith(
+      Object.fromEntries(ZENDESK_ACTION_KEYS.map((key, index) => [key, (['deny', 'ask', 'allow'] as const)[index % 3]])) as
+        Partial<Record<ZendeskActionName, ZendeskActionPolicy>>
+    )
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => settingsResponse(loaded),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => settingsResponse(loaded),
+      })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <ZendeskConnectorSettingsDialog
+        open
+        slug="alice"
+        connectorId="conn-zendesk-1"
+        connectorName="Zendesk"
+        onOpenChange={onOpenChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    for (const [action, policy] of Object.entries(loaded)) {
+      const policyIndex = policy === 'deny' ? 0 : policy === 'ask' ? 1 : 2
+      const buttons = getActionButtons(
+        {
+          search_tickets: 'Search tickets',
+          get_ticket: 'Read ticket details',
+          list_ticket_comments: 'List ticket comments',
+          create_ticket_public: 'Create tickets with a public comment',
+          create_ticket_internal: 'Create tickets with an internal note',
+          update_ticket_fields: 'Update ticket fields',
+          update_ticket_with_public_comment: 'Update tickets with a public comment',
+          update_ticket_with_internal_note: 'Update tickets with an internal note',
+        }[action as ZendeskActionName]
+      )
+      expect(buttons[policyIndex].className).toContain('bg-primary')
+    }
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save settings' }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+    const [, patchRequest] = fetchMock.mock.calls[1] as [string, RequestInit]
+    expect(JSON.parse(String(patchRequest.body))).toEqual({
+      zendeskActionPermissions: { version: 1, actions: loaded },
+    })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 })

--- a/apps/web/src/components/connectors/zendesk-connector-settings-dialog.tsx
+++ b/apps/web/src/components/connectors/zendesk-connector-settings-dialog.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react'
 import { SpinnerGap } from '@phosphor-icons/react'
 
 import { getConnectorErrorMessage } from '@/components/connectors/error-messages'
-import { ConnectorToolPermissionsSection } from '@/components/connectors/connector-tool-permissions-section'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -13,14 +12,14 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Switch } from '@/components/ui/switch'
 import {
-  getZendeskConnectorPermissionsConstraintMessage,
-} from '@/lib/connectors/zendesk'
-import {
-  DEFAULT_ZENDESK_CONNECTOR_PERMISSIONS,
-  type ZendeskConnectorPermissions,
+  DEFAULT_ZENDESK_ACTION_PERMISSIONS,
+  type ZendeskActionName,
+  type ZendeskActionPermissions,
+  type ZendeskActionPolicy,
 } from '@/lib/connectors/zendesk-types'
+import { notifyWorkspaceConfigChanged } from '@/lib/runtime/config-status-events'
+import { cn } from '@/lib/utils'
 
 type ZendeskConnectorSettingsDialogProps = {
   open: boolean
@@ -31,25 +30,134 @@ type ZendeskConnectorSettingsDialogProps = {
 }
 
 type ZendeskSettingsResponse = {
-  permissions: ZendeskConnectorPermissions
+  permissions: Record<string, unknown>
+  zendeskActionPermissions: {
+    version: number
+    actions: ZendeskActionPermissions
+  }
 }
 
-type PermissionFieldProps = {
-  checked: boolean
+const ACTION_POLICY_LABELS: Record<ZendeskActionPolicy, string> = {
+  deny: 'Deny',
+  ask: 'Ask',
+  allow: 'Allow',
+}
+
+const ZENDESK_ACTION_GROUPS: Array<{
+  title: string
+  description: string
+  actions: Array<{ name: ZendeskActionName; label: string; description: string }>
+}> = [
+  {
+    title: 'Ticket reading',
+    description: 'Control whether the agent can inspect tickets and their comments.',
+    actions: [
+      {
+        name: 'search_tickets',
+        label: 'Search tickets',
+        description: 'Search tickets with Zendesk search queries.',
+      },
+      {
+        name: 'get_ticket',
+        label: 'Read ticket details',
+        description: 'Fetch a single ticket by ID.',
+      },
+      {
+        name: 'list_ticket_comments',
+        label: 'List ticket comments',
+        description: 'Read the comments on a ticket, public and internal.',
+      },
+    ],
+  },
+  {
+    title: 'Ticket updates',
+    description: 'Change ticket fields without adding a comment.',
+    actions: [
+      {
+        name: 'update_ticket_fields',
+        label: 'Update ticket fields',
+        description: 'Change subject, status, priority, type, or assignee without a comment.',
+      },
+    ],
+  },
+  {
+    title: 'Public communication',
+    description: 'Public comments can notify the requester by email.',
+    actions: [
+      {
+        name: 'create_ticket_public',
+        label: 'Create tickets with a public comment',
+        description: 'Open a new ticket whose initial comment is public.',
+      },
+      {
+        name: 'update_ticket_with_public_comment',
+        label: 'Update tickets with a public comment',
+        description: 'Add a public comment and optionally change fields in one update.',
+      },
+    ],
+  },
+  {
+    title: 'Internal communication',
+    description: 'Internal notes stay visible only to Zendesk agents.',
+    actions: [
+      {
+        name: 'create_ticket_internal',
+        label: 'Create tickets with an internal note',
+        description: 'Open a new ticket whose initial comment is internal.',
+      },
+      {
+        name: 'update_ticket_with_internal_note',
+        label: 'Update tickets with an internal note',
+        description: 'Add an internal note and optionally change fields in one update.',
+      },
+    ],
+  },
+]
+
+type ActionPolicySelectorProps = {
+  action: ZendeskActionName
   description: string
   disabled: boolean
   label: string
-  onCheckedChange: (checked: boolean) => void
+  value: ZendeskActionPolicy
+  onChange: (policy: ZendeskActionPolicy) => void
 }
 
-function PermissionField({ checked, description, disabled, label, onCheckedChange }: PermissionFieldProps) {
+function ActionPolicySelector({ action, description, disabled, label, value, onChange }: ActionPolicySelectorProps) {
+  const labelId = `${action}-policy-label`
+
   return (
-    <div className="flex items-start justify-between gap-4 rounded-xl border border-border/60 bg-card/40 px-4 py-3">
-      <div className="space-y-1">
-        <p className="text-sm font-medium text-foreground">{label}</p>
-        <p className="text-xs text-muted-foreground">{description}</p>
+    <div className="rounded-xl border border-border/60 bg-card/40 px-4 py-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <p id={labelId} className="text-sm font-medium text-foreground">{label}</p>
+          <p className="text-xs text-muted-foreground">{description}</p>
+        </div>
+
+        <div
+          role="group"
+          aria-labelledby={labelId}
+          className="grid shrink-0 grid-cols-3 overflow-hidden rounded-lg border border-border/60 text-xs"
+        >
+          {(['deny', 'ask', 'allow'] as const).map((policy) => (
+            <button
+              key={policy}
+              type="button"
+              disabled={disabled}
+              aria-pressed={value === policy}
+              onClick={() => onChange(policy)}
+              className={cn(
+                'px-3 py-1.5 transition-colors focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/30 disabled:opacity-50',
+                value === policy
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-background text-muted-foreground hover:bg-muted',
+              )}
+            >
+              {ACTION_POLICY_LABELS[policy]}
+            </button>
+          ))}
+        </div>
       </div>
-      <Switch checked={checked} disabled={disabled} onCheckedChange={onCheckedChange} />
     </div>
   )
 }
@@ -61,27 +169,16 @@ export function ZendeskConnectorSettingsDialog({
   connectorName,
   onOpenChange,
 }: ZendeskConnectorSettingsDialogProps) {
-  const [permissions, setPermissions] = useState<ZendeskConnectorPermissions>(DEFAULT_ZENDESK_CONNECTOR_PERMISSIONS)
+  const [actions, setActions] = useState<ZendeskActionPermissions>(DEFAULT_ZENDESK_ACTION_PERMISSIONS)
   const [hasLoadedSettings, setHasLoadedSettings] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const isLoading = open && Boolean(connectorId) && !hasLoadedSettings && error === null
-
-  const hasCommentVisibility = permissions.allowPublicComments || permissions.allowInternalComments
-  const permissionsConstraintMessage = getZendeskConnectorPermissionsConstraintMessage(permissions)
-  const canEditPermissions = hasLoadedSettings && !isLoading && !isSaving
-  const createTicketsDisabled =
-    !canEditPermissions || (!hasCommentVisibility && !permissions.allowCreateTickets)
-  const internalCommentsDisabled =
-    !canEditPermissions ||
-    (permissions.allowCreateTickets && permissions.allowInternalComments && !permissions.allowPublicComments)
-  const publicCommentsDisabled =
-    !canEditPermissions ||
-    (permissions.allowCreateTickets && permissions.allowPublicComments && !permissions.allowInternalComments)
+  const canEditActions = hasLoadedSettings && !isLoading && !isSaving
 
   function resetDialogState() {
-    setPermissions(DEFAULT_ZENDESK_CONNECTOR_PERMISSIONS)
+    setActions(DEFAULT_ZENDESK_ACTION_PERMISSIONS)
     setHasLoadedSettings(false)
     setError(null)
     setIsSaving(false)
@@ -112,12 +209,12 @@ export function ZendeskConnectorSettingsDialog({
 
         if (cancelled) return
 
-        if (!response.ok || !data?.permissions) {
+        if (!response.ok || !data?.zendeskActionPermissions?.actions) {
           setError(getConnectorErrorMessage(data, 'load_settings_failed'))
           return
         }
 
-        setPermissions(data.permissions)
+        setActions(data.zendeskActionPermissions.actions)
         setHasLoadedSettings(true)
         setError(null)
       } catch {
@@ -134,15 +231,15 @@ export function ZendeskConnectorSettingsDialog({
     }
   }, [connectorId, open, slug])
 
-  function updatePermission<K extends keyof ZendeskConnectorPermissions>(key: K, value: boolean) {
-    setPermissions((current) => ({
+  function updateAction(action: ZendeskActionName, policy: ZendeskActionPolicy) {
+    setActions((current) => ({
       ...current,
-      [key]: value,
+      [action]: policy,
     }))
   }
 
   async function handleSave() {
-    if (!connectorId || !hasLoadedSettings || isLoading || isSaving || permissionsConstraintMessage) {
+    if (!connectorId || !hasLoadedSettings || isLoading || isSaving) {
       return
     }
 
@@ -153,18 +250,24 @@ export function ZendeskConnectorSettingsDialog({
       const response = await fetch(`/api/u/${slug}/connectors/${connectorId}/zendesk-settings`, {
         method: 'PATCH',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ permissions }),
+        body: JSON.stringify({
+          zendeskActionPermissions: {
+            version: 1,
+            actions,
+          },
+        }),
       })
       const data = (await response.json().catch(() => null)) as
         | (ZendeskSettingsResponse & { error?: string; message?: string })
         | null
 
-      if (!response.ok || !data?.permissions) {
+      if (!response.ok || !data?.zendeskActionPermissions?.actions) {
         setError(getConnectorErrorMessage(data, 'save_failed'))
         return
       }
 
-      setPermissions(data.permissions)
+      setActions(data.zendeskActionPermissions.actions)
+      notifyWorkspaceConfigChanged()
       handleDialogOpenChange(false)
     } catch {
       setError(getConnectorErrorMessage(null, 'network_error'))
@@ -179,7 +282,8 @@ export function ZendeskConnectorSettingsDialog({
         <DialogHeader>
           <DialogTitle>Zendesk settings</DialogTitle>
           <DialogDescription>
-            Restrict what {connectorName ?? 'this connector'} can do. These limits are enforced by Arche before any Zendesk request is sent.
+            Restrict what {connectorName ?? 'this connector'} can do. Deny is enforced by Arche before
+            any Zendesk request is sent, and Ask requires approval in the workspace before the action runs.
           </DialogDescription>
         </DialogHeader>
 
@@ -197,91 +301,37 @@ export function ZendeskConnectorSettingsDialog({
             </p>
           ) : null}
 
-          {permissionsConstraintMessage ? (
-            <p className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-sm text-amber-700 dark:text-amber-300">
-              {permissionsConstraintMessage}
-            </p>
-          ) : null}
+          {!isLoading
+            ? ZENDESK_ACTION_GROUPS.map((group) => (
+                <section className="space-y-3" key={group.title}>
+                  <div className="space-y-1">
+                    <h3 className="text-sm font-semibold text-foreground">{group.title}</h3>
+                    <p className="text-xs text-muted-foreground">{group.description}</p>
+                  </div>
 
-          <section className="space-y-3">
-            <div className="space-y-1">
-              <h3 className="text-sm font-semibold text-foreground">Ticket access</h3>
-              <p className="text-xs text-muted-foreground">
-                Control whether the agent can inspect tickets or perform write operations.
-              </p>
-            </div>
-
-            <div className="space-y-3">
-              <PermissionField
-                checked={permissions.allowRead}
-                description="Allow searching tickets, reading ticket details and listing comments."
-                disabled={!canEditPermissions}
-                label="Read tickets"
-                onCheckedChange={(checked) => updatePermission('allowRead', checked)}
-              />
-              <PermissionField
-                checked={permissions.allowCreateTickets}
-                description="Allow creating new tickets in Zendesk."
-                disabled={createTicketsDisabled}
-                label="Create tickets"
-                onCheckedChange={(checked) => updatePermission('allowCreateTickets', checked)}
-              />
-              <PermissionField
-                checked={permissions.allowUpdateTickets}
-                description="Allow changing ticket fields and adding comments to existing tickets."
-                disabled={!canEditPermissions}
-                label="Update tickets"
-                onCheckedChange={(checked) => updatePermission('allowUpdateTickets', checked)}
-              />
-
-              {!hasCommentVisibility && !permissions.allowCreateTickets ? (
-                <p className="text-xs text-muted-foreground">
-                  Enable public comments or internal notes before allowing ticket creation.
-                </p>
-              ) : null}
-            </div>
-          </section>
-
-          <section className="space-y-3">
-            <div className="space-y-1">
-              <h3 className="text-sm font-semibold text-foreground">Comment visibility</h3>
-              <p className="text-xs text-muted-foreground">
-                Apply these limits to both ticket creation and updates. Requests outside this policy fail explicitly.
-              </p>
-            </div>
-
-            <div className="space-y-3">
-              <PermissionField
-                checked={permissions.allowInternalComments}
-                description="Allow private internal notes that stay visible only to Zendesk agents."
-                disabled={internalCommentsDisabled}
-                label="Internal notes"
-                onCheckedChange={(checked) => updatePermission('allowInternalComments', checked)}
-              />
-              <PermissionField
-                checked={permissions.allowPublicComments}
-                description="Allow public comments that can notify the requester by email."
-                disabled={publicCommentsDisabled}
-                label="Public comments"
-                onCheckedChange={(checked) => updatePermission('allowPublicComments', checked)}
-              />
-
-              {permissions.allowCreateTickets && permissions.allowPublicComments !== permissions.allowInternalComments ? (
-                <p className="text-xs text-muted-foreground">
-                  Ticket creation needs at least one comment option. Disable ticket creation first to turn off the last enabled comment type.
-                </p>
-              ) : null}
-            </div>
-          </section>
-
-          <ConnectorToolPermissionsSection connectorId={connectorId} enabled={open && hasLoadedSettings} slug={slug} />
+                  <div className="space-y-3">
+                    {group.actions.map((action) => (
+                      <ActionPolicySelector
+                        key={action.name}
+                        action={action.name}
+                        description={action.description}
+                        disabled={!canEditActions}
+                        label={action.label}
+                        value={actions[action.name]}
+                        onChange={(policy) => updateAction(action.name, policy)}
+                      />
+                    ))}
+                  </div>
+                </section>
+              ))
+            : null}
 
           <div className="flex justify-end gap-2">
             <Button disabled={isSaving} variant="ghost" onClick={() => handleDialogOpenChange(false)}>
               Cancel
             </Button>
             <Button
-              disabled={isLoading || isSaving || !connectorId || !hasLoadedSettings || Boolean(permissionsConstraintMessage)}
+              disabled={isLoading || isSaving || !connectorId || !hasLoadedSettings}
               onClick={() => void handleSave()}
             >
               {isSaving ? 'Saving...' : 'Save settings'}

--- a/apps/web/src/components/workspace/__tests__/permission-card.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/permission-card.test.tsx
@@ -1,0 +1,170 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { PermissionCard } from '@/components/workspace/chat-panel/permission-card'
+import type { WorkspacePermission } from '@/lib/opencode/permission'
+import type { PermissionToolPart } from '@/lib/opencode/permission-tool-parts'
+
+function makePermission(overrides: Partial<WorkspacePermission> = {}): WorkspacePermission {
+  return {
+    id: 'perm-1',
+    sessionId: 's1',
+    callId: 'call-1',
+    title: 'Approval required',
+    state: 'pending',
+    ...overrides,
+  }
+}
+
+const ZENDESK_TOOL_PART: PermissionToolPart = {
+  toolName: 'arche_zendesk_z1_create_ticket_public',
+  input: {
+    subject: 'Need help',
+    comment: 'The issue started this morning.',
+    priority: 'high',
+  },
+}
+
+// Production permission events reference the full MCP tool name in the title
+// or pattern; mirror that so recognition works before the tool part arrives.
+function makeZendeskPermission(toolName: string, overrides: Partial<WorkspacePermission> = {}): WorkspacePermission {
+  return makePermission({ title: toolName, pattern: toolName, ...overrides })
+}
+
+describe('PermissionCard Zendesk previews', () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  function renderCard(permission: WorkspacePermission, toolPart?: PermissionToolPart | null) {
+    const onAnswerPermission = vi.fn().mockResolvedValue(true)
+    render(
+      <PermissionCard
+        onAnswerPermission={onAnswerPermission}
+        permission={permission}
+        toolPart={toolPart}
+      />
+    )
+    return onAnswerPermission
+  }
+
+  function expectButtonsDisabled(disabled: boolean) {
+    for (const label of ['Allow once', 'Allow for this session', 'Reject']) {
+      const button = screen.getByRole('button', { name: label }) as HTMLButtonElement
+      expect(button.disabled).toBe(disabled)
+    }
+  }
+
+  it('shows connector, action, visibility, and fields for a resolved preview', () => {
+    renderCard(
+      makeZendeskPermission(ZENDESK_TOOL_PART.toolName),
+      ZENDESK_TOOL_PART,
+    )
+
+    expect(screen.getByText('Zendesk')).toBeTruthy()
+    expect(screen.getByText('Create ticket with a public comment')).toBeTruthy()
+    expect(screen.getByText('Public')).toBeTruthy()
+    expect(screen.getByText('Need help')).toBeTruthy()
+    expect(screen.getByText('The issue started this morning.')).toBeTruthy()
+    expect(screen.getByText('high')).toBeTruthy()
+    expect(screen.queryByText('arche_zendesk_z1_create_ticket_public')).toBeNull()
+    expectButtonsDisabled(false)
+  })
+
+  it('labels internal notes as internal', () => {
+    renderCard(
+      makeZendeskPermission('arche_zendesk_z1_update_ticket_with_internal_note'),
+      {
+        toolName: 'arche_zendesk_z1_update_ticket_with_internal_note',
+        input: { ticketId: 42, comment: 'Internal only' },
+      },
+    )
+
+    expect(screen.getByText('Internal')).toBeTruthy()
+    expect(screen.getByText('Update ticket with an internal note')).toBeTruthy()
+    expect(screen.getByText('42')).toBeTruthy()
+  })
+
+  it('previews ticket creation with subject, comment, and optional fields', () => {
+    renderCard(
+      makeZendeskPermission('arche_zendesk_z1_create_ticket_internal'),
+      {
+        toolName: 'arche_zendesk_z1_create_ticket_internal',
+        input: { subject: 'Note', comment: 'Context', status: 'new', tags: ['a', 'b'] },
+      },
+    )
+
+    expect(screen.getByText('Note')).toBeTruthy()
+    expect(screen.getByText('a, b')).toBeTruthy()
+    expect(screen.getByText('new')).toBeTruthy()
+  })
+
+  it('previews ticket updates with the target ticket and changed fields', () => {
+    renderCard(
+      makeZendeskPermission('arche_zendesk_z1_update_ticket_fields'),
+      {
+        toolName: 'arche_zendesk_z1_update_ticket_fields',
+        input: { ticketId: 42, status: 'solved' },
+      },
+    )
+
+    expect(screen.getByText('Update ticket fields')).toBeTruthy()
+    expect(screen.getByText('42')).toBeTruthy()
+    expect(screen.getByText('solved')).toBeTruthy()
+  })
+
+  it('disables responses and shows a loading state while the tool input is unresolved', () => {
+    renderCard(makeZendeskPermission('arche_zendesk_z1_create_ticket_public'), undefined)
+
+    expect(screen.getByText('Loading approval details...')).toBeTruthy()
+    expectButtonsDisabled(true)
+  })
+
+  it('disables responses and shows a retrieval error when the tool input cannot be found', () => {
+    renderCard(makeZendeskPermission('arche_zendesk_z1_create_ticket_public'), null)
+
+    expect(screen.getByText(/Could not load the details of this Zendesk action/)).toBeTruthy()
+    expectButtonsDisabled(true)
+  })
+
+  it('never submits while the preview is unavailable', async () => {
+    const onAnswerPermission = renderCard(
+      makeZendeskPermission('arche_zendesk_z1_create_ticket_public'),
+      null,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allow once' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }))
+
+    await waitFor(() => {
+      expect(onAnswerPermission).not.toHaveBeenCalled()
+    })
+  })
+
+  it('keeps the generic fallback for non-Zendesk permissions', () => {
+    renderCard(
+      makePermission({ title: 'bash', pattern: 'rm -rf', callId: undefined }),
+      undefined,
+    )
+
+    expect(screen.queryByText('Loading approval details...')).toBeNull()
+    expect(screen.getByText('bash')).toBeTruthy()
+    expectButtonsDisabled(false)
+  })
+
+  it('sends the existing response values from a previewed permission', async () => {
+    const onAnswerPermission = renderCard(
+      makeZendeskPermission(ZENDESK_TOOL_PART.toolName),
+      ZENDESK_TOOL_PART,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allow for this session' }))
+
+    await waitFor(() => {
+      expect(onAnswerPermission).toHaveBeenCalledWith('s1', 'perm-1', 'always')
+    })
+  })
+})

--- a/apps/web/src/components/workspace/__tests__/sessions-panel.test.tsx
+++ b/apps/web/src/components/workspace/__tests__/sessions-panel.test.tsx
@@ -114,7 +114,9 @@ describe("SessionsPanel", () => {
     renderPanel([
       { id: "today-session", title: "Today chat", status: "idle", updatedAt: "now", updatedAtRaw: now },
       { id: "yesterday-session", title: "Yesterday chat", status: "idle", updatedAt: "1d", updatedAtRaw: now - dayMs },
-      { id: "old-session", title: "Old chat", status: "idle", updatedAt: "30d", updatedAtRaw: now - 30 * dayMs },
+      // 62 days back always lands in a previous calendar month, so the bucket
+      // is deterministically "Older" regardless of the current date.
+      { id: "old-session", title: "Old chat", status: "idle", updatedAt: "62d", updatedAtRaw: now - 62 * dayMs },
     ]);
 
     expect(screen.getByText("Today")).toBeTruthy();

--- a/apps/web/src/components/workspace/chat-panel.tsx
+++ b/apps/web/src/components/workspace/chat-panel.tsx
@@ -58,6 +58,7 @@ import { useAgentMentionAutocomplete } from "@/hooks/use-agent-mention-autocompl
 import type { SkillListItem } from "@/hooks/use-skills-catalog";
 import type { AgentCatalogItem } from "@/hooks/use-workspace";
 import type { WorkspacePermission } from "@/lib/opencode/permission";
+import type { ResolvedPermissionToolPart } from "@/lib/opencode/permission-tool-parts";
 import type { AvailableModel, PermissionResponse } from "@/lib/opencode/types";
 import { getDesktopPlatform, getOptionalDesktopBridge } from "@/lib/runtime/desktop/client";
 import {
@@ -88,6 +89,7 @@ type ChatPanelProps = {
   skills?: SkillListItem[];
   messages: ChatMessage[];
   permissions?: WorkspacePermission[];
+  permissionToolParts?: Record<string, ResolvedPermissionToolPart>;
   activeSessionId: string | null;
   sessionTabs?: SessionTabInfo[];
   openFilePaths: string[];
@@ -140,6 +142,7 @@ const EMPTY_AGENTS: AgentCatalogItem[] = [];
 const EMPTY_CONTEXT_FILE_PATHS: string[] = [];
 const EMPTY_MODELS: AvailableModel[] = [];
 const EMPTY_PERMISSIONS: WorkspacePermission[] = [];
+const EMPTY_PERMISSION_TOOL_PARTS: Record<string, ResolvedPermissionToolPart> = {};
 const EMPTY_SESSION_TABS: SessionTabInfo[] = [];
 const EMPTY_SKILLS: SkillListItem[] = [];
 
@@ -211,6 +214,7 @@ export function ChatPanel({
   skills = EMPTY_SKILLS,
   messages,
   permissions = EMPTY_PERMISSIONS,
+  permissionToolParts = EMPTY_PERMISSION_TOOL_PARTS,
   activeSessionId,
   sessionTabs = EMPTY_SESSION_TABS,
   openFilePaths,
@@ -1163,6 +1167,7 @@ export function ChatPanel({
         isStreaming={isSending}
         messages={messages}
         permissions={permissions}
+        permissionToolParts={permissionToolParts}
         messagesEndRef={messagesEndRef}
         onOpenFile={onOpenFile}
         onAnswerPermission={isReadOnly ? undefined : onAnswerPermission}

--- a/apps/web/src/components/workspace/chat-panel/messages.tsx
+++ b/apps/web/src/components/workspace/chat-panel/messages.tsx
@@ -30,6 +30,7 @@ import {
 import { copyTextToClipboard } from "@/lib/clipboard";
 import { formatTimestamp } from "@/lib/format-timestamp";
 import type { WorkspacePermission } from "@/lib/opencode/permission";
+import type { ResolvedPermissionToolPart } from "@/lib/opencode/permission-tool-parts";
 import type { MessagePart, PermissionResponse } from "@/lib/opencode/types";
 import { cn } from "@/lib/utils";
 import type { ChatMessage } from "@/types/workspace";
@@ -45,6 +46,7 @@ type ChatPanelMessagesProps = {
   isStreaming?: boolean;
   messages: ChatMessage[];
   permissions?: WorkspacePermission[];
+  permissionToolParts?: Record<string, ResolvedPermissionToolPart>;
   messagesEndRef: RefObject<HTMLDivElement | null>;
   onAnswerPermission?: (
     sessionId: string,
@@ -399,6 +401,7 @@ export function ChatPanelMessages({
   isStreaming = false,
   messages,
   permissions = [],
+  permissionToolParts = {},
   messagesEndRef,
   onAnswerPermission,
   onOpenFile,
@@ -617,6 +620,7 @@ export function ChatPanelMessages({
                   key={permission.id}
                   onAnswerPermission={onAnswerPermission}
                   permission={permission}
+                  toolPart={permissionToolParts[permission.id] ?? undefined}
                 />
               ))}
 

--- a/apps/web/src/components/workspace/chat-panel/permission-card.tsx
+++ b/apps/web/src/components/workspace/chat-panel/permission-card.tsx
@@ -2,10 +2,12 @@
 
 import { useCallback, useState } from 'react'
 
-import { Warning } from '@phosphor-icons/react'
+import { SpinnerGap, Warning } from '@phosphor-icons/react'
 
 import { Button } from '@/components/ui/button'
+import { buildZendeskPermissionPreview, matchZendeskActionName, type ZendeskPermissionPreview } from '@/lib/connectors/zendesk-permission-preview'
 import type { WorkspacePermission } from '@/lib/opencode/permission'
+import type { ResolvedPermissionToolPart } from '@/lib/opencode/permission-tool-parts'
 import type { PermissionResponse } from '@/lib/opencode/types'
 import { cn } from '@/lib/utils'
 
@@ -16,6 +18,7 @@ type PermissionCardProps = {
     response: PermissionResponse,
   ) => Promise<boolean>
   permission: WorkspacePermission
+  toolPart?: ResolvedPermissionToolPart
 }
 
 const ACTION_SIZE_CLASS = 'h-7 w-auto px-2.5 text-xs'
@@ -34,11 +37,125 @@ function getPermissionSubtitle(permission: WorkspacePermission): string | undefi
   return permission.pattern
 }
 
-export function PermissionCard({ onAnswerPermission, permission }: PermissionCardProps) {
+type ZendeskPreviewState =
+  | { kind: 'preview'; preview: ZendeskPermissionPreview }
+  | { kind: 'loading' }
+  | { kind: 'unavailable' }
+
+// Resolves the Zendesk approval preview for a recognized atomic action,
+// recognizing the connector from the permission text itself so controls can
+// stay disabled before the tool part arrives. A recognized action with no
+// tool part yet stays in the loading state; a session whose messages are
+// loaded without the referenced tool call fails retrieval instead of allowing
+// a blind approval. Returns null for non-Zendesk permissions.
+function resolveZendeskPreview(
+  permission: WorkspacePermission,
+  toolPart: ResolvedPermissionToolPart
+): ZendeskPreviewState | null {
+  const textAction =
+    matchZendeskActionName(getString(permission.metadata?.tool)) ??
+    matchZendeskActionName(permission.title) ??
+    matchZendeskActionName(permission.pattern)
+
+  if (toolPart === undefined) {
+    return textAction ? { kind: 'loading' } : null
+  }
+
+  if (toolPart === null) {
+    return textAction ? { kind: 'unavailable' } : null
+  }
+
+  const partAction = matchZendeskActionName(toolPart.toolName)
+  if (!textAction && !partAction) {
+    return null
+  }
+
+  const preview = buildZendeskPermissionPreview(toolPart.toolName, toolPart.input)
+  if (!preview) {
+    return { kind: 'unavailable' }
+  }
+
+  return { kind: 'preview', preview }
+}
+
+function ZendeskPreviewBody({ state }: { state: ZendeskPreviewState }) {
+  if (state.kind === 'loading') {
+    return (
+      <p
+        role="status"
+        className="flex items-center gap-2 border-t border-border/30 px-3 py-2 text-xs text-muted-foreground"
+      >
+        <SpinnerGap size={12} className="animate-spin" aria-hidden />
+        Loading approval details...
+      </p>
+    )
+  }
+
+  if (state.kind === 'unavailable') {
+    return (
+      <p role="alert" className="border-t border-border/30 px-3 py-2 text-xs text-destructive">
+        Could not load the details of this Zendesk action.
+      </p>
+    )
+  }
+
+  const { preview } = state
+  const visibilityLabel = preview.visibility === 'public' ? 'Public' : preview.visibility === 'internal' ? 'Internal' : null
+  const comment = preview.fields.find((field) => field.label === 'Comment')
+  const otherFields = preview.fields.filter((field) => field !== comment)
+
+  return (
+    <div className="space-y-2 border-t border-border/30 px-3 py-2">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="rounded bg-muted/60 px-1.5 py-0.5 text-[11px] font-medium text-foreground/80">
+          {preview.connectorName}
+        </span>
+        <span className="text-xs font-medium text-foreground">{preview.actionLabel}</span>
+        {visibilityLabel ? (
+          <span
+            className={cn(
+              'rounded px-1.5 py-0.5 text-[11px] font-medium',
+              preview.visibility === 'public'
+                ? 'bg-warning/15 text-warning'
+                : 'bg-muted/60 text-muted-foreground',
+            )}
+          >
+            {visibilityLabel}
+          </span>
+        ) : null}
+      </div>
+
+      {otherFields.length > 0 ? (
+        <dl className="space-y-1">
+          {otherFields.map((field) => (
+            <div key={field.label} className="flex gap-2 text-xs">
+              <dt className="shrink-0 font-medium text-muted-foreground">{field.label}</dt>
+              <dd className="min-w-0 break-words text-foreground">{field.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+
+      {comment ? (
+        <div className="space-y-1">
+          <p className="text-xs font-medium text-muted-foreground">{comment.label}</p>
+          <pre className="scrollbar-custom max-h-40 overflow-y-auto whitespace-pre-wrap break-words rounded-md bg-muted/40 px-2 py-1.5 font-sans text-xs text-foreground">
+            {comment.value}
+          </pre>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export function PermissionCard({ onAnswerPermission, permission, toolPart }: PermissionCardProps) {
   const [submittingResponse, setSubmittingResponse] = useState<PermissionResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
   const isSubmitting = Boolean(submittingResponse)
   const subtitle = getPermissionSubtitle(permission)
+  const previewState = resolveZendeskPreview(permission, toolPart)
+  const isZendeskAction = previewState !== null
+  const disableZendeskResponses = previewState !== null && previewState.kind !== 'preview'
 
   const handleAnswer = useCallback(
     async (response: PermissionResponse) => {
@@ -63,7 +180,7 @@ export function PermissionCard({ onAnswerPermission, permission }: PermissionCar
             <Warning size={12} weight="fill" className={cn('shrink-0', 'text-warning')} aria-hidden />
             <span className="shrink-0 whitespace-nowrap font-medium">Approval required</span>
           </div>
-          {subtitle ? (
+          {subtitle && !isZendeskAction ? (
             <p className="mt-0.5 truncate pl-5 text-muted-foreground" title={subtitle}>
               {subtitle}
             </p>
@@ -71,12 +188,14 @@ export function PermissionCard({ onAnswerPermission, permission }: PermissionCar
         </div>
       </div>
 
+      {previewState ? <ZendeskPreviewBody state={previewState} /> : null}
+
       <div className="flex flex-wrap items-center justify-start gap-2 px-3 pb-3" aria-busy={isSubmitting}>
         <Button
           type="button"
           size="sm"
           className={`${ACTION_SIZE_CLASS} bg-warning text-foreground hover:bg-warning/90 active:bg-warning/85 dark:bg-[hsl(38_92%_50%)] dark:text-background`}
-          disabled={!onAnswerPermission || isSubmitting}
+          disabled={!onAnswerPermission || isSubmitting || disableZendeskResponses}
           onClick={() => void handleAnswer('once')}
         >
           {submittingResponse === 'once' ? 'Sending...' : 'Allow once'}
@@ -86,7 +205,7 @@ export function PermissionCard({ onAnswerPermission, permission }: PermissionCar
           size="sm"
           variant="outline"
           className={SECONDARY_ACTION_CLASS}
-          disabled={!onAnswerPermission || isSubmitting}
+          disabled={!onAnswerPermission || isSubmitting || disableZendeskResponses}
           onClick={() => void handleAnswer('always')}
         >
           {submittingResponse === 'always' ? 'Sending...' : 'Allow for this session'}
@@ -96,7 +215,7 @@ export function PermissionCard({ onAnswerPermission, permission }: PermissionCar
           size="sm"
           variant="outline"
           className={SECONDARY_ACTION_CLASS}
-          disabled={!onAnswerPermission || isSubmitting}
+          disabled={!onAnswerPermission || isSubmitting || disableZendeskResponses}
           onClick={() => void handleAnswer('reject')}
         >
           {submittingResponse === 'reject' ? 'Sending...' : 'Reject'}

--- a/apps/web/src/components/workspace/workspace-shell.tsx
+++ b/apps/web/src/components/workspace/workspace-shell.tsx
@@ -740,6 +740,7 @@ export function WorkspaceShell({
       skills={skillsCatalog.skills}
       messages={uiMessages}
       permissions={workspace.permissions}
+      permissionToolParts={workspace.permissionToolParts}
       activeSessionId={workspace.activeSessionId}
       isInitialSessionsReady={workspace.isInitialSessionsReady}
       isLoadingMessages={workspace.isLoadingMessages}

--- a/apps/web/src/hooks/workspace/__tests__/use-workspace-permission-messages-effect.test.tsx
+++ b/apps/web/src/hooks/workspace/__tests__/use-workspace-permission-messages-effect.test.tsx
@@ -1,0 +1,103 @@
+/** @vitest-environment jsdom */
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useWorkspacePermissionMessagesEffect } from "@/hooks/workspace/use-workspace-permission-messages-effect";
+import type { WorkspacePermission } from "@/lib/opencode/permission";
+
+function makePermission(sessionId: string): WorkspacePermission {
+  return {
+    id: `perm-${sessionId}`,
+    sessionId,
+    callId: `call-${sessionId}`,
+    title: "arche_zendesk_z1_get_ticket",
+    state: "pending",
+  };
+}
+
+describe("useWorkspacePermissionMessagesEffect", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("hydrates referenced sessions whose messages are not cached", () => {
+    const hydrateSessionMessages = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() =>
+      useWorkspacePermissionMessagesEffect({
+        enabled: true,
+        hydrateSessionMessages,
+        messagesBySession: { active: [] },
+        permissions: [makePermission("child-1")],
+      })
+    );
+
+    expect(hydrateSessionMessages).toHaveBeenCalledWith("child-1", { trackLoading: false });
+  });
+
+  it("skips sessions that are already cached and hydrates each missing session once", () => {
+    const hydrateSessionMessages = vi.fn().mockResolvedValue(undefined);
+    const permissions = [makePermission("child-1"), makePermission("active")];
+
+    const { rerender } = renderHook(
+      ({ messages }: { messages: Record<string, never[]> }) =>
+        useWorkspacePermissionMessagesEffect({
+          enabled: true,
+          hydrateSessionMessages,
+          messagesBySession: messages,
+          permissions,
+        }),
+      { initialProps: { messages: { active: [] } as Record<string, never[]> } }
+    );
+
+    expect(hydrateSessionMessages).toHaveBeenCalledTimes(1);
+    expect(hydrateSessionMessages).toHaveBeenCalledWith("child-1", { trackLoading: false });
+
+    act(() => {
+      rerender({ messages: { active: [], "child-1": [] } });
+    });
+
+    expect(hydrateSessionMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when disabled", () => {
+    const hydrateSessionMessages = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() =>
+      useWorkspacePermissionMessagesEffect({
+        enabled: false,
+        hydrateSessionMessages,
+        messagesBySession: {},
+        permissions: [makePermission("child-1")],
+      })
+    );
+
+    expect(hydrateSessionMessages).not.toHaveBeenCalled();
+  });
+
+  it("does not retry a session that failed to hydrate", () => {
+    const hydrateSessionMessages = vi.fn().mockRejectedValue(new Error("offline"));
+
+    const { rerender } = renderHook(
+      ({ permissions }: { permissions: WorkspacePermission[] }) =>
+        useWorkspacePermissionMessagesEffect({
+          enabled: true,
+          hydrateSessionMessages,
+          messagesBySession: {},
+          permissions,
+        }),
+      { initialProps: { permissions: [makePermission("child-1")] } }
+    );
+
+    const permissions = [makePermission("child-1"), makePermission("child-2")];
+    act(() => {
+      rerender({ permissions });
+    });
+
+    expect(hydrateSessionMessages).toHaveBeenCalledTimes(2);
+    expect(hydrateSessionMessages).toHaveBeenNthCalledWith(1, "child-1", { trackLoading: false });
+    expect(hydrateSessionMessages).toHaveBeenNthCalledWith(2, "child-2", { trackLoading: false });
+  });
+});

--- a/apps/web/src/hooks/workspace/use-workspace-composed.ts
+++ b/apps/web/src/hooks/workspace/use-workspace-composed.ts
@@ -9,11 +9,13 @@ import {
 import { useWorkspaceRuntime } from "@/contexts/workspace-runtime-context";
 import { useWorkspaceDiffs } from "@/hooks/use-workspace-diffs";
 import { useWorkspaceFiles } from "@/hooks/use-workspace-files";
+import { selectPermissionToolParts } from "@/lib/opencode/permission-tool-parts";
 import {
   useWorkspaceActiveSessionEffects,
   useWorkspaceConfigRefreshEffect,
   useWorkspaceFlowSeenEffect,
   useWorkspaceInitialRefreshEffect,
+  useWorkspacePermissionMessagesEffect,
   useWorkspacePollingEffect,
 } from "@/hooks/workspace/use-workspace-effects";
 import { useWorkspaceDerivedState } from "@/hooks/workspace/use-workspace-derived-state";
@@ -102,6 +104,7 @@ export function useWorkspace({
   });
   const {
     store,
+    hydrateSessionMessages,
     isLoadingMessages,
     refreshMessages,
     updateMessages,
@@ -127,6 +130,22 @@ export function useWorkspace({
     () => selectVisiblePermissions(store.permissions, sessions, activeSessionId),
     [activeSessionId, sessions, store.permissions],
   );
+
+  // Tool parts correlated to the visible permissions for approval previews,
+  // resolved across every cached session so delegated child sessions resolve.
+  const permissionToolParts = useMemo(
+    () => selectPermissionToolParts(store.messages, permissions),
+    [permissions, store.messages],
+  );
+
+  // Hydrate referenced sessions whose messages are not cached yet (delegated
+  // child sessions) so their previews resolve instead of stalling in loading.
+  useWorkspacePermissionMessagesEffect({
+    enabled: enabled && isConnected,
+    hydrateSessionMessages,
+    messagesBySession: store.messages,
+    permissions,
+  });
 
   const { createSession, deleteSession } = useWorkspaceSessionActions({
     createWorkspaceSession,
@@ -233,6 +252,7 @@ export function useWorkspace({
     abortSession,
     refreshMessages,
     permissions,
+    permissionToolParts,
     diffs: diffsHook.diffs,
     isLoadingDiffs: diffsHook.isLoadingDiffs,
     diffsError: diffsHook.diffsError,

--- a/apps/web/src/hooks/workspace/use-workspace-effects.ts
+++ b/apps/web/src/hooks/workspace/use-workspace-effects.ts
@@ -4,4 +4,5 @@ export { useWorkspaceActiveSessionEffects } from "@/hooks/workspace/use-workspac
 export { useWorkspaceFlowSeenEffect } from "@/hooks/workspace/use-workspace-flow-seen-effect";
 export { useWorkspaceConfigRefreshEffect } from "@/hooks/workspace/use-workspace-config-refresh-effect";
 export { useWorkspaceInitialRefreshEffect } from "@/hooks/workspace/use-workspace-initial-refresh-effect";
+export { useWorkspacePermissionMessagesEffect } from "@/hooks/workspace/use-workspace-permission-messages-effect";
 export { useWorkspacePollingEffect } from "@/hooks/workspace/use-workspace-polling-effect";

--- a/apps/web/src/hooks/workspace/use-workspace-event-bus.ts
+++ b/apps/web/src/hooks/workspace/use-workspace-event-bus.ts
@@ -142,8 +142,9 @@ export function useWorkspaceEventBus({
   );
 
   const hydrateSessionMessages = useCallback(
-    async (sessionId: string) => {
-      setIsLoadingMessages(true);
+    async (sessionId: string, options?: { trackLoading?: boolean }) => {
+      const trackLoading = options?.trackLoading !== false;
+      if (trackLoading) setIsLoadingMessages(true);
       const statusBefore = getStore().sessionStatus[sessionId];
       try {
         const result = await listMessagesAction(slug, sessionId);
@@ -164,7 +165,7 @@ export function useWorkspaceEventBus({
           });
         }
       } finally {
-        setIsLoadingMessages(false);
+        if (trackLoading) setIsLoadingMessages(false);
       }
     },
     [slug, mergeHydratedMessages, getStore, commitStore],
@@ -326,6 +327,7 @@ export function useWorkspaceEventBus({
     commitStore,
     isLoadingMessages,
     isBusConnected,
+    hydrateSessionMessages,
     refreshMessages,
     updateMessages,
     setSessionStatus,

--- a/apps/web/src/hooks/workspace/use-workspace-permission-messages-effect.ts
+++ b/apps/web/src/hooks/workspace/use-workspace-permission-messages-effect.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import type { WorkspacePermission } from "@/lib/opencode/permission";
+import type { WorkspaceMessage } from "@/lib/opencode/types";
+
+type UseWorkspacePermissionMessagesEffectInput = {
+  enabled: boolean;
+  hydrateSessionMessages: (
+    sessionId: string,
+    options?: { trackLoading?: boolean }
+  ) => Promise<void>;
+  messagesBySession: Record<string, WorkspaceMessage[]>;
+  permissions: WorkspacePermission[];
+};
+
+// Pending permissions can reference sessions whose messages were never loaded
+// into the store — delegated child sessions in particular. Approval previews
+// need the referenced tool call, so hydrate each referenced session once
+// (quietly, without toggling the active session's loading indicator). A
+// session that fails to hydrate stays in the preview loading state instead of
+// being retried in a loop.
+export function useWorkspacePermissionMessagesEffect(
+  input: UseWorkspacePermissionMessagesEffectInput
+): void {
+  const attemptedSessionsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!input.enabled) return;
+
+    for (const permission of input.permissions) {
+      if (permission.sessionId in input.messagesBySession) continue;
+      if (attemptedSessionsRef.current.has(permission.sessionId)) continue;
+
+      attemptedSessionsRef.current.add(permission.sessionId);
+      void input.hydrateSessionMessages(permission.sessionId, { trackLoading: false });
+    }
+  }, [input]);
+}

--- a/apps/web/src/hooks/workspace/workspace-types.ts
+++ b/apps/web/src/hooks/workspace/workspace-types.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { WorkspacePermission } from "@/lib/opencode/permission";
+import type { ResolvedPermissionToolPart } from "@/lib/opencode/permission-tool-parts";
 import type {
   AvailableModel,
   PermissionResponse,
@@ -249,6 +250,9 @@ export type UseWorkspaceReturn = {
   // Permissions (pending) visible for the active session, from the event-bus
   // store: the active session plus its known child sessions.
   permissions: WorkspacePermission[];
+  // Tool parts correlated to pending permissions by call id, resolved across
+  // every cached session (parent + delegated children) for approval previews.
+  permissionToolParts: Record<string, ResolvedPermissionToolPart>;
 
   // Diffs
   diffs: import("@/hooks/use-workspace-diffs").WorkspaceDiff[];

--- a/apps/web/src/lib/connectors/__tests__/zendesk-action-permissions.test.ts
+++ b/apps/web/src/lib/connectors/__tests__/zendesk-action-permissions.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildLegacyProjectionFromActionPermissions,
+  mergeLegacyToolPermissions,
+  normalizeZendeskActionPermissions,
+  parseZendeskActionPermissionsConfig,
+} from '@/lib/connectors/zendesk-action-permissions'
+import {
+  DEFAULT_ZENDESK_ACTION_PERMISSIONS,
+  ZENDESK_ACTION_KEYS,
+} from '@/lib/connectors/zendesk-types'
+
+function legacyPermissions(overrides: Partial<Record<string, boolean>> = {}) {
+  return {
+    allowRead: true,
+    allowCreateTickets: true,
+    allowUpdateTickets: true,
+    allowPublicComments: true,
+    allowInternalComments: true,
+    ...overrides,
+  }
+}
+
+describe('parseZendeskActionPermissionsConfig', () => {
+  it('accepts a complete versioned map', () => {
+    const actions = Object.fromEntries(
+      ZENDESK_ACTION_KEYS.map((key, index) => [key, ['deny', 'ask', 'allow'][index % 3]])
+    )
+    const result = parseZendeskActionPermissionsConfig({ version: 1, actions })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toEqual({ version: 1, actions })
+    }
+  })
+
+  it('rejects non-object values', () => {
+    expect(parseZendeskActionPermissionsConfig('bad')).toEqual({
+      ok: false,
+      message: 'zendeskActionPermissions must be an object',
+    })
+  })
+
+  it('rejects a missing or non-1 version', () => {
+    expect(parseZendeskActionPermissionsConfig({ actions: {} })).toEqual({
+      ok: false,
+      message: 'zendeskActionPermissions.version must be 1',
+    })
+    expect(parseZendeskActionPermissionsConfig({ version: 2, actions: {} })).toEqual({
+      ok: false,
+      message: 'zendeskActionPermissions.version must be 1',
+    })
+  })
+
+  it('rejects missing actions object', () => {
+    expect(parseZendeskActionPermissionsConfig({ version: 1 })).toEqual({
+      ok: false,
+      message: 'zendeskActionPermissions.actions must be an object',
+    })
+  })
+
+  it.each(ZENDESK_ACTION_KEYS)('rejects a map missing %s', (action) => {
+    const actions: Record<string, string> = {}
+    for (const key of ZENDESK_ACTION_KEYS) {
+      if (key !== action) actions[key] = 'allow'
+    }
+    expect(parseZendeskActionPermissionsConfig({ version: 1, actions })).toEqual({
+      ok: false,
+      message: `zendeskActionPermissions.actions.${action} is required`,
+    })
+  })
+
+  it.each(ZENDESK_ACTION_KEYS)('rejects an invalid policy for %s', (action) => {
+    const actions: Record<string, string> = {}
+    for (const key of ZENDESK_ACTION_KEYS) {
+      actions[key] = key === action ? 'block' : 'allow'
+    }
+    expect(parseZendeskActionPermissionsConfig({ version: 1, actions })).toEqual({
+      ok: false,
+      message: `zendeskActionPermissions.actions.${action} must be deny, ask or allow`,
+    })
+  })
+
+  it('rejects unknown extra actions keys', () => {
+    const actions: Record<string, string> = {}
+    for (const key of ZENDESK_ACTION_KEYS) actions[key] = 'allow'
+    actions.create_ticket = 'allow'
+    const result = parseZendeskActionPermissionsConfig({ version: 1, actions })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(Object.keys(result.value.actions).sort()).toEqual([...ZENDESK_ACTION_KEYS].sort())
+    }
+  })
+})
+
+describe('normalizeZendeskActionPermissions', () => {
+  it('defaults every action to allow when no permission fields exist', () => {
+    expect(normalizeZendeskActionPermissions({ subdomain: 'x', email: 'a@b.c', apiToken: 't' }))
+      .toEqual(DEFAULT_ZENDESK_ACTION_PERMISSIONS)
+  })
+
+  it('prefers a valid canonical map over legacy fields', () => {
+    const actions = { ...DEFAULT_ZENDESK_ACTION_PERMISSIONS, create_ticket_public: 'deny' as const }
+    const result = normalizeZendeskActionPermissions({
+      permissions: legacyPermissions({ allowRead: false }),
+      zendeskActionPermissions: { version: 1, actions },
+    })
+    expect(result).toEqual(actions)
+  })
+
+  it('falls back to legacy migration when the canonical map is invalid', () => {
+    const result = normalizeZendeskActionPermissions({
+      permissions: legacyPermissions({ allowPublicComments: false }),
+      zendeskActionPermissions: { version: 2, actions: {} },
+    })
+    expect(result.create_ticket_public).toBe('deny')
+    expect(result.search_tickets).toBe('allow')
+  })
+
+  it('denies every action covered by a false legacy boolean', () => {
+    const cases: Array<[string, string[], Partial<Record<string, boolean>>]> = [
+      ['allowRead', ['search_tickets', 'get_ticket', 'list_ticket_comments'], { allowRead: false }],
+      ['allowCreateTickets', ['create_ticket_public', 'create_ticket_internal'], { allowCreateTickets: false }],
+      ['allowUpdateTickets', ['update_ticket_fields', 'update_ticket_with_public_comment', 'update_ticket_with_internal_note'], { allowUpdateTickets: false }],
+      ['allowPublicComments', ['create_ticket_public', 'update_ticket_with_public_comment'], { allowPublicComments: false }],
+      ['allowInternalComments', ['create_ticket_internal', 'update_ticket_with_internal_note'], { allowInternalComments: false }],
+    ]
+
+    for (const [booleanKey, deniedActions, overrides] of cases) {
+      const result = normalizeZendeskActionPermissions({ permissions: legacyPermissions(overrides) })
+      for (const action of ZENDESK_ACTION_KEYS) {
+        expect(result[action]).toBe(deniedActions.includes(action) ? 'deny' : 'allow')
+      }
+      expect(overrides).toHaveProperty(booleanKey)
+    }
+  })
+
+  it('resolves allow < ask < deny across all applicable legacy values', () => {
+    const result = normalizeZendeskActionPermissions({
+      permissions: legacyPermissions(),
+      mcpToolPermissions: { create_ticket: 'ask', update_ticket: 'deny' },
+    })
+    expect(result.create_ticket_public).toBe('ask')
+    expect(result.create_ticket_internal).toBe('ask')
+    expect(result.update_ticket_fields).toBe('deny')
+    expect(result.update_ticket_with_public_comment).toBe('deny')
+    expect(result.update_ticket_with_internal_note).toBe('deny')
+  })
+
+  it('migrates stored read tool policies one-to-one', () => {
+    const result = normalizeZendeskActionPermissions({
+      permissions: legacyPermissions(),
+      mcpToolPermissions: { search_tickets: 'ask', get_ticket: 'deny', list_ticket_comments: 'ask' },
+    })
+    expect(result.search_tickets).toBe('ask')
+    expect(result.get_ticket).toBe('deny')
+    expect(result.list_ticket_comments).toBe('ask')
+  })
+
+  it('migrates an ask update policy when internal comments stay enabled', () => {
+    const result = normalizeZendeskActionPermissions({
+      permissions: legacyPermissions(),
+      mcpToolPermissions: { update_ticket: 'ask' },
+    })
+    expect(result.update_ticket_fields).toBe('ask')
+    expect(result.update_ticket_with_internal_note).toBe('ask')
+  })
+
+  it('denies public actions when public comments are disabled regardless of a lenient tool policy', () => {
+    const result = normalizeZendeskActionPermissions({
+      permissions: legacyPermissions({ allowPublicComments: false }),
+      mcpToolPermissions: { create_ticket: 'allow', update_ticket: 'allow' },
+    })
+    expect(result.create_ticket_public).toBe('deny')
+    expect(result.update_ticket_with_public_comment).toBe('deny')
+    expect(result.create_ticket_internal).toBe('allow')
+    expect(result.update_ticket_with_internal_note).toBe('allow')
+  })
+})
+
+describe('buildLegacyProjectionFromActionPermissions', () => {
+  it('projects deny-only policies to disabled legacy booleans and most-restrictive tool policies', () => {
+    const actions = {
+      ...DEFAULT_ZENDESK_ACTION_PERMISSIONS,
+      create_ticket_public: 'deny' as const,
+      update_ticket_fields: 'ask' as const,
+      update_ticket_with_internal_note: 'deny' as const,
+    }
+    const projection = buildLegacyProjectionFromActionPermissions(actions)
+    expect(projection.permissions).toEqual(
+      legacyPermissions({
+        allowCreateTickets: false,
+        allowPublicComments: false,
+        allowUpdateTickets: false,
+        allowInternalComments: false,
+      })
+    )
+    expect(projection.legacyToolPermissions).toEqual({
+      search_tickets: 'allow',
+      get_ticket: 'allow',
+      list_ticket_comments: 'allow',
+      create_ticket: 'deny',
+      update_ticket: 'deny',
+    })
+  })
+
+  it('never grants an older runtime broader access than the canonical map', () => {
+    const cases: Array<Partial<Record<string, string>>> = [
+      { create_ticket_public: 'deny' },
+      { create_ticket_internal: 'deny' },
+      { create_ticket_public: 'ask' },
+      { update_ticket_with_public_comment: 'deny' },
+      { update_ticket_with_internal_note: 'ask' },
+      { search_tickets: 'deny' },
+      { get_ticket: 'ask' },
+      { list_ticket_comments: 'deny' },
+      { update_ticket_fields: 'deny' },
+    ]
+
+    for (const overrides of cases) {
+      const actions = { ...DEFAULT_ZENDESK_ACTION_PERMISSIONS, ...overrides }
+      const projection = buildLegacyProjectionFromActionPermissions(actions)
+      for (const [action, policy] of Object.entries(overrides)) {
+        expect(policy).toBeDefined()
+        if (policy === 'deny') {
+          for (const booleanKey of ['allowRead', 'allowCreateTickets', 'allowUpdateTickets', 'allowPublicComments', 'allowInternalComments']) {
+            if (action.includes('search') || action === 'get_ticket' || action === 'list_ticket_comments') {
+              if (booleanKey === 'allowRead') expect(projection.permissions.allowRead).toBe(false)
+            }
+            if (action.startsWith('create_ticket')) {
+              if (booleanKey === 'allowCreateTickets') expect(projection.permissions.allowCreateTickets).toBe(false)
+              if (action.includes('public') && booleanKey === 'allowPublicComments') {
+                expect(projection.permissions.allowPublicComments).toBe(false)
+              }
+              if (action.includes('internal') && booleanKey === 'allowInternalComments') {
+                expect(projection.permissions.allowInternalComments).toBe(false)
+              }
+            }
+            if (action.startsWith('update_ticket')) {
+              if (booleanKey === 'allowUpdateTickets') expect(projection.permissions.allowUpdateTickets).toBe(false)
+              if (action.includes('public') && booleanKey === 'allowPublicComments') {
+                expect(projection.permissions.allowPublicComments).toBe(false)
+              }
+              if (action.includes('internal') && booleanKey === 'allowInternalComments') {
+                expect(projection.permissions.allowInternalComments).toBe(false)
+              }
+            }
+          }
+        }
+        if (policy === 'ask') {
+          if (action === 'search_tickets') expect(projection.legacyToolPermissions.search_tickets).toBe('ask')
+          if (action === 'get_ticket') expect(projection.legacyToolPermissions.get_ticket).toBe('ask')
+          if (action === 'list_ticket_comments') expect(projection.legacyToolPermissions.list_ticket_comments).toBe('ask')
+          if (action.startsWith('create_ticket')) expect(projection.legacyToolPermissions.create_ticket).toBe('ask')
+          if (action.startsWith('update_ticket')) expect(projection.legacyToolPermissions.update_ticket).toBe('ask')
+        }
+      }
+    }
+  })
+
+  it('merges projections over existing stored tool permissions without dropping unknown entries', () => {
+    const projection = buildLegacyProjectionFromActionPermissions(DEFAULT_ZENDESK_ACTION_PERMISSIONS)
+    const merged = mergeLegacyToolPermissions({ custom_tool: 'deny' }, projection.legacyToolPermissions)
+    expect(merged.custom_tool).toBe('deny')
+    expect(merged.create_ticket).toBe('allow')
+  })
+
+  it('merges over a null stored map', () => {
+    const projection = buildLegacyProjectionFromActionPermissions(DEFAULT_ZENDESK_ACTION_PERMISSIONS)
+    expect(mergeLegacyToolPermissions(null, projection.legacyToolPermissions)).toEqual(
+      projection.legacyToolPermissions
+    )
+  })
+})

--- a/apps/web/src/lib/connectors/__tests__/zendesk-config.test.ts
+++ b/apps/web/src/lib/connectors/__tests__/zendesk-config.test.ts
@@ -5,59 +5,12 @@ vi.mock('@/lib/connectors/zendesk-shared', () => ({
 }))
 
 import {
-  getZendeskConnectorPermissionsConstraintMessage,
   parseZendeskConnectorPermissions,
   parseZendeskConnectorConfig,
   validateZendeskConnectorConfig,
 } from '@/lib/connectors/zendesk-config'
 
 describe('zendesk-config', () => {
-  describe('getZendeskConnectorPermissionsConstraintMessage', () => {
-    it('returns message when create tickets is allowed but both comment types are disabled', () => {
-      const result = getZendeskConnectorPermissionsConstraintMessage({
-        allowRead: true,
-        allowCreateTickets: true,
-        allowUpdateTickets: true,
-        allowPublicComments: false,
-        allowInternalComments: false,
-      })
-      expect(result).toBe('Ticket creation requires public comments or internal notes to stay enabled.')
-    })
-
-    it('returns null when constraint is satisfied with public comments', () => {
-      const result = getZendeskConnectorPermissionsConstraintMessage({
-        allowRead: true,
-        allowCreateTickets: true,
-        allowUpdateTickets: true,
-        allowPublicComments: true,
-        allowInternalComments: false,
-      })
-      expect(result).toBeNull()
-    })
-
-    it('returns null when constraint is satisfied with internal comments', () => {
-      const result = getZendeskConnectorPermissionsConstraintMessage({
-        allowRead: true,
-        allowCreateTickets: true,
-        allowUpdateTickets: true,
-        allowPublicComments: false,
-        allowInternalComments: true,
-      })
-      expect(result).toBeNull()
-    })
-
-    it('returns null when create tickets is disabled', () => {
-      const result = getZendeskConnectorPermissionsConstraintMessage({
-        allowRead: true,
-        allowCreateTickets: false,
-        allowUpdateTickets: true,
-        allowPublicComments: false,
-        allowInternalComments: false,
-      })
-      expect(result).toBeNull()
-    })
-  })
-
   describe('parseZendeskConnectorPermissions', () => {
     it('returns defaults when value is undefined and not required', () => {
       const result = parseZendeskConnectorPermissions(undefined)
@@ -183,7 +136,7 @@ describe('zendesk-config', () => {
       expect(result).toEqual({ valid: false, missing: ['subdomain', 'email', 'apiToken'] })
     })
 
-    it('returns invalid with constraint message', () => {
+    it('accepts a legacy config without any comment type enabled', () => {
       const result = validateZendeskConnectorConfig({
         subdomain: 'mycompany',
         email: 'admin@example.com',
@@ -196,10 +149,59 @@ describe('zendesk-config', () => {
           allowInternalComments: false,
         },
       })
-      expect(result).toEqual({
-        valid: false,
-        message: 'Ticket creation requires public comments or internal notes to stay enabled.',
+      expect(result).toEqual({ valid: true })
+    })
+  })
+
+  describe('canonical action permissions parsing', () => {
+    const canonicalActions = {
+      search_tickets: 'allow',
+      get_ticket: 'allow',
+      list_ticket_comments: 'allow',
+      create_ticket_public: 'deny',
+      create_ticket_internal: 'ask',
+      update_ticket_fields: 'allow',
+      update_ticket_with_public_comment: 'ask',
+      update_ticket_with_internal_note: 'allow',
+    }
+
+    it('exposes a valid canonical map on the parsed config', () => {
+      const result = parseZendeskConnectorConfig({
+        subdomain: 'mycompany',
+        email: 'admin@example.com',
+        apiToken: 'token123',
+        zendeskActionPermissions: { version: 1, actions: canonicalActions },
       })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.value.zendeskActionPermissions).toEqual(canonicalActions)
+      }
+    })
+
+    it('omits the canonical map when it is malformed instead of failing the connector', () => {
+      const result = parseZendeskConnectorConfig({
+        subdomain: 'mycompany',
+        email: 'admin@example.com',
+        apiToken: 'token123',
+        zendeskActionPermissions: { version: 1, actions: { search_tickets: 'block' } },
+      })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.value.zendeskActionPermissions).toBeUndefined()
+        expect(result.value.permissions.allowRead).toBe(true)
+      }
+    })
+
+    it('parses configs without a canonical map', () => {
+      const result = parseZendeskConnectorConfig({
+        subdomain: 'mycompany',
+        email: 'admin@example.com',
+        apiToken: 'token123',
+      })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.value.zendeskActionPermissions).toBeUndefined()
+      }
     })
   })
 })

--- a/apps/web/src/lib/connectors/__tests__/zendesk-permission-preview.test.ts
+++ b/apps/web/src/lib/connectors/__tests__/zendesk-permission-preview.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildZendeskPermissionPreview,
+  matchZendeskActionName,
+} from '@/lib/connectors/zendesk-permission-preview'
+
+describe('matchZendeskActionName', () => {
+  it('matches atomic action suffixes in MCP tool names', () => {
+    expect(matchZendeskActionName('arche_zendesk_z1_create_ticket_public')).toBe('create_ticket_public')
+    expect(matchZendeskActionName('arche_zendesk_z1_update_ticket_with_internal_note')).toBe('update_ticket_with_internal_note')
+    expect(matchZendeskActionName('arche_zendesk_z1_search_tickets')).toBe('search_tickets')
+  })
+
+  it('rejects retired composite tool names and unknown tools', () => {
+    expect(matchZendeskActionName('arche_zendesk_z1_create_ticket')).toBeNull()
+    expect(matchZendeskActionName('arche_zendesk_z1_update_ticket')).toBeNull()
+    expect(matchZendeskActionName('arche_linear_1_list_issues')).toBeNull()
+    expect(matchZendeskActionName(undefined)).toBeNull()
+  })
+})
+
+describe('buildZendeskPermissionPreview', () => {
+  it('returns null for non-Zendesk tools', () => {
+    expect(buildZendeskPermissionPreview('arche_linear_1_list_issues', {})).toBeNull()
+    expect(buildZendeskPermissionPreview('bash', { command: 'ls' })).toBeNull()
+  })
+
+  it('previews a public ticket creation with whitelisted fields', () => {
+    const preview = buildZendeskPermissionPreview('arche_zendesk_z1_create_ticket_public', {
+      subject: 'Need help',
+      comment: 'The issue started this morning.',
+      priority: 'high',
+      tags: ['vip', 'urgent'],
+      secretField: 'should-not-render',
+    })
+
+    expect(preview).not.toBeNull()
+    expect(preview!.connectorName).toBe('Zendesk')
+    expect(preview!.action).toBe('create_ticket_public')
+    expect(preview!.actionLabel).toBe('Create ticket with a public comment')
+    expect(preview!.visibility).toBe('public')
+    expect(preview!.fields).toEqual([
+      { label: 'Subject', value: 'Need help' },
+      { label: 'Comment', value: 'The issue started this morning.' },
+      { label: 'Priority', value: 'high' },
+      { label: 'Tags', value: 'vip, urgent' },
+    ])
+  })
+
+  it('previews an internal note update with ticket id and fields', () => {
+    const preview = buildZendeskPermissionPreview('arche_zendesk_z1_update_ticket_with_internal_note', {
+      ticketId: 42,
+      comment: 'Root cause identified.',
+      status: 'solved',
+      assigneeId: 7,
+    })
+
+    expect(preview!.visibility).toBe('internal')
+    expect(preview!.actionLabel).toBe('Update ticket with an internal note')
+    expect(preview!.fields).toEqual([
+      { label: 'Ticket ID', value: '42' },
+      { label: 'Comment', value: 'Root cause identified.' },
+      { label: 'Status', value: 'solved' },
+      { label: 'Assignee ID', value: '7' },
+    ])
+  })
+
+  it('previews field-only updates without visibility', () => {
+    const preview = buildZendeskPermissionPreview('arche_zendesk_z1_update_ticket_fields', {
+      ticketId: 42,
+      status: 'open',
+    })
+
+    expect(preview!.visibility).toBeNull()
+    expect(preview!.actionLabel).toBe('Update ticket fields')
+    expect(preview!.fields).toEqual([
+      { label: 'Ticket ID', value: '42' },
+      { label: 'Status', value: 'open' },
+    ])
+  })
+
+  it('previews reads with their query or ticket id', () => {
+    const search = buildZendeskPermissionPreview('arche_zendesk_z1_search_tickets', {
+      query: 'status:open urgent',
+    })
+    expect(search!.fields).toEqual([{ label: 'Query', value: 'status:open urgent' }])
+
+    const read = buildZendeskPermissionPreview('arche_zendesk_z1_get_ticket', { ticketId: 7 })
+    expect(read!.fields).toEqual([{ label: 'Ticket ID', value: '7' }])
+  })
+
+  it('omits empty values and never renders non-scalar data', () => {
+    const preview = buildZendeskPermissionPreview('arche_zendesk_z1_create_ticket_internal', {
+      subject: 'Note',
+      comment: '',
+      metadata: { nested: 'object' },
+    })
+
+    expect(preview!.fields).toEqual([{ label: 'Subject', value: 'Note' }])
+  })
+})

--- a/apps/web/src/lib/connectors/__tests__/zendesk-tools-extended.test.ts
+++ b/apps/web/src/lib/connectors/__tests__/zendesk-tools-extended.test.ts
@@ -1,14 +1,19 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { executeZendeskMcpTool, getZendeskMcpTools } from '@/lib/connectors/zendesk'
+import { executeZendeskMcpTool } from '@/lib/connectors/zendesk'
 import {
+  DEFAULT_ZENDESK_ACTION_PERMISSIONS,
   DEFAULT_ZENDESK_CONNECTOR_PERMISSIONS,
+  type ZendeskActionPermissions,
   type ZendeskConnectorConfig,
   type ZendeskConnectorPermissions,
 } from '@/lib/connectors/zendesk-types'
 
 function buildConfig(
-  permissions: Partial<ZendeskConnectorPermissions> = {}
+  overrides: {
+    permissions?: Partial<ZendeskConnectorPermissions>
+    actions?: Partial<ZendeskActionPermissions>
+  } = {}
 ): ZendeskConnectorConfig {
   return {
     subdomain: 'acme',
@@ -16,8 +21,9 @@ function buildConfig(
     apiToken: 'token-123',
     permissions: {
       ...DEFAULT_ZENDESK_CONNECTOR_PERMISSIONS,
-      ...permissions,
+      ...overrides.permissions,
     },
+    ...(overrides.actions ? { zendeskActionPermissions: { ...DEFAULT_ZENDESK_ACTION_PERMISSIONS, ...overrides.actions } } : {}),
   }
 }
 
@@ -30,67 +36,14 @@ describe('zendesk-tools extended', () => {
     vi.unstubAllGlobals()
   })
 
-  it('exposes all tools when all permissions are granted', () => {
-    const tools = getZendeskMcpTools(buildConfig())
-    const names = tools.map((t) => t.name)
-    expect(names).toContain('search_tickets')
-    expect(names).toContain('get_ticket')
-    expect(names).toContain('list_ticket_comments')
-    expect(names).toContain('create_ticket')
-    expect(names).toContain('update_ticket')
-  })
-
-  it('exposes only read tools when create/update are disabled', () => {
-    const tools = getZendeskMcpTools(buildConfig({
-      allowCreateTickets: false,
-      allowUpdateTickets: false,
-    }))
-    const names = tools.map((t) => t.name)
-    expect(names).toEqual(['search_tickets', 'get_ticket', 'list_ticket_comments'])
-  })
-
-  it('returns empty tools list when all permissions are disabled', () => {
-    expect(
-      getZendeskMcpTools(
-        buildConfig({ allowRead: false, allowCreateTickets: false, allowUpdateTickets: false })
-      )
-    ).toEqual([])
-  })
-
   it('returns protocol version', async () => {
     const { getZendeskMcpProtocolVersion } = await import('@/lib/connectors/zendesk-tools')
     expect(getZendeskMcpProtocolVersion()).toBe('2025-03-26')
   })
 
-  it('rejects create when create permission is disabled', async () => {
-    const result = await executeZendeskMcpTool(
-      buildConfig({ allowCreateTickets: false }),
-      'create_ticket',
-      { subject: 'Test', comment: 'Body' }
-    )
-
-    expect(result.isError).toBe(true)
-    const parsed = parseToolResult(result) as { ok: boolean; error: string }
-    expect(parsed.ok).toBe(false)
-    expect(parsed.error).toBe('operation_not_allowed')
-  })
-
-  it('rejects update when update permission is disabled', async () => {
-    const result = await executeZendeskMcpTool(
-      buildConfig({ allowUpdateTickets: false }),
-      'update_ticket',
-      { ticketId: 42, subject: 'Updated' }
-    )
-
-    expect(result.isError).toBe(true)
-    const parsed = parseToolResult(result) as { ok: boolean; error: string }
-    expect(parsed.ok).toBe(false)
-    expect(parsed.error).toBe('operation_not_allowed')
-  })
-
-  it('creates a ticket successfully', async () => {
+  it('executes allow actions without any approval gate at the connector layer', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ ticket: { id: 99, subject: 'Need help', status: 'open' } }), {
+      new Response(JSON.stringify({ ticket: { id: 42, subject: 'Bug' } }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       })
@@ -98,23 +51,34 @@ describe('zendesk-tools extended', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const result = await executeZendeskMcpTool(
-      buildConfig(),
-      'create_ticket',
-      { subject: 'Need help', comment: 'Please help', priority: 'high', status: 'open' }
+      buildConfig({ actions: { get_ticket: 'allow' } }),
+      'get_ticket',
+      { ticketId: 42 }
     )
 
-    const parsed = parseToolResult(result) as { ok: boolean; ticket: { id: number } }
+    const parsed = parseToolResult(result) as { ok: boolean }
     expect(parsed.ok).toBe(true)
-    expect(parsed.ticket.id).toBe(99)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
 
-    const [url] = fetchMock.mock.calls[0] as [URL]
-    expect(url.pathname).toBe('/api/v2/tickets.json')
-    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
-    const body = JSON.parse(String(init.body))
-    expect(body.ticket.subject).toBe('Need help')
-    expect(body.ticket.priority).toBe('high')
-    expect(body.ticket.status).toBe('open')
-    expect(body.ticket.comment).toEqual({ body: 'Please help', public: true })
+  it('executes ask actions at the connector layer because only the managed runtime conducts approval', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ticket: { id: 42 } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await executeZendeskMcpTool(
+      buildConfig({ actions: { update_ticket_fields: 'ask' } }),
+      'update_ticket_fields',
+      { ticketId: 42, status: 'solved' }
+    )
+
+    const parsed = parseToolResult(result) as { ok: boolean }
+    expect(parsed.ok).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
   it('searches tickets with scoped query', async () => {
@@ -223,19 +187,37 @@ describe('zendesk-tools extended', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('rejects unknown tool name', async () => {
+  it('rejects invalid enum arguments for write tools', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
 
     const result = await executeZendeskMcpTool(
       buildConfig(),
-      'unknown_tool',
-      {}
+      'create_ticket_public',
+      { subject: 'Test', comment: 'Body', status: 'exploded' }
     )
 
     const parsed = parseToolResult(result) as { ok: boolean; error: string }
     expect(parsed.ok).toBe(false)
-    expect(parsed.error).toBe('unknown_tool')
+    expect(parsed.error).toBe('invalid_arguments')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects missing subject or comment for creation tools', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    for (const toolName of ['create_ticket_public', 'create_ticket_internal']) {
+      const missingSubject = await executeZendeskMcpTool(buildConfig(), toolName, { comment: 'Body' })
+      const parsedSubject = parseToolResult(missingSubject) as { ok: boolean; error: string }
+      expect(parsedSubject.ok).toBe(false)
+      expect(parsedSubject.error).toBe('invalid_arguments')
+
+      const missingComment = await executeZendeskMcpTool(buildConfig(), toolName, { subject: 'Test' })
+      const parsedComment = parseToolResult(missingComment) as { ok: boolean; error: string }
+      expect(parsedComment.ok).toBe(false)
+      expect(parsedComment.error).toBe('invalid_arguments')
+    }
     expect(fetchMock).not.toHaveBeenCalled()
   })
 

--- a/apps/web/src/lib/connectors/__tests__/zendesk-tools.test.ts
+++ b/apps/web/src/lib/connectors/__tests__/zendesk-tools.test.ts
@@ -2,14 +2,19 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { executeZendeskMcpTool, getZendeskMcpTools } from '@/lib/connectors/zendesk'
 import {
+  DEFAULT_ZENDESK_ACTION_PERMISSIONS,
   DEFAULT_ZENDESK_CONNECTOR_PERMISSIONS,
+  type ZendeskActionPermissions,
   type ZendeskConnectorConfig,
   type ZendeskConnectorPermissions,
   type ZendeskMcpToolResult,
 } from '@/lib/connectors/zendesk-types'
 
 function buildConfig(
-  permissions: Partial<ZendeskConnectorPermissions> = {}
+  overrides: {
+    permissions?: Partial<ZendeskConnectorPermissions>
+    actions?: Partial<ZendeskActionPermissions>
+  } = {}
 ): ZendeskConnectorConfig {
   return {
     subdomain: 'acme',
@@ -17,8 +22,9 @@ function buildConfig(
     apiToken: 'token-123',
     permissions: {
       ...DEFAULT_ZENDESK_CONNECTOR_PERMISSIONS,
-      ...permissions,
+      ...overrides.permissions,
     },
+    ...(overrides.actions ? { zendeskActionPermissions: { ...DEFAULT_ZENDESK_ACTION_PERMISSIONS, ...overrides.actions } } : {}),
   }
 }
 
@@ -31,89 +37,114 @@ describe('zendesk-tools', () => {
     vi.unstubAllGlobals()
   })
 
-  it('filters unavailable tools from tools/list based on connector permissions', () => {
-    const toolNames = getZendeskMcpTools(buildConfig({
-      allowRead: false,
-      allowCreateTickets: false,
-      allowUpdateTickets: true,
-    })).map((tool) => tool.name)
+  it('exposes the eight atomic actions and no legacy composite tools', () => {
+    const names = getZendeskMcpTools(buildConfig()).map((tool) => tool.name)
+    expect(names).toEqual([
+      'search_tickets',
+      'get_ticket',
+      'list_ticket_comments',
+      'create_ticket_public',
+      'create_ticket_internal',
+      'update_ticket_fields',
+      'update_ticket_with_public_comment',
+      'update_ticket_with_internal_note',
+    ])
+  })
 
-    expect(toolNames).toEqual(['update_ticket'])
+  it('omits publicComment from every write tool schema', () => {
+    const tools = getZendeskMcpTools(buildConfig())
+    for (const tool of tools) {
+      if (!tool.name.startsWith('create_ticket') && !tool.name.startsWith('update_ticket')) continue
+      expect(tool.inputSchema).not.toHaveProperty('properties.publicComment')
+    }
+  })
+
+  it('requires a comment for visibility-specific updates and omits it from update_ticket_fields', () => {
+    const tools = getZendeskMcpTools(buildConfig())
+    const schemaOf = (name: string) => tools.find((tool) => tool.name === name)?.inputSchema
+
+    expect(schemaOf('update_ticket_with_public_comment')).toHaveProperty('required')
+    expect(schemaOf('update_ticket_with_internal_note')).toHaveProperty('required')
+    expect(schemaOf('update_ticket_fields')).not.toHaveProperty('properties.comment')
   })
 
   it('does not expose internal permission metadata in tools/list', () => {
     const tools = getZendeskMcpTools(buildConfig())
 
-    expect(tools.every((tool) => !Object.prototype.hasOwnProperty.call(tool, 'permission'))).toBe(true)
+    expect(tools.every((tool) => !Object.prototype.hasOwnProperty.call(tool, 'action'))).toBe(true)
   })
 
-  it('rejects read operations when read access is disabled', async () => {
+  it('filters denied actions from tools/list while non-denied actions remain available', () => {
+    const names = getZendeskMcpTools(buildConfig({
+      actions: {
+        search_tickets: 'deny',
+        create_ticket_public: 'deny',
+        update_ticket_fields: 'deny',
+      },
+    })).map((tool) => tool.name)
+
+    expect(names).toEqual([
+      'get_ticket',
+      'list_ticket_comments',
+      'create_ticket_internal',
+      'update_ticket_with_public_comment',
+      'update_ticket_with_internal_note',
+    ])
+  })
+
+  it('migrates legacy booleans for inventory filtering without stored canonical policies', () => {
+    const names = getZendeskMcpTools(buildConfig({
+      permissions: {
+        allowRead: false,
+        allowCreateTickets: false,
+        allowUpdateTickets: true,
+      },
+    })).map((tool) => tool.name)
+
+    expect(names).toEqual([
+      'update_ticket_fields',
+      'update_ticket_with_public_comment',
+      'update_ticket_with_internal_note',
+    ])
+  })
+
+  it('rejects direct invocation of a denied action before any Zendesk request', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
 
     const result = await executeZendeskMcpTool(
-      buildConfig({ allowRead: false }),
+      buildConfig({ actions: { create_ticket_public: 'deny' } }),
+      'create_ticket_public',
+      { subject: 'Need help', comment: 'Please check this issue' }
+    )
+
+    expect(parseToolResult(result)).toEqual({
+      ok: false,
+      error: 'operation_not_allowed',
+      message: 'This Zendesk action is denied for this connector',
+    })
+    expect(result.isError).toBe(true)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects direct invocation of an action denied through legacy migration', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await executeZendeskMcpTool(
+      buildConfig({ permissions: { allowRead: false } }),
       'get_ticket',
       { ticketId: 42 }
     )
 
-    expect(parseToolResult(result)).toEqual({
-      ok: false,
-      error: 'operation_not_allowed',
-      message: 'Read operations are disabled for this Zendesk connector',
-    })
+    expect(parseToolResult(result)).toMatchObject({ ok: false, error: 'operation_not_allowed' })
     expect(result.isError).toBe(true)
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('rejects public comments when they are disabled', async () => {
-    const fetchMock = vi.fn()
-    vi.stubGlobal('fetch', fetchMock)
-
-    const result = await executeZendeskMcpTool(
-      buildConfig({ allowPublicComments: false, allowInternalComments: true }),
-      'create_ticket',
-      {
-        subject: 'Need help',
-        comment: 'Please check this issue',
-      }
-    )
-
-    expect(parseToolResult(result)).toEqual({
-      ok: false,
-      error: 'operation_not_allowed',
-      message: 'Public comments are disabled for this Zendesk connector',
-    })
-    expect(result.isError).toBe(true)
-    expect(fetchMock).not.toHaveBeenCalled()
-  })
-
-  it('rejects internal comments when they are disabled', async () => {
-    const fetchMock = vi.fn()
-    vi.stubGlobal('fetch', fetchMock)
-
-    const result = await executeZendeskMcpTool(
-      buildConfig({ allowPublicComments: true, allowInternalComments: false }),
-      'update_ticket',
-      {
-        ticketId: 42,
-        comment: 'Internal note',
-        publicComment: false,
-      }
-    )
-
-    expect(parseToolResult(result)).toEqual({
-      ok: false,
-      error: 'operation_not_allowed',
-      message: 'Internal comments are disabled for this Zendesk connector',
-    })
-    expect(result.isError).toBe(true)
-    expect(fetchMock).not.toHaveBeenCalled()
-  })
-
-  it('allows ticket updates without comments even when comment permissions are disabled', async () => {
+  it('creates a public ticket with the visibility from the tool identity', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ ticket: { id: 42, subject: 'Updated', status: 'open' } }), {
+      new Response(JSON.stringify({ ticket: { id: 99, subject: 'Need help', status: 'open' } }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       })
@@ -121,37 +152,198 @@ describe('zendesk-tools', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const result = await executeZendeskMcpTool(
-      buildConfig({ allowPublicComments: false, allowInternalComments: false }),
-      'update_ticket',
-      {
-        ticketId: 42,
-        subject: 'Updated',
-      }
+      buildConfig(),
+      'create_ticket_public',
+      { subject: 'Need help', comment: 'Please help', priority: 'high', status: 'open', tags: ['vip'] }
     )
 
-    expect(parseToolResult(result)).toEqual({
-      ok: true,
-      ticket: {
-        id: 42,
-        subject: 'Updated',
-        status: 'open',
-        priority: null,
-        type: null,
-        requesterId: null,
-        assigneeId: null,
-        organizationId: null,
-        createdAt: null,
-        updatedAt: null,
-        tags: [],
-        url: 'https://acme.zendesk.com/agent/tickets/42',
-      },
-    })
+    const parsed = parseToolResult(result) as { ok: boolean; ticket: { id: number } }
+    expect(parsed.ok).toBe(true)
+    expect(parsed.ticket.id).toBe(99)
 
-    const [, requestInit] = fetchMock.mock.calls[0] as [URL, RequestInit]
-    expect(JSON.parse(String(requestInit.body))).toEqual({
+    const [url] = fetchMock.mock.calls[0] as [URL]
+    expect(url.pathname).toBe('/api/v2/tickets.json')
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+    expect(JSON.parse(String(init.body))).toEqual({
       ticket: {
-        subject: 'Updated',
+        subject: 'Need help',
+        comment: { body: 'Please help', public: true },
+        requester: { email: 'agent@example.com' },
+        priority: 'high',
+        status: 'open',
+        tags: ['vip'],
       },
     })
+  })
+
+  it('creates an internal ticket with the visibility from the tool identity', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ticket: { id: 100, subject: 'Note', status: 'open' } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await executeZendeskMcpTool(
+      buildConfig(),
+      'create_ticket_internal',
+      { subject: 'Note', comment: 'Internal context' }
+    )
+
+    const parsed = parseToolResult(result) as { ok: boolean }
+    expect(parsed.ok).toBe(true)
+
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+    expect(JSON.parse(String(init.body))).toEqual({
+      ticket: {
+        subject: 'Note',
+        comment: { body: 'Internal context', public: false },
+        requester: { email: 'agent@example.com' },
+      },
+    })
+  })
+
+  it('updates fields without a comment in one request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ticket: { id: 42, subject: 'Updated' } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await executeZendeskMcpTool(
+      buildConfig(),
+      'update_ticket_fields',
+      { ticketId: 42, subject: 'Updated', assigneeId: 7 }
+    )
+
+    const parsed = parseToolResult(result) as { ok: boolean }
+    expect(parsed.ok).toBe(true)
+
+    const [url] = fetchMock.mock.calls[0] as [URL]
+    expect(url.pathname).toBe('/api/v2/tickets/42.json')
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+    expect(JSON.parse(String(init.body))).toEqual({
+      ticket: { subject: 'Updated', assigneeId: 7 },
+    })
+  })
+
+  it('rejects comment input for update_ticket_fields', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await executeZendeskMcpTool(
+      buildConfig(),
+      'update_ticket_fields',
+      { ticketId: 42, comment: 'Should not be accepted' }
+    )
+
+    const parsed = parseToolResult(result) as { ok: boolean; error: string }
+    expect(parsed.ok).toBe(false)
+    expect(parsed.error).toBe('invalid_arguments')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('sends field changes and a public comment in one Zendesk update request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ticket: { id: 42 } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await executeZendeskMcpTool(
+      buildConfig(),
+      'update_ticket_with_public_comment',
+      { ticketId: 42, comment: 'Fixed in 2.1', status: 'solved', priority: 'low' }
+    )
+
+    const parsed = parseToolResult(result) as { ok: boolean }
+    expect(parsed.ok).toBe(true)
+
+    const [url] = fetchMock.mock.calls[0] as [URL]
+    expect(url.pathname).toBe('/api/v2/tickets/42.json')
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+    expect(JSON.parse(String(init.body))).toEqual({
+      ticket: {
+        comment: { body: 'Fixed in 2.1', public: true },
+        status: 'solved',
+        priority: 'low',
+      },
+    })
+  })
+
+  it('sends field changes and an internal note in one Zendesk update request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ticket: { id: 42 } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await executeZendeskMcpTool(
+      buildConfig(),
+      'update_ticket_with_internal_note',
+      { ticketId: 42, comment: 'Root cause identified' }
+    )
+
+    const parsed = parseToolResult(result) as { ok: boolean }
+    expect(parsed.ok).toBe(true)
+
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+    expect(JSON.parse(String(init.body))).toEqual({
+      ticket: {
+        comment: { body: 'Root cause identified', public: false },
+      },
+    })
+  })
+
+  it('rejects visibility-specific updates without a comment', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await executeZendeskMcpTool(
+      buildConfig(),
+      'update_ticket_with_public_comment',
+      { ticketId: 42, subject: 'No comment' }
+    )
+
+    const parsed = parseToolResult(result) as { ok: boolean; error: string }
+    expect(parsed.ok).toBe(false)
+    expect(parsed.error).toBe('invalid_arguments')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty update_ticket_fields payload', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await executeZendeskMcpTool(
+      buildConfig(),
+      'update_ticket_fields',
+      { ticketId: 42 }
+    )
+
+    const parsed = parseToolResult(result) as { ok: boolean; error: string }
+    expect(parsed.ok).toBe(false)
+    expect(parsed.error).toBe('invalid_arguments')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects unknown and retired tool names', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    for (const toolName of ['unknown_tool', 'create_ticket', 'update_ticket']) {
+      const result = await executeZendeskMcpTool(buildConfig(), toolName, {})
+      const parsed = parseToolResult(result) as { ok: boolean; error: string }
+      expect(parsed.ok).toBe(false)
+      expect(parsed.error).toBe('unknown_tool')
+    }
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/lib/connectors/zendesk-action-permissions.ts
+++ b/apps/web/src/lib/connectors/zendesk-action-permissions.ts
@@ -1,0 +1,248 @@
+import {
+  getStoredConnectorToolPermissions,
+  type ConnectorToolPermissionMap,
+} from '@/lib/connectors/tool-permissions'
+import {
+  ZENDESK_ACTION_KEYS,
+  ZENDESK_ACTION_PERMISSIONS_CONFIG_KEY,
+  ZENDESK_ACTION_PERMISSIONS_VERSION,
+  type ZendeskActionName,
+  type ZendeskActionPermissions,
+  type ZendeskActionPermissionsConfig,
+  type ZendeskActionPolicy,
+  type ZendeskConnectorPermissions,
+} from '@/lib/connectors/zendesk-types'
+import { hasOwnProperty, isRecord } from '@/lib/connectors/zendesk-values'
+
+const LEGACY_TOOL_NAME_TO_ACTION: Record<string, ZendeskActionName | null> = {
+  search_tickets: 'search_tickets',
+  get_ticket: 'get_ticket',
+  list_ticket_comments: 'list_ticket_comments',
+  create_ticket: null,
+  update_ticket: null,
+}
+
+const LEGACY_ACTION_COVERAGE: Record<ZendeskActionName, {
+  booleans: (keyof ZendeskConnectorPermissions)[]
+  legacyTool: 'create_ticket' | 'update_ticket' | null
+}> = {
+  search_tickets: { booleans: ['allowRead'], legacyTool: null },
+  get_ticket: { booleans: ['allowRead'], legacyTool: null },
+  list_ticket_comments: { booleans: ['allowRead'], legacyTool: null },
+  create_ticket_public: {
+    booleans: ['allowCreateTickets', 'allowPublicComments'],
+    legacyTool: 'create_ticket',
+  },
+  create_ticket_internal: {
+    booleans: ['allowCreateTickets', 'allowInternalComments'],
+    legacyTool: 'create_ticket',
+  },
+  update_ticket_fields: { booleans: ['allowUpdateTickets'], legacyTool: 'update_ticket' },
+  update_ticket_with_public_comment: {
+    booleans: ['allowUpdateTickets', 'allowPublicComments'],
+    legacyTool: 'update_ticket',
+  },
+  update_ticket_with_internal_note: {
+    booleans: ['allowUpdateTickets', 'allowInternalComments'],
+    legacyTool: 'update_ticket',
+  },
+}
+
+const RESTRICTIVE_ORDER: Record<ZendeskActionPolicy, number> = {
+  allow: 0,
+  ask: 1,
+  deny: 2,
+}
+
+function mostRestrictive(left: ZendeskActionPolicy, right: ZendeskActionPolicy): ZendeskActionPolicy {
+  return RESTRICTIVE_ORDER[left] >= RESTRICTIVE_ORDER[right] ? left : right
+}
+
+export function parseZendeskActionPermissionsConfig(
+  value: unknown
+): { ok: true; value: ZendeskActionPermissionsConfig } | { ok: false; message: string } {
+  if (!isRecord(value)) {
+    return { ok: false, message: 'zendeskActionPermissions must be an object' }
+  }
+
+  if (value.version !== ZENDESK_ACTION_PERMISSIONS_VERSION) {
+    return { ok: false, message: `zendeskActionPermissions.version must be ${ZENDESK_ACTION_PERMISSIONS_VERSION}` }
+  }
+
+  if (!isRecord(value.actions)) {
+    return { ok: false, message: 'zendeskActionPermissions.actions must be an object' }
+  }
+
+  const actions: Partial<Record<ZendeskActionName, ZendeskActionPolicy>> = {}
+  for (const key of ZENDESK_ACTION_KEYS) {
+    if (!hasOwnProperty(value.actions, key)) {
+      return { ok: false, message: `zendeskActionPermissions.actions.${key} is required` }
+    }
+
+    const policy = value.actions[key]
+    if (policy !== 'deny' && policy !== 'ask' && policy !== 'allow') {
+      return { ok: false, message: `zendeskActionPermissions.actions.${key} must be deny, ask or allow` }
+    }
+
+    actions[key] = policy
+  }
+
+  return {
+    ok: true,
+    value: {
+      version: ZENDESK_ACTION_PERMISSIONS_VERSION,
+      actions: actions as ZendeskActionPermissions,
+    },
+  }
+}
+
+function combinePolicy(
+  left: ZendeskActionPolicy | undefined,
+  right: ZendeskActionPolicy | undefined
+): ZendeskActionPolicy {
+  if (left && right) return mostRestrictive(left, right)
+  return left ?? right ?? 'allow'
+}
+
+function toActionPolicyFromBoolean(value: boolean | undefined): ZendeskActionPolicy {
+  if (value === false) return 'deny'
+  return 'allow'
+}
+
+function toActionPolicyFromStored(
+  stored: ConnectorToolPermissionMap,
+  toolName: string
+): ZendeskActionPolicy | undefined {
+  return stored[toolName] as ZendeskActionPolicy | undefined
+}
+
+function normalizeLegacyActionPermissions(input: {
+  permissions: ZendeskConnectorPermissions
+  storedToolPermissions: ConnectorToolPermissionMap
+}): ZendeskActionPermissions {
+  const actions = {} as ZendeskActionPermissions
+
+  for (const action of ZENDESK_ACTION_KEYS) {
+    const coverage = LEGACY_ACTION_COVERAGE[action]
+    let policy: ZendeskActionPolicy | undefined
+
+    for (const booleanKey of coverage.booleans) {
+      policy = combinePolicy(policy, toActionPolicyFromBoolean(input.permissions[booleanKey]))
+    }
+
+    if (coverage.legacyTool) {
+      policy = combinePolicy(policy, toActionPolicyFromStored(input.storedToolPermissions, coverage.legacyTool))
+    } else {
+      policy = combinePolicy(policy, toActionPolicyFromStored(input.storedToolPermissions, action))
+    }
+
+    actions[action] = policy ?? 'allow'
+  }
+
+  return actions
+}
+
+export function normalizeZendeskActionPermissions(config: Record<string, unknown>): ZendeskActionPermissions {
+  const canonical = config[ZENDESK_ACTION_PERMISSIONS_CONFIG_KEY]
+  if (canonical !== undefined) {
+    const parsed = parseZendeskActionPermissionsConfig(canonical)
+    if (parsed.ok) {
+      return parsed.value.actions
+    }
+  }
+
+  const permissions = isRecord(config.permissions) ? config.permissions : {}
+  const legacyPermissions: ZendeskConnectorPermissions = {
+    allowRead: typeof permissions.allowRead === 'boolean' ? permissions.allowRead : true,
+    allowCreateTickets: typeof permissions.allowCreateTickets === 'boolean' ? permissions.allowCreateTickets : true,
+    allowUpdateTickets: typeof permissions.allowUpdateTickets === 'boolean' ? permissions.allowUpdateTickets : true,
+    allowPublicComments: typeof permissions.allowPublicComments === 'boolean' ? permissions.allowPublicComments : true,
+    allowInternalComments: typeof permissions.allowInternalComments === 'boolean' ? permissions.allowInternalComments : true,
+  }
+
+  return normalizeLegacyActionPermissions({
+    permissions: legacyPermissions,
+    storedToolPermissions: getStoredConnectorToolPermissions(config) ?? {},
+  })
+}
+
+// Resolves the effective canonical map from an already-parsed connector
+// config: the stored canonical map wins, otherwise the legacy permission
+// fields (booleans plus stored read/create/update tool policies) migrate in
+// memory so legacy restrictions stay effective without a settings save.
+export function resolveZendeskActionPermissions(config: {
+  permissions: ZendeskConnectorPermissions
+  zendeskActionPermissions?: ZendeskActionPermissions
+  storedToolPermissions?: ConnectorToolPermissionMap
+}): ZendeskActionPermissions {
+  if (config.zendeskActionPermissions) {
+    return config.zendeskActionPermissions
+  }
+
+  return normalizeLegacyActionPermissions({
+    permissions: config.permissions,
+    storedToolPermissions: config.storedToolPermissions ?? {},
+  })
+}
+
+// Runtime projection for the MCP config builder: the canonical action names
+// are the atomic MCP tool names, so the normalized map keys directly into the
+// exact OpenCode permission expansion. Denied actions stay in the map (defense
+// in depth if tool discovery is stale); retired composite names never appear.
+export function getZendeskRuntimeToolPermissions(
+  config: Record<string, unknown>
+): ConnectorToolPermissionMap {
+  return { ...normalizeZendeskActionPermissions(config) }
+}
+
+export type ZendeskLegacyProjection = {
+  permissions: ZendeskConnectorPermissions
+  legacyToolPermissions: ConnectorToolPermissionMap
+}
+
+export function buildLegacyProjectionFromActionPermissions(
+  actions: ZendeskActionPermissions
+): ZendeskLegacyProjection {
+  const booleans: ZendeskConnectorPermissions = {
+    allowRead: true,
+    allowCreateTickets: true,
+    allowUpdateTickets: true,
+    allowPublicComments: true,
+    allowInternalComments: true,
+  }
+
+  for (const action of ZENDESK_ACTION_KEYS) {
+    const policy = actions[action]
+    for (const booleanKey of LEGACY_ACTION_COVERAGE[action].booleans) {
+      if (policy === 'deny') {
+        booleans[booleanKey] = false
+      }
+    }
+  }
+
+  const legacyToolPermissions: ConnectorToolPermissionMap = {}
+  for (const [legacyToolName, action] of Object.entries(LEGACY_TOOL_NAME_TO_ACTION)) {
+    if (action) {
+      legacyToolPermissions[legacyToolName] = actions[action]
+      continue
+    }
+
+    const coveredActions = ZENDESK_ACTION_KEYS.filter(
+      (candidate) => LEGACY_ACTION_COVERAGE[candidate].legacyTool === legacyToolName
+    )
+    let policy: ZendeskActionPolicy = 'allow'
+    for (const coveredAction of coveredActions) {
+      policy = mostRestrictive(policy, actions[coveredAction])
+    }
+    legacyToolPermissions[legacyToolName] = policy
+  }
+
+  return { permissions: booleans, legacyToolPermissions }
+}
+
+export function mergeLegacyToolPermissions(
+  current: ConnectorToolPermissionMap | null,
+  projection: ConnectorToolPermissionMap
+): ConnectorToolPermissionMap {
+  return { ...(current ?? {}), ...projection }
+}

--- a/apps/web/src/lib/connectors/zendesk-config.ts
+++ b/apps/web/src/lib/connectors/zendesk-config.ts
@@ -1,8 +1,12 @@
 import type { ConnectorConfigValidationResult } from '@/lib/connectors/config-validation'
+import { getStoredConnectorToolPermissions } from '@/lib/connectors/tool-permissions'
+import { parseZendeskActionPermissionsConfig } from '@/lib/connectors/zendesk-action-permissions'
 import { normalizeZendeskSubdomain } from '@/lib/connectors/zendesk-shared'
 import {
   DEFAULT_ZENDESK_CONNECTOR_PERMISSIONS,
+  ZENDESK_ACTION_PERMISSIONS_CONFIG_KEY,
   ZENDESK_CONNECTOR_PERMISSION_KEYS,
+  type ZendeskActionPermissions,
   type ZendeskConnectorConfig,
   type ZendeskConnectorPermissions,
 } from '@/lib/connectors/zendesk-types'
@@ -15,20 +19,6 @@ type ParsedZendeskConnectorConfig =
 type ParsedZendeskConnectorPermissions =
   | { ok: true; value: ZendeskConnectorPermissions }
   | { ok: false; message: string }
-
-export function getZendeskConnectorPermissionsConstraintMessage(
-  permissions: ZendeskConnectorPermissions
-): string | null {
-  if (
-    permissions.allowCreateTickets &&
-    !permissions.allowPublicComments &&
-    !permissions.allowInternalComments
-  ) {
-    return 'Ticket creation requires public comments or internal notes to stay enabled.'
-  }
-
-  return null
-}
 
 function isValidZendeskSubdomain(subdomain: string): boolean {
   return /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(subdomain)
@@ -43,7 +33,7 @@ export function parseZendeskConnectorPermissions(
       return { ok: false, message: 'permissions is required' }
     }
 
-    return { ok: true, value: { ...DEFAULT_ZENDESK_CONNECTOR_PERMISSIONS } }
+    return { ok: true, value: DEFAULT_ZENDESK_CONNECTOR_PERMISSIONS }
   }
 
   if (!isRecord(value)) {
@@ -99,6 +89,17 @@ function parseZendeskConnectorFields(config: Record<string, unknown>): ParsedZen
     return permissions
   }
 
+  const canonical = config[ZENDESK_ACTION_PERMISSIONS_CONFIG_KEY]
+  let zendeskActionPermissions: ZendeskActionPermissions | undefined
+  if (canonical !== undefined) {
+    const parsedCanonical = parseZendeskActionPermissionsConfig(canonical)
+    // An invalid canonical map is ignored so the connector keeps working from
+    // the legacy permission fields; normalization falls back to migrating them.
+    zendeskActionPermissions = parsedCanonical.ok ? parsedCanonical.value.actions : undefined
+  }
+
+  const storedToolPermissions = getStoredConnectorToolPermissions(config) ?? undefined
+
   return {
     ok: true,
     value: {
@@ -106,6 +107,8 @@ function parseZendeskConnectorFields(config: Record<string, unknown>): ParsedZen
       email,
       apiToken,
       permissions: permissions.value,
+      ...(zendeskActionPermissions ? { zendeskActionPermissions } : {}),
+      ...(storedToolPermissions ? { storedToolPermissions } : {}),
     },
   }
 }
@@ -119,16 +122,6 @@ export function validateZendeskConnectorConfig(
       valid: false,
       missing: parsed.missing,
       message: parsed.message,
-    }
-  }
-
-  const permissionsMessage = getZendeskConnectorPermissionsConstraintMessage(
-    parsed.value.permissions
-  )
-  if (permissionsMessage) {
-    return {
-      valid: false,
-      message: permissionsMessage,
     }
   }
 

--- a/apps/web/src/lib/connectors/zendesk-permission-preview.ts
+++ b/apps/web/src/lib/connectors/zendesk-permission-preview.ts
@@ -1,0 +1,142 @@
+import type { ZendeskActionName } from '@/lib/connectors/zendesk-types'
+
+export const ZENDESK_CONNECTOR_DISPLAY_NAME = 'Zendesk'
+
+const ZENDESK_ACTION_SUFFIXES: ZendeskActionName[] = [
+  'search_tickets',
+  'get_ticket',
+  'list_ticket_comments',
+  'create_ticket_public',
+  'create_ticket_internal',
+  'update_ticket_fields',
+  'update_ticket_with_public_comment',
+  'update_ticket_with_internal_note',
+]
+
+const ACTION_LABELS: Record<ZendeskActionName, string> = {
+  search_tickets: 'Search tickets',
+  get_ticket: 'Read ticket details',
+  list_ticket_comments: 'List ticket comments',
+  create_ticket_public: 'Create ticket with a public comment',
+  create_ticket_internal: 'Create ticket with an internal note',
+  update_ticket_fields: 'Update ticket fields',
+  update_ticket_with_public_comment: 'Update ticket with a public comment',
+  update_ticket_with_internal_note: 'Update ticket with an internal note',
+}
+
+export type ZendeskPreviewField = {
+  label: string
+  value: string
+}
+
+export type ZendeskPermissionPreview = {
+  action: ZendeskActionName
+  actionLabel: string
+  connectorName: string
+  fields: ZendeskPreviewField[]
+  visibility: 'public' | 'internal' | null
+}
+
+export function matchZendeskActionName(text: string | undefined): ZendeskActionName | null {
+  if (!text) return null
+
+  for (const action of ZENDESK_ACTION_SUFFIXES) {
+    if (text.endsWith(action)) return action
+  }
+
+  return null
+}
+
+function toPreviewString(value: unknown): string | null {
+  if (typeof value === 'string' && value.trim()) return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return null
+}
+
+function addField(
+  fields: ZendeskPreviewField[],
+  input: Record<string, unknown>,
+  key: string,
+  label: string
+): void {
+  const value = toPreviewString(input[key])
+  if (value !== null) {
+    fields.push({ label, value })
+  }
+}
+
+function addTagsField(fields: ZendeskPreviewField[], input: Record<string, unknown>): void {
+  const tags = input.tags
+  if (!Array.isArray(tags)) return
+
+  const values = tags
+    .map((tag) => toPreviewString(tag))
+    .filter((tag): tag is string => tag !== null)
+  if (values.length > 0) {
+    fields.push({ label: 'Tags', value: values.join(', ') })
+  }
+}
+
+// Builds the approval preview from the atomic tool name and the model-produced
+// input stored on the correlated tool part. Only whitelisted schema fields are
+// rendered; unknown metadata, connector configuration, and credentials are
+// never included.
+export function buildZendeskPermissionPreview(
+  toolName: string,
+  input: Record<string, unknown>
+): ZendeskPermissionPreview | null {
+  const action = matchZendeskActionName(toolName)
+  if (!action) return null
+
+  const fields: ZendeskPreviewField[] = []
+  let visibility: 'public' | 'internal' | null = null
+
+  switch (action) {
+    case 'search_tickets':
+      addField(fields, input, 'query', 'Query')
+      addField(fields, input, 'page', 'Page')
+      addField(fields, input, 'perPage', 'Per page')
+      break
+    case 'get_ticket':
+    case 'list_ticket_comments':
+      addField(fields, input, 'ticketId', 'Ticket ID')
+      break
+    case 'create_ticket_public':
+    case 'create_ticket_internal':
+      visibility = action === 'create_ticket_public' ? 'public' : 'internal'
+      addField(fields, input, 'subject', 'Subject')
+      addField(fields, input, 'comment', 'Comment')
+      addField(fields, input, 'priority', 'Priority')
+      addField(fields, input, 'status', 'Status')
+      addField(fields, input, 'type', 'Type')
+      addTagsField(fields, input)
+      break
+    case 'update_ticket_fields':
+      addField(fields, input, 'ticketId', 'Ticket ID')
+      addField(fields, input, 'subject', 'Subject')
+      addField(fields, input, 'priority', 'Priority')
+      addField(fields, input, 'status', 'Status')
+      addField(fields, input, 'type', 'Type')
+      addField(fields, input, 'assigneeId', 'Assignee ID')
+      break
+    case 'update_ticket_with_public_comment':
+    case 'update_ticket_with_internal_note':
+      visibility = action === 'update_ticket_with_public_comment' ? 'public' : 'internal'
+      addField(fields, input, 'ticketId', 'Ticket ID')
+      addField(fields, input, 'subject', 'Subject')
+      addField(fields, input, 'comment', 'Comment')
+      addField(fields, input, 'priority', 'Priority')
+      addField(fields, input, 'status', 'Status')
+      addField(fields, input, 'type', 'Type')
+      addField(fields, input, 'assigneeId', 'Assignee ID')
+      break
+  }
+
+  return {
+    action,
+    actionLabel: ACTION_LABELS[action],
+    connectorName: ZENDESK_CONNECTOR_DISPLAY_NAME,
+    fields,
+    visibility,
+  }
+}

--- a/apps/web/src/lib/connectors/zendesk-tools.ts
+++ b/apps/web/src/lib/connectors/zendesk-tools.ts
@@ -1,14 +1,14 @@
 import { ZENDESK_MCP_PROTOCOL_VERSION } from '@/lib/connectors/zendesk-shared'
 import { mapTicket, mapTicketComment, requestZendeskJson } from '@/lib/connectors/zendesk-client'
+import { resolveZendeskActionPermissions } from '@/lib/connectors/zendesk-action-permissions'
 import type {
+  ZendeskActionName,
   ZendeskApiResponse,
   ZendeskConnectorConfig,
-  ZendeskConnectorPermissions,
   ZendeskMcpTool,
   ZendeskMcpToolResult,
 } from '@/lib/connectors/zendesk-types'
 import {
-  getBoolean,
   getFiniteNumber,
   getPositiveInteger,
   getString,
@@ -23,16 +23,14 @@ const TICKET_STATUSES = ['new', 'open', 'pending', 'hold', 'solved', 'closed'] a
 const TICKET_PRIORITIES = ['urgent', 'high', 'normal', 'low'] as const
 const TICKET_TYPES = ['problem', 'incident', 'question', 'task'] as const
 
-type ZendeskToolPermission = 'read' | 'create' | 'update'
-
 type ZendeskMcpToolDefinition = ZendeskMcpTool & {
-  permission: ZendeskToolPermission
+  action: ZendeskActionName
 }
 
 const ZENDESK_MCP_TOOLS: ZendeskMcpToolDefinition[] = [
   {
     name: 'search_tickets',
-    permission: 'read',
+    action: 'search_tickets',
     description: 'Search Zendesk tickets using Zendesk search query syntax. The connector automatically scopes queries to tickets.',
     inputSchema: {
       type: 'object',
@@ -59,7 +57,7 @@ const ZENDESK_MCP_TOOLS: ZendeskMcpToolDefinition[] = [
   },
   {
     name: 'get_ticket',
-    permission: 'read',
+    action: 'get_ticket',
     description: 'Fetch a single Zendesk ticket by ID.',
     inputSchema: {
       type: 'object',
@@ -76,7 +74,7 @@ const ZENDESK_MCP_TOOLS: ZendeskMcpToolDefinition[] = [
   },
   {
     name: 'list_ticket_comments',
-    permission: 'read',
+    action: 'list_ticket_comments',
     description: 'List comments for a Zendesk ticket.',
     inputSchema: {
       type: 'object',
@@ -92,9 +90,9 @@ const ZENDESK_MCP_TOOLS: ZendeskMcpToolDefinition[] = [
     },
   },
   {
-    name: 'create_ticket',
-    permission: 'create',
-    description: 'Create a Zendesk ticket with an initial comment as the authenticated connector account.',
+    name: 'create_ticket_public',
+    action: 'create_ticket_public',
+    description: 'Create a Zendesk ticket whose initial comment is public and can notify the requester by email.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -104,7 +102,7 @@ const ZENDESK_MCP_TOOLS: ZendeskMcpToolDefinition[] = [
         },
         comment: {
           type: 'string',
-          description: 'Initial ticket comment body.',
+          description: 'Initial public ticket comment body.',
         },
         priority: {
           type: 'string',
@@ -121,9 +119,45 @@ const ZENDESK_MCP_TOOLS: ZendeskMcpToolDefinition[] = [
           enum: [...TICKET_TYPES],
           description: 'Optional ticket type.',
         },
-        publicComment: {
-          type: 'boolean',
-          description: 'Whether the initial comment should be public. Defaults to true.',
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Optional ticket tags.',
+        },
+      },
+      required: ['subject', 'comment'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'create_ticket_internal',
+    action: 'create_ticket_internal',
+    description: 'Create a Zendesk ticket whose initial comment is an internal note visible only to Zendesk agents.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        subject: {
+          type: 'string',
+          description: 'Ticket subject line.',
+        },
+        comment: {
+          type: 'string',
+          description: 'Initial internal ticket comment body.',
+        },
+        priority: {
+          type: 'string',
+          enum: [...TICKET_PRIORITIES],
+          description: 'Optional ticket priority.',
+        },
+        status: {
+          type: 'string',
+          enum: [...TICKET_STATUSES],
+          description: 'Optional ticket status.',
+        },
+        type: {
+          type: 'string',
+          enum: [...TICKET_TYPES],
+          description: 'Optional ticket type.',
         },
         tags: {
           type: 'array',
@@ -136,9 +170,9 @@ const ZENDESK_MCP_TOOLS: ZendeskMcpToolDefinition[] = [
     },
   },
   {
-    name: 'update_ticket',
-    permission: 'update',
-    description: 'Update a Zendesk ticket and optionally add a comment.',
+    name: 'update_ticket_fields',
+    action: 'update_ticket_fields',
+    description: 'Update Zendesk ticket fields (subject, status, priority, type, assignee) without adding a comment.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -150,10 +184,6 @@ const ZENDESK_MCP_TOOLS: ZendeskMcpToolDefinition[] = [
         subject: {
           type: 'string',
           description: 'Optional new subject.',
-        },
-        comment: {
-          type: 'string',
-          description: 'Optional comment body to add while updating the ticket.',
         },
         priority: {
           type: 'string',
@@ -175,12 +205,98 @@ const ZENDESK_MCP_TOOLS: ZendeskMcpToolDefinition[] = [
           description: 'Optional assignee user ID.',
           minimum: 1,
         },
-        publicComment: {
-          type: 'boolean',
-          description: 'Whether the new comment should be public. Defaults to true.',
-        },
       },
       required: ['ticketId'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'update_ticket_with_public_comment',
+    action: 'update_ticket_with_public_comment',
+    description: 'Update a Zendesk ticket and add a public comment in the same request. The comment can notify the requester by email.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ticketId: {
+          type: 'integer',
+          description: 'Zendesk ticket ID.',
+          minimum: 1,
+        },
+        comment: {
+          type: 'string',
+          description: 'Public comment body to add while updating the ticket.',
+        },
+        subject: {
+          type: 'string',
+          description: 'Optional new subject.',
+        },
+        priority: {
+          type: 'string',
+          enum: [...TICKET_PRIORITIES],
+          description: 'Optional new priority.',
+        },
+        status: {
+          type: 'string',
+          enum: [...TICKET_STATUSES],
+          description: 'Optional new status.',
+        },
+        type: {
+          type: 'string',
+          enum: [...TICKET_TYPES],
+          description: 'Optional new ticket type.',
+        },
+        assigneeId: {
+          type: 'integer',
+          description: 'Optional assignee user ID.',
+          minimum: 1,
+        },
+      },
+      required: ['ticketId', 'comment'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'update_ticket_with_internal_note',
+    action: 'update_ticket_with_internal_note',
+    description: 'Update a Zendesk ticket and add an internal note visible only to Zendesk agents in the same request.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ticketId: {
+          type: 'integer',
+          description: 'Zendesk ticket ID.',
+          minimum: 1,
+        },
+        comment: {
+          type: 'string',
+          description: 'Internal note body to add while updating the ticket.',
+        },
+        subject: {
+          type: 'string',
+          description: 'Optional new subject.',
+        },
+        priority: {
+          type: 'string',
+          enum: [...TICKET_PRIORITIES],
+          description: 'Optional new priority.',
+        },
+        status: {
+          type: 'string',
+          enum: [...TICKET_STATUSES],
+          description: 'Optional new status.',
+        },
+        type: {
+          type: 'string',
+          enum: [...TICKET_TYPES],
+          description: 'Optional new ticket type.',
+        },
+        assigneeId: {
+          type: 'integer',
+          description: 'Optional assignee user ID.',
+          minimum: 1,
+        },
+      },
+      required: ['ticketId', 'comment'],
       additionalProperties: false,
     },
   },
@@ -237,10 +353,6 @@ function getOptionalIntegerArg(args: Record<string, unknown>, key: string): numb
   return getPositiveInteger(args[key])
 }
 
-function getOptionalBooleanArg(args: Record<string, unknown>, key: string): boolean | undefined {
-  return getBoolean(args[key])
-}
-
 function validateEnumArg<T extends readonly string[]>(
   value: string | undefined,
   values: T,
@@ -254,7 +366,7 @@ function validateEnumArg<T extends readonly string[]>(
   return { ok: false, message: `${label} must be one of: ${values.join(', ')}` }
 }
 
-function validateCreateOrUpdateEnums(args: Record<string, unknown>): { ok: true } | { ok: false; message: string } {
+function validateTicketFieldEnums(args: Record<string, unknown>): { ok: true } | { ok: false; message: string } {
   const status = validateEnumArg(getOptionalStringArg(args, 'status'), TICKET_STATUSES, 'status')
   if (!status.ok) return status
 
@@ -271,108 +383,41 @@ function getZendeskToolDefinition(toolName: string): ZendeskMcpToolDefinition | 
   return ZENDESK_MCP_TOOLS.find((tool) => tool.name === toolName)
 }
 
-function isZendeskToolEnabled(
-  permissions: ZendeskConnectorPermissions,
-  tool: ZendeskMcpToolDefinition
-): boolean {
-  switch (tool.permission) {
-    case 'read':
-      return permissions.allowRead
-    case 'create':
-      return permissions.allowCreateTickets
-    case 'update':
-      return permissions.allowUpdateTickets
-  }
+type ZendeskTicketFields = {
+  subject?: string
+  status?: string
+  priority?: string
+  type?: string
+  assigneeId?: number
 }
 
-function getZendeskToolDisabledMessage(
-  permissions: ZendeskConnectorPermissions,
-  toolName: string
-): string | null {
-  const tool = getZendeskToolDefinition(toolName)
-  if (!tool) {
-    return null
-  }
-
-  switch (tool.permission) {
-    case 'read':
-      return permissions.allowRead ? null : 'Read operations are disabled for this Zendesk connector'
-    case 'create':
-      return permissions.allowCreateTickets ? null : 'Ticket creation is disabled for this Zendesk connector'
-    case 'update':
-      return permissions.allowUpdateTickets ? null : 'Ticket updates are disabled for this Zendesk connector'
-  }
-}
-
-function buildTicketPayload(
-  config: ZendeskConnectorConfig,
-  args: Record<string, unknown>,
-  mode: 'create' | 'update'
-) {
-  const ticket: Record<string, unknown> = {}
+function buildTicketFieldPayload(args: Record<string, unknown>): ZendeskTicketFields {
+  const fields: ZendeskTicketFields = {}
 
   const subject = getOptionalStringArg(args, 'subject')
-  if (subject) ticket.subject = subject
+  if (subject) fields.subject = subject
 
   const status = getOptionalStringArg(args, 'status')
-  if (status) ticket.status = status
+  if (status) fields.status = status
 
   const priority = getOptionalStringArg(args, 'priority')
-  if (priority) ticket.priority = priority
+  if (priority) fields.priority = priority
 
   const type = getOptionalStringArg(args, 'type')
-  if (type) ticket.type = type
-
-  if (hasOwnProperty(args, 'assigneeId') && getOptionalIntegerArg(args, 'assigneeId') === undefined) {
-    return { ok: false, error: 'invalid_arguments', message: 'assigneeId must be a positive integer' } as const
-  }
+  if (type) fields.type = type
 
   const assigneeId = getOptionalIntegerArg(args, 'assigneeId')
-  if (assigneeId) ticket.assignee_id = assigneeId
+  if (assigneeId) fields.assigneeId = assigneeId
 
-  if (hasOwnProperty(args, 'tags') && !isStringArray(args.tags)) {
-    return { ok: false, error: 'invalid_arguments', message: 'tags must be a string array' } as const
+  return fields
+}
+
+function validateAssigneeIdArg(args: Record<string, unknown>): { ok: true } | { ok: false; message: string } {
+  if (hasOwnProperty(args, 'assigneeId') && getOptionalIntegerArg(args, 'assigneeId') === undefined) {
+    return { ok: false, message: 'assigneeId must be a positive integer' }
   }
 
-  const tags = getStringArray(args.tags)
-  if (mode === 'create' && tags) {
-    ticket.tags = tags
-  }
-
-  if (hasOwnProperty(args, 'publicComment') && getOptionalBooleanArg(args, 'publicComment') === undefined) {
-    return { ok: false, error: 'invalid_arguments', message: 'publicComment must be a boolean' } as const
-  }
-
-  const comment = getOptionalStringArg(args, 'comment')
-  if (comment) {
-    const isPublicComment = getOptionalBooleanArg(args, 'publicComment') ?? true
-    if (isPublicComment && !config.permissions.allowPublicComments) {
-      return {
-        ok: false,
-        error: 'operation_not_allowed',
-        message: 'Public comments are disabled for this Zendesk connector',
-      } as const
-    }
-
-    if (!isPublicComment && !config.permissions.allowInternalComments) {
-      return {
-        ok: false,
-        error: 'operation_not_allowed',
-        message: 'Internal comments are disabled for this Zendesk connector',
-      } as const
-    }
-
-    ticket.comment = {
-      body: comment,
-      public: isPublicComment,
-    }
-  }
-
-  if (mode === 'create') {
-    ticket.requester = { email: config.email }
-  }
-
-  return { ok: true, ticket } as const
+  return { ok: true }
 }
 
 function mapZendeskToolResponse(
@@ -406,7 +451,8 @@ export function getZendeskMcpProtocolVersion(): string {
 }
 
 export function getZendeskMcpTools(config: ZendeskConnectorConfig): ZendeskMcpTool[] {
-  return ZENDESK_MCP_TOOLS.filter((tool) => isZendeskToolEnabled(config.permissions, tool)).map(toZendeskMcpTool)
+  const actions = resolveZendeskActionPermissions(config)
+  return ZENDESK_MCP_TOOLS.filter((tool) => actions[tool.action] !== 'deny').map(toZendeskMcpTool)
 }
 
 export async function executeZendeskMcpTool(
@@ -415,9 +461,14 @@ export async function executeZendeskMcpTool(
   args: unknown
 ): Promise<ZendeskMcpToolResult> {
   const toolArgs = requireObjectArguments(args)
-  const permissionError = getZendeskToolDisabledMessage(config.permissions, toolName)
-  if (permissionError) {
-    return toToolError('operation_not_allowed', permissionError)
+  const tool = getZendeskToolDefinition(toolName)
+  if (!tool) {
+    return toToolError('unknown_tool', `Unknown Zendesk tool: ${toolName}`)
+  }
+
+  const actions = resolveZendeskActionPermissions(config)
+  if (actions[tool.action] === 'deny') {
+    return toToolError('operation_not_allowed', 'This Zendesk action is denied for this connector')
   }
 
   try {
@@ -496,21 +547,37 @@ export async function executeZendeskMcpTool(
         })
       }
 
-      case 'create_ticket': {
+      case 'create_ticket_public':
+      case 'create_ticket_internal': {
         const subject = requireStringArg(toolArgs, 'subject')
         const comment = requireStringArg(toolArgs, 'comment')
         if (!subject || !comment) {
           return toToolError('invalid_arguments', 'subject and comment are required')
         }
 
-        const enumValidation = validateCreateOrUpdateEnums(toolArgs)
+        const enumValidation = validateTicketFieldEnums(toolArgs)
         if (!enumValidation.ok) {
           return toToolError('invalid_arguments', enumValidation.message)
         }
 
-        const payload = buildTicketPayload(config, toolArgs, 'create')
-        if (!payload.ok) {
-          return toToolError(payload.error, payload.message)
+        if (hasOwnProperty(toolArgs, 'tags') && !isStringArray(toolArgs.tags)) {
+          return toToolError('invalid_arguments', 'tags must be a string array')
+        }
+
+        const isPublic = toolName === 'create_ticket_public'
+        const ticket: Record<string, unknown> = {
+          subject,
+          comment: {
+            body: comment,
+            public: isPublic,
+          },
+          requester: { email: config.email },
+        }
+        Object.assign(ticket, buildTicketFieldPayload(toolArgs))
+
+        const tags = getStringArray(toolArgs.tags)
+        if (tags) {
+          ticket.tags = tags
         }
 
         return runZendeskRequest(
@@ -518,7 +585,7 @@ export async function executeZendeskMcpTool(
           {
             path: '/tickets.json',
             method: 'POST',
-            body: { ticket: payload.ticket },
+            body: { ticket },
           },
           (data) => ({
             ok: true,
@@ -527,24 +594,33 @@ export async function executeZendeskMcpTool(
         )
       }
 
-      case 'update_ticket': {
+      case 'update_ticket_fields': {
         const ticketId = getOptionalIntegerArg(toolArgs, 'ticketId')
         if (!ticketId) {
           return toToolError('invalid_arguments', 'ticketId is required and must be a positive integer')
         }
 
-        const enumValidation = validateCreateOrUpdateEnums(toolArgs)
+        if (hasOwnProperty(toolArgs, 'comment')) {
+          return toToolError('invalid_arguments', 'comment is not supported by update_ticket_fields; use update_ticket_with_public_comment or update_ticket_with_internal_note')
+        }
+
+        if (hasOwnProperty(toolArgs, 'publicComment')) {
+          return toToolError('invalid_arguments', 'publicComment is not supported by update_ticket_fields')
+        }
+
+        const enumValidation = validateTicketFieldEnums(toolArgs)
         if (!enumValidation.ok) {
           return toToolError('invalid_arguments', enumValidation.message)
         }
 
-        const payload = buildTicketPayload(config, toolArgs, 'update')
-        if (!payload.ok) {
-          return toToolError(payload.error, payload.message)
+        const assigneeValidation = validateAssigneeIdArg(toolArgs)
+        if (!assigneeValidation.ok) {
+          return toToolError('invalid_arguments', assigneeValidation.message)
         }
 
-        if (Object.keys(payload.ticket).length === 0) {
-          return toToolError('invalid_arguments', 'At least one ticket field or comment must be provided')
+        const fields = buildTicketFieldPayload(toolArgs)
+        if (Object.keys(fields).length === 0) {
+          return toToolError('invalid_arguments', 'At least one ticket field must be provided')
         }
 
         return runZendeskRequest(
@@ -552,7 +628,51 @@ export async function executeZendeskMcpTool(
           {
             path: `/tickets/${ticketId}.json`,
             method: 'PUT',
-            body: { ticket: payload.ticket },
+            body: { ticket: fields },
+          },
+          (data) => ({
+            ok: true,
+            ticket: mapTicket(data?.ticket, config.subdomain),
+          })
+        )
+      }
+
+      case 'update_ticket_with_public_comment':
+      case 'update_ticket_with_internal_note': {
+        const ticketId = getOptionalIntegerArg(toolArgs, 'ticketId')
+        const comment = requireStringArg(toolArgs, 'comment')
+        if (!ticketId) {
+          return toToolError('invalid_arguments', 'ticketId is required and must be a positive integer')
+        }
+        if (!comment) {
+          return toToolError('invalid_arguments', 'comment is required')
+        }
+
+        const enumValidation = validateTicketFieldEnums(toolArgs)
+        if (!enumValidation.ok) {
+          return toToolError('invalid_arguments', enumValidation.message)
+        }
+
+        const assigneeValidation = validateAssigneeIdArg(toolArgs)
+        if (!assigneeValidation.ok) {
+          return toToolError('invalid_arguments', assigneeValidation.message)
+        }
+
+        const isPublic = toolName === 'update_ticket_with_public_comment'
+        const ticket: Record<string, unknown> = {
+          comment: {
+            body: comment,
+            public: isPublic,
+          },
+          ...buildTicketFieldPayload(toolArgs),
+        }
+
+        return runZendeskRequest(
+          config,
+          {
+            path: `/tickets/${ticketId}.json`,
+            method: 'PUT',
+            body: { ticket },
           },
           (data) => ({
             ok: true,

--- a/apps/web/src/lib/connectors/zendesk-types.ts
+++ b/apps/web/src/lib/connectors/zendesk-types.ts
@@ -1,3 +1,5 @@
+import type { ConnectorToolPermissionMap } from '@/lib/connectors/tool-permissions'
+
 export const ZENDESK_CONNECTOR_PERMISSION_KEYS = [
   'allowRead',
   'allowCreateTickets',
@@ -27,14 +29,48 @@ export type ZendeskConnectorConfig = {
   email: string
   apiToken: string
   permissions: ZendeskConnectorPermissions
+  zendeskActionPermissions?: ZendeskActionPermissions
+  storedToolPermissions?: ConnectorToolPermissionMap
 }
 
-export type ZendeskToolName =
-  | 'search_tickets'
-  | 'get_ticket'
-  | 'list_ticket_comments'
-  | 'create_ticket'
-  | 'update_ticket'
+export const ZENDESK_ACTION_PERMISSIONS_CONFIG_KEY = 'zendeskActionPermissions'
+
+export const ZENDESK_ACTION_PERMISSIONS_VERSION = 1 as const
+
+export const ZENDESK_ACTION_KEYS = [
+  'search_tickets',
+  'get_ticket',
+  'list_ticket_comments',
+  'create_ticket_public',
+  'create_ticket_internal',
+  'update_ticket_fields',
+  'update_ticket_with_public_comment',
+  'update_ticket_with_internal_note',
+] as const
+
+export type ZendeskActionName = (typeof ZENDESK_ACTION_KEYS)[number]
+
+export type ZendeskActionPolicy = 'deny' | 'ask' | 'allow'
+
+export type ZendeskActionPermissions = Record<ZendeskActionName, ZendeskActionPolicy>
+
+export const DEFAULT_ZENDESK_ACTION_PERMISSIONS: ZendeskActionPermissions = {
+  search_tickets: 'allow',
+  get_ticket: 'allow',
+  list_ticket_comments: 'allow',
+  create_ticket_public: 'allow',
+  create_ticket_internal: 'allow',
+  update_ticket_fields: 'allow',
+  update_ticket_with_public_comment: 'allow',
+  update_ticket_with_internal_note: 'allow',
+}
+
+export type ZendeskActionPermissionsConfig = {
+  version: typeof ZENDESK_ACTION_PERMISSIONS_VERSION
+  actions: ZendeskActionPermissions
+}
+
+export type ZendeskToolName = ZendeskActionName
 
 export type ZendeskMcpTextContent = {
   type: 'text'

--- a/apps/web/src/lib/connectors/zendesk.ts
+++ b/apps/web/src/lib/connectors/zendesk.ts
@@ -1,9 +1,16 @@
 export {
-  getZendeskConnectorPermissionsConstraintMessage,
   parseZendeskConnectorConfig,
   parseZendeskConnectorPermissions,
   validateZendeskConnectorConfig,
 } from '@/lib/connectors/zendesk-config'
+export {
+  buildLegacyProjectionFromActionPermissions,
+  getZendeskRuntimeToolPermissions,
+  mergeLegacyToolPermissions,
+  normalizeZendeskActionPermissions,
+  parseZendeskActionPermissionsConfig,
+  resolveZendeskActionPermissions,
+} from '@/lib/connectors/zendesk-action-permissions'
 export { testZendeskConnection } from '@/lib/connectors/zendesk-client'
 export {
   executeZendeskMcpTool,
@@ -11,6 +18,10 @@ export {
   getZendeskMcpTools,
 } from '@/lib/connectors/zendesk-tools'
 export type {
+  ZendeskActionName,
+  ZendeskActionPermissions,
+  ZendeskActionPermissionsConfig,
+  ZendeskActionPolicy,
   ZendeskApiResponse,
   ZendeskConnectorConfig,
   ZendeskConnectorPermissions,

--- a/apps/web/src/lib/opencode/__tests__/permission-tool-parts.test.ts
+++ b/apps/web/src/lib/opencode/__tests__/permission-tool-parts.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+
+import { selectPermissionToolParts } from '@/lib/opencode/permission-tool-parts'
+import type { WorkspaceMessage } from '@/lib/opencode/types'
+
+function makePermission(id: string, sessionId: string, callId?: string) {
+  return {
+    id,
+    sessionId,
+    ...(callId ? { callId } : {}),
+    title: 'Tool approval required',
+    state: 'pending' as const,
+  }
+}
+
+function makeMessage(id: string, sessionId: string, parts: WorkspaceMessage['parts']): WorkspaceMessage {
+  return {
+    id,
+    sessionId,
+    role: 'assistant',
+    content: '',
+    timestamp: '2026-01-01T00:00:00Z',
+    parts,
+  }
+}
+
+describe('selectPermissionToolParts', () => {
+  it('resolves a permission whose tool part already arrived (tool-part-first ordering)', () => {
+    const messages = {
+      s1: [
+        makeMessage('m1', 's1', [
+          { type: 'tool', id: 'call-1', name: 'arche_zendesk_z1_create_ticket_public', state: { status: 'pending', input: { subject: 'Hi' } } },
+        ]),
+      ],
+    }
+    const result = selectPermissionToolParts(messages, [makePermission('p1', 's1', 'call-1')])
+
+    expect(result.p1).toEqual({
+      toolName: 'arche_zendesk_z1_create_ticket_public',
+      input: { subject: 'Hi' },
+    })
+  })
+
+  it('keeps loading when the permission session has no cached messages yet (permission-first ordering)', () => {
+    const result = selectPermissionToolParts({}, [makePermission('p1', 's1', 'call-1')])
+
+    expect(result.p1).toBeUndefined()
+  })
+
+  it('resolves after hydration when messages arrive later', () => {
+    const empty = selectPermissionToolParts({}, [makePermission('p1', 's1', 'call-1')])
+    expect(empty.p1).toBeUndefined()
+
+    const hydrated = selectPermissionToolParts(
+      {
+        s1: [
+          makeMessage('m1', 's1', [
+            { type: 'tool', id: 'call-1', name: 'arche_zendesk_z1_get_ticket', state: { status: 'running', input: { ticketId: 5 } } },
+          ]),
+        ],
+      },
+      [makePermission('p1', 's1', 'call-1')],
+    )
+    expect(hydrated.p1).toEqual({ toolName: 'arche_zendesk_z1_get_ticket', input: { ticketId: 5 } })
+  })
+
+  it('reports retrieval failure when the session is loaded but the call id is missing', () => {
+    const messages = {
+      s1: [
+        makeMessage('m1', 's1', [
+          { type: 'tool', id: 'other-call', name: 'bash', state: { status: 'pending', input: {} } },
+        ]),
+      ],
+    }
+    const result = selectPermissionToolParts(messages, [makePermission('p1', 's1', 'call-1')])
+
+    expect(result.p1).toBeNull()
+  })
+
+  it('correlates delegated child sessions referenced by a parent-visible permission', () => {
+    const messages = {
+      parent: [makeMessage('m-parent', 'parent', [])],
+      child: [
+        makeMessage('m-child', 'child', [
+          { type: 'tool', id: 'call-child', name: 'arche_zendesk_z1_update_ticket_with_public_comment', state: { status: 'pending', input: { ticketId: 9, comment: 'Hi' } } },
+        ]),
+      ],
+    }
+    const result = selectPermissionToolParts(messages, [
+      makePermission('p1', 'child', 'call-child'),
+    ])
+
+    expect(result.p1).toEqual({
+      toolName: 'arche_zendesk_z1_update_ticket_with_public_comment',
+      input: { ticketId: 9, comment: 'Hi' },
+    })
+  })
+
+  it('ignores permissions without a call id and non-tool parts', () => {
+    const messages = {
+      s1: [
+        makeMessage('m1', 's1', [{ type: 'text', text: 'hello' }]),
+      ],
+    }
+    const result = selectPermissionToolParts(messages, [makePermission('p1', 's1')])
+
+    expect(result.p1).toBeUndefined()
+  })
+})

--- a/apps/web/src/lib/opencode/permission-tool-parts.ts
+++ b/apps/web/src/lib/opencode/permission-tool-parts.ts
@@ -1,0 +1,61 @@
+import type { WorkspaceMessage } from '@/lib/opencode/types'
+import type { WorkspacePermission } from '@/lib/opencode/permission'
+
+export type PermissionToolPart = {
+  toolName: string
+  input: Record<string, unknown>
+}
+
+/**
+ * Permission preview resolution:
+ * - `PermissionToolPart` — the referenced tool call was found.
+ * - `null` — the permission's session messages are loaded but no tool part
+ *   matches; retrieval failed and the approval must not proceed blindly.
+ * - `undefined` — the referenced session's messages are not (yet) loaded;
+ *   keep waiting for hydration.
+ */
+export type ResolvedPermissionToolPart = PermissionToolPart | null | undefined
+
+// Correlates pending permissions with tool parts across all cached session
+// messages (including delegated child sessions already in the store). Tool
+// parts and permission events can arrive in either order, so callers recompute
+// this reactively whenever messages or permissions change.
+export function selectPermissionToolParts(
+  messagesBySession: Record<string, WorkspaceMessage[]>,
+  permissions: WorkspacePermission[]
+): Record<string, ResolvedPermissionToolPart> {
+  const toolPartsByCallId = new Map<string, PermissionToolPart>()
+  const loadedSessions = new Set<string>()
+
+  for (const [sessionId, messages] of Object.entries(messagesBySession)) {
+    if (!Array.isArray(messages)) continue
+    loadedSessions.add(sessionId)
+
+    for (const message of messages) {
+      if (!Array.isArray(message.parts)) continue
+
+      for (const part of message.parts) {
+        if (part.type !== 'tool') continue
+        toolPartsByCallId.set(part.id, {
+          toolName: part.name,
+          input: part.state.input ?? {},
+        })
+      }
+    }
+  }
+
+  const resolved: Record<string, ResolvedPermissionToolPart> = {}
+  for (const permission of permissions) {
+    if (!permission.callId) continue
+
+    const matched = toolPartsByCallId.get(permission.callId)
+    if (matched) {
+      resolved[permission.id] = matched
+      continue
+    }
+
+    resolved[permission.id] = loadedSessions.has(permission.sessionId) ? null : undefined
+  }
+
+  return resolved
+}

--- a/apps/web/src/lib/spawner/__tests__/agent-config-transforms.test.ts
+++ b/apps/web/src/lib/spawner/__tests__/agent-config-transforms.test.ts
@@ -883,6 +883,46 @@ describe('remapAgentConnectorTools', () => {
     expect(permission['arche_custom_sameconnector_sync']).toBe('deny')
   })
 
+  it('expands atomic Zendesk actions into independent exact permission entries', () => {
+    const config = {
+      agent: {
+        support: {
+          tools: {
+            'arche_zendesk_z1_*': true,
+          },
+        },
+      },
+    }
+    const permissions = {
+      search_tickets: 'deny',
+      get_ticket: 'ask',
+      list_ticket_comments: 'allow',
+      create_ticket_public: 'deny',
+      create_ticket_internal: 'ask',
+      update_ticket_fields: 'allow',
+      update_ticket_with_public_comment: 'ask',
+      update_ticket_with_internal_note: 'allow',
+    } as const
+
+    const result = remapAgentConnectorTools(
+      config,
+      new Set(['arche_zendesk_z1']),
+      { arche_zendesk_z1: permissions },
+    )
+    const agent = (result.agent as Record<string, Record<string, unknown>>).support
+    const tools = agent.tools as Record<string, boolean>
+    const permission = agent.permission as Record<string, unknown>
+
+    expect(tools['arche_zendesk_z1_*']).toBeUndefined()
+    for (const [action, policy] of Object.entries(permissions)) {
+      expect(tools[`arche_zendesk_z1_${action}`]).toBe(true)
+      expect(permission[`arche_zendesk_z1_${action}`]).toBe(policy)
+    }
+    // Session-level `always` is scoped to the exact atomic tool name, so an
+    // approval of one action never authorizes a differently named action.
+    expect(new Set(Object.keys(permission).filter((key) => key.startsWith('arche_zendesk_z1_'))).size).toBe(8)
+  })
+
   it('preserves non-MCP tools', () => {
     const config = {
       agent: {

--- a/apps/web/src/lib/spawner/__tests__/mcp-config.test.ts
+++ b/apps/web/src/lib/spawner/__tests__/mcp-config.test.ts
@@ -34,7 +34,8 @@ vi.mock('@/lib/connectors/ahrefs', () => ({
   parseAhrefsConnectorConfig: connectorMocks.parseAhrefsConnectorConfig,
 }))
 
-vi.mock('@/lib/connectors/zendesk', () => ({
+vi.mock('@/lib/connectors/zendesk', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/connectors/zendesk')>()),
   parseZendeskConnectorConfig: connectorMocks.parseZendeskConnectorConfig,
 }))
 
@@ -648,6 +649,101 @@ describe('mcp-config', () => {
           })
         })
       }
+    })
+
+    // -----------------------------------------------------------------------
+    // Zendesk action-policy adapter
+    // -----------------------------------------------------------------------
+
+    describe('Zendesk action-policy adapter', () => {
+      const ZENDESK_CONFIG_BASE = {
+        subdomain: 'acme',
+        email: 'a@b.com',
+        apiToken: 'tok',
+        permissions: {
+          allowRead: true,
+          allowCreateTickets: true,
+          allowUpdateTickets: true,
+          allowPublicComments: true,
+          allowInternalComments: true,
+        },
+      }
+
+      function buildWithZendeskConfig(config: Record<string, unknown>) {
+        connectorMocks.validateConnectorType.mockReturnValue(true)
+        connectorMocks.validateConnectorConfig.mockReturnValue({ valid: true })
+        connectorMocks.decryptConfig.mockReturnValue(config)
+        connectorMocks.parseZendeskConnectorConfig.mockReturnValue({ ok: true })
+        const connector = makeConnector({ type: 'zendesk', id: 'z1' })
+
+        return buildMcpConfigFromConnectors([connector], {
+          gatewayTargets: { z1: { url: 'http://gateway/z1/mcp', token: 'gw-token' } },
+        })
+      }
+
+      it('derives runtime permissions from legacy booleans and stored tool policies with deny entries included', () => {
+        const result = buildWithZendeskConfig({
+          ...ZENDESK_CONFIG_BASE,
+          permissions: { ...ZENDESK_CONFIG_BASE.permissions, allowPublicComments: false },
+          mcpToolPermissions: { update_ticket: 'ask' },
+        })
+
+        expect(result.connectorToolPermissions['arche_zendesk_z1']).toEqual({
+          search_tickets: 'allow',
+          get_ticket: 'allow',
+          list_ticket_comments: 'allow',
+          create_ticket_public: 'deny',
+          create_ticket_internal: 'allow',
+          update_ticket_fields: 'ask',
+          update_ticket_with_public_comment: 'deny',
+          update_ticket_with_internal_note: 'ask',
+        })
+      })
+
+      it('prefers stored canonical actions over legacy fields', () => {
+        const actions = {
+          search_tickets: 'deny' as const,
+          get_ticket: 'allow' as const,
+          list_ticket_comments: 'allow' as const,
+          create_ticket_public: 'ask' as const,
+          create_ticket_internal: 'deny' as const,
+          update_ticket_fields: 'allow' as const,
+          update_ticket_with_public_comment: 'ask' as const,
+          update_ticket_with_internal_note: 'allow' as const,
+        }
+        const result = buildWithZendeskConfig({
+          ...ZENDESK_CONFIG_BASE,
+          permissions: { ...ZENDESK_CONFIG_BASE.permissions, allowRead: false },
+          zendeskActionPermissions: { version: 1, actions },
+        })
+
+        expect(result.connectorToolPermissions['arche_zendesk_z1']).toEqual(actions)
+      })
+
+      it('never emits retired composite tool names in runtime permissions', () => {
+        const result = buildWithZendeskConfig({
+          ...ZENDESK_CONFIG_BASE,
+          mcpToolPermissions: { create_ticket: 'deny', update_ticket: 'ask' },
+        })
+
+        const permissions = result.connectorToolPermissions['arche_zendesk_z1'] ?? {}
+        expect(permissions.create_ticket).toBeUndefined()
+        expect(permissions.update_ticket).toBeUndefined()
+      })
+
+      it('keeps other connectors on generic stored tool permissions', () => {
+        connectorMocks.validateConnectorType.mockReturnValue(true)
+        connectorMocks.validateConnectorConfig.mockReturnValue({ valid: true })
+        connectorMocks.decryptConfig.mockReturnValue({
+          apiKey: 'linear-key',
+          mcpToolPermissions: { list_issues: 'ask' },
+        })
+        const connector = makeConnector({ type: 'linear', id: 'l1' })
+
+        const result = buildMcpConfigFromConnectors([connector])
+
+        expect(result.connectorToolPermissions['arche_linear_l1']).toEqual({ list_issues: 'ask' })
+      })
     })
 
     // -----------------------------------------------------------------------

--- a/apps/web/src/lib/spawner/mcp-config.ts
+++ b/apps/web/src/lib/spawner/mcp-config.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/connectors/tool-permissions'
 import type { ConnectorType } from '@/lib/connectors/types'
 import { validateConnectorConfig, validateConnectorType } from '@/lib/connectors/validators'
+import { getZendeskRuntimeToolPermissions } from '@/lib/connectors/zendesk'
 import {
   buildConnectorMcpServerConfig,
   shouldExposeConnectorViaGateway,
@@ -54,6 +55,20 @@ export function buildMcpServerKey(type: ConnectorType, id: string): string {
   return `arche_${type}_${id}`
 }
 
+// Connector-type policy adapter: Zendesk derives its runtime permissions from
+// the normalized canonical action map; every other connector keeps reading the
+// generic stored `mcpToolPermissions`.
+function getRuntimeConnectorToolPermissions(
+  type: ConnectorType,
+  config: Record<string, unknown>
+): ConnectorToolPermissionMap | null {
+  if (type === 'zendesk') {
+    return getZendeskRuntimeToolPermissions(config)
+  }
+
+  return getStoredConnectorToolPermissions(config)
+}
+
 export function buildMcpConfigFromConnectors(
   connectors: ConnectorRecord[],
   options?: { gatewayTargets?: Record<string, GatewayTarget> },
@@ -88,7 +103,7 @@ export function buildMcpConfigFromConnectors(
       mcp[serverKey] = serverConfig
       connectorDisplayNames[serverKey] = connector.name.trim() || connector.id
 
-      const toolPermissions = getStoredConnectorToolPermissions(config)
+      const toolPermissions = getRuntimeConnectorToolPermissions(connector.type, config)
       if (toolPermissions) {
         connectorToolPermissions[serverKey] = toolPermissions
       }

--- a/apps/web/tests/connectors-mcp-route.test.ts
+++ b/apps/web/tests/connectors-mcp-route.test.ts
@@ -132,8 +132,11 @@ describe('internal connector MCP route', () => {
       'search_tickets',
       'get_ticket',
       'list_ticket_comments',
-      'create_ticket',
-      'update_ticket',
+      'create_ticket_public',
+      'create_ticket_internal',
+      'update_ticket_fields',
+      'update_ticket_with_public_comment',
+      'update_ticket_with_internal_note',
     ])
   })
 
@@ -164,7 +167,8 @@ describe('internal connector MCP route', () => {
       'search_tickets',
       'get_ticket',
       'list_ticket_comments',
-      'update_ticket',
+      'update_ticket_fields',
+      'update_ticket_with_internal_note',
     ])
   })
 
@@ -242,12 +246,10 @@ describe('internal connector MCP route', () => {
         id: 'tool-call-2',
         method: 'tools/call',
         params: {
-          name: 'create_ticket',
+          name: 'create_ticket_public',
           arguments: {
             subject: 'Need help',
             comment: 'The issue is still happening.',
-            requesterEmail: 'external@example.com',
-            requesterName: 'External User',
           },
         },
       },
@@ -270,7 +272,7 @@ describe('internal connector MCP route', () => {
     })
   })
 
-  it('rejects invalid boolean tool arguments instead of coercing them', async () => {
+  it('rejects invalid assignee arguments instead of coercing them', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
 
@@ -280,11 +282,10 @@ describe('internal connector MCP route', () => {
         id: 'tool-call-3',
         method: 'tools/call',
         params: {
-          name: 'update_ticket',
+          name: 'update_ticket_fields',
           arguments: {
             ticketId: 42,
-            comment: 'Internal note',
-            publicComment: 'false',
+            assigneeId: 'nope',
           },
         },
       },
@@ -294,23 +295,29 @@ describe('internal connector MCP route', () => {
     expect(JSON.parse(body.result.content[0].text)).toEqual({
       ok: false,
       error: 'invalid_arguments',
-      message: 'publicComment must be a boolean',
+      message: 'assigneeId must be a positive integer',
     })
     expect(body.result.isError).toBe(true)
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('rejects public comments when the connector forbids them', async () => {
+  it('rejects direct invocation of a connector-denied action', async () => {
     mockDecryptConfig.mockReturnValueOnce({
       subdomain: 'acme',
       email: 'agent@example.com',
       apiToken: 'token-123',
-      permissions: {
-        allowRead: true,
-        allowCreateTickets: true,
-        allowUpdateTickets: true,
-        allowPublicComments: false,
-        allowInternalComments: true,
+      zendeskActionPermissions: {
+        version: 1,
+        actions: {
+          search_tickets: 'allow',
+          get_ticket: 'allow',
+          list_ticket_comments: 'allow',
+          create_ticket_public: 'deny',
+          create_ticket_internal: 'allow',
+          update_ticket_fields: 'allow',
+          update_ticket_with_public_comment: 'allow',
+          update_ticket_with_internal_note: 'allow',
+        },
       },
     })
 
@@ -323,9 +330,9 @@ describe('internal connector MCP route', () => {
         id: 'tool-call-5',
         method: 'tools/call',
         params: {
-          name: 'update_ticket',
+          name: 'create_ticket_public',
           arguments: {
-            ticketId: 42,
+            subject: 'Need help',
             comment: 'This will notify the requester',
           },
         },
@@ -336,13 +343,13 @@ describe('internal connector MCP route', () => {
     expect(JSON.parse(body.result.content[0].text)).toEqual({
       ok: false,
       error: 'operation_not_allowed',
-      message: 'Public comments are disabled for this Zendesk connector',
+      message: 'This Zendesk action is denied for this connector',
     })
     expect(body.result.isError).toBe(true)
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('rejects update_ticket calls without any ticket changes', async () => {
+  it('rejects field-only update calls without any ticket changes', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
 
@@ -352,7 +359,7 @@ describe('internal connector MCP route', () => {
         id: 'tool-call-4',
         method: 'tools/call',
         params: {
-          name: 'update_ticket',
+          name: 'update_ticket_fields',
           arguments: {
             ticketId: 42,
           },
@@ -364,7 +371,7 @@ describe('internal connector MCP route', () => {
     expect(JSON.parse(body.result.content[0].text)).toEqual({
       ok: false,
       error: 'invalid_arguments',
-      message: 'At least one ticket field or comment must be provided',
+      message: 'At least one ticket field must be provided',
     })
     expect(body.result.isError).toBe(true)
     expect(fetchMock).not.toHaveBeenCalled()

--- a/apps/web/tests/connectors-zendesk-settings-route.test.ts
+++ b/apps/web/tests/connectors-zendesk-settings-route.test.ts
@@ -103,15 +103,27 @@ describe('Zendesk connector settings route', () => {
     const { status, body } = await callGetRoute()
 
     expect(status).toBe(200)
-    expect(body).toEqual({
-      permissions: {
-        allowRead: true,
-        allowCreateTickets: true,
-        allowUpdateTickets: true,
-        allowPublicComments: true,
-        allowInternalComments: true,
+    expect(body.permissions).toEqual({
+      allowRead: true,
+      allowCreateTickets: true,
+      allowUpdateTickets: true,
+      allowPublicComments: true,
+      allowInternalComments: true,
+    })
+    expect(body.zendeskActionPermissions).toEqual({
+      version: 1,
+      actions: {
+        search_tickets: 'allow',
+        get_ticket: 'allow',
+        list_ticket_comments: 'allow',
+        create_ticket_public: 'allow',
+        create_ticket_internal: 'allow',
+        update_ticket_fields: 'allow',
+        update_ticket_with_public_comment: 'allow',
+        update_ticket_with_internal_note: 'allow',
       },
     })
+    expect(JSON.stringify(body)).not.toContain('token-123')
   })
 
   it('updates Zendesk permissions while preserving the stored credentials', async () => {
@@ -122,16 +134,41 @@ describe('Zendesk connector settings route', () => {
       allowPublicComments: false,
       allowInternalComments: true,
     }
+    const canonicalActions = {
+      search_tickets: 'allow',
+      get_ticket: 'allow',
+      list_ticket_comments: 'allow',
+      create_ticket_public: 'deny',
+      create_ticket_internal: 'deny',
+      update_ticket_fields: 'allow',
+      update_ticket_with_public_comment: 'deny',
+      update_ticket_with_internal_note: 'allow',
+    }
 
     const { status, body } = await callPatchRoute({ permissions: nextPermissions })
 
     expect(status).toBe(200)
-    expect(body).toEqual({ permissions: nextPermissions })
+    expect(body.permissions).toEqual({
+      allowRead: true,
+      allowCreateTickets: false,
+      allowUpdateTickets: false,
+      allowPublicComments: false,
+      allowInternalComments: false,
+    })
+    expect(body.zendeskActionPermissions).toEqual({ version: 1, actions: canonicalActions })
     expect(mockEncryptConfig).toHaveBeenCalledWith({
       subdomain: 'acme',
       email: 'agent@example.com',
       apiToken: 'token-123',
-      permissions: nextPermissions,
+      permissions: body.permissions,
+      mcpToolPermissions: {
+        search_tickets: 'allow',
+        get_ticket: 'allow',
+        list_ticket_comments: 'allow',
+        create_ticket: 'deny',
+        update_ticket: 'deny',
+      },
+      zendeskActionPermissions: { version: 1, actions: canonicalActions },
     })
     expect(mockUpdateManyByIdAndUserId).toHaveBeenCalledWith('conn-zendesk-1', 'user-1', {
       config: 'encrypted-updated-config',
@@ -141,7 +178,8 @@ describe('Zendesk connector settings route', () => {
       action: 'connector.zendesk_settings_updated',
       metadata: {
         connectorId: 'conn-zendesk-1',
-        permissions: nextPermissions,
+        permissions: body.permissions,
+        zendeskActionPermissions: { version: 1, actions: canonicalActions },
       },
     })
   })
@@ -161,7 +199,7 @@ describe('Zendesk connector settings route', () => {
     expect(mockEncryptConfig).not.toHaveBeenCalled()
   })
 
-  it('rejects ticket creation without any allowed comment visibility', async () => {
+  it('accepts and normalizes a legacy request without any allowed comment visibility', async () => {
     const { status, body } = await callPatchRoute({
       permissions: {
         allowRead: true,
@@ -172,12 +210,18 @@ describe('Zendesk connector settings route', () => {
       },
     })
 
-    expect(status).toBe(400)
-    expect(body).toEqual({
-      error: 'invalid_permissions',
-      message: 'Ticket creation requires public comments or internal notes to stay enabled.',
+    expect(status).toBe(200)
+    expect(body.zendeskActionPermissions.actions).toEqual({
+      search_tickets: 'allow',
+      get_ticket: 'allow',
+      list_ticket_comments: 'allow',
+      create_ticket_public: 'deny',
+      create_ticket_internal: 'deny',
+      update_ticket_fields: 'allow',
+      update_ticket_with_public_comment: 'deny',
+      update_ticket_with_internal_note: 'deny',
     })
-    expect(mockEncryptConfig).not.toHaveBeenCalled()
+    expect(mockEncryptConfig).toHaveBeenCalled()
   })
 
   it('rejects non-Zendesk connectors', async () => {

--- a/apps/web/tests/connectors.test.ts
+++ b/apps/web/tests/connectors.test.ts
@@ -388,7 +388,7 @@ describe('connectors/validators', () => {
       })
     })
 
-    it('rejects Zendesk ticket creation without any allowed comment visibility', () => {
+    it('accepts Zendesk ticket creation without any allowed comment visibility', () => {
       expect(validateConnectorConfig('zendesk', {
         subdomain: 'acme',
         email: 'agent@example.com',
@@ -401,8 +401,7 @@ describe('connectors/validators', () => {
           allowInternalComments: false,
         },
       })).toEqual({
-        valid: false,
-        message: 'Ticket creation requires public comments or internal notes to stay enabled.',
+        valid: true,
       })
     })
 

--- a/openspec/changes/unify-zendesk-action-permissions/.openspec.yaml
+++ b/openspec/changes/unify-zendesk-action-permissions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/unify-zendesk-action-permissions/design.md
+++ b/openspec/changes/unify-zendesk-action-permissions/design.md
@@ -1,0 +1,166 @@
+## Context
+
+See `proposal.md` for motivation and `specs/zendesk-action-permissions/spec.md` for the behavioral contract.
+
+Zendesk configuration is encrypted JSON containing credentials, five legacy boolean permission flags, and optionally the generic `mcpToolPermissions` map. The embedded Zendesk MCP server currently uses the booleans to filter `tools/list` and to reject disabled operations. Runtime configuration separately expands `mcpToolPermissions` into exact OpenCode tool permissions.
+
+OpenCode 1.18.18 evaluates MCP approval policy by the sanitized MCP tool name. MCP tools provide the permission pattern `*` and no argument metadata, so `create_ticket(publicComment: true)` and `create_ticket(publicComment: false)` cannot receive different policies. The connector also cannot initiate an OpenCode permission request after inspecting arguments; MCP elicitation is not enabled by the pinned OpenCode runtime.
+
+Permission events do carry the session, message, and call identifiers. Arche transforms an OpenCode tool call ID into the corresponding tool-part ID and retains tool inputs in the per-session chat store, which provides a separate path for building an approval preview.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make one canonical action-policy map the source of truth for Zendesk permissions.
+- Preserve one Zendesk API request when an update contains both field changes and a comment.
+- Keep `deny` enforceable at the connector boundary and use OpenCode only for the interactive distinction between `ask` and `allow`.
+- Migrate legacy settings conservatively and support a staged rollout while old and new application versions share connector records.
+- Show a deterministic, connector-specific approval preview before a Zendesk permission response can be submitted.
+
+**Non-Goals:**
+
+- Add argument-aware permissions to OpenCode or a general approval broker inside the connector gateway.
+- Enable MCP elicitation or replace OpenCode's existing `once`, `always`, and `reject` responses.
+- Change generic tool-permission behavior for non-Zendesk connectors.
+- Add Zendesk role, requester, organization, brand, or field-level authorization.
+- Distinguish reading public comments from reading internal notes; listing ticket comments remains one independently configurable read action.
+
+## Decisions
+
+### 1. Store canonical policies separately and derive compatibility projections
+
+Add a versioned `zendeskActionPermissions` object to encrypted Zendesk configuration. Its keys are the complete supported action names and its values use the existing connector permission action type: `deny`, `ask`, or `allow`.
+
+```text
+zendeskActionPermissions
+├── search_tickets
+├── get_ticket
+├── list_ticket_comments
+├── create_ticket_public
+├── create_ticket_internal
+├── update_ticket_fields
+├── update_ticket_with_public_comment
+└── update_ticket_with_internal_note
+```
+
+This object is the only authoritative state after migration. The legacy boolean `permissions` object and legacy entries in `mcpToolPermissions` remain temporarily as derived compatibility projections, not independently editable policy. Keeping a distinct key avoids changing the type of an existing field while old and new web versions can read the same connector record.
+
+The Zendesk settings API accepts and returns the canonical map. During the compatibility release it also continues accepting the old boolean request shape, normalizing it into canonical actions. Saving canonical policies dual-writes a conservative legacy projection:
+
+- Existing read tool policies project one-to-one.
+- Legacy `create_ticket` receives the most restrictive public/internal create policy.
+- Legacy `update_ticket` receives the most restrictive field/public/internal update policy.
+- A legacy boolean gate remains enabled only when none of the actions it covers is denied; the projected old tool policy handles `ask` and may over-prompt a less restrictive variant.
+
+This guarantees an older runtime can be more restrictive, but cannot bypass a canonical `ask` or `deny`. A later contract change may remove the projections after mixed-version and rollback support is no longer required.
+
+Alternative considered: make `mcpToolPermissions` itself canonical. This minimizes storage changes but leaves legacy and new tool names mixed in one generic map, makes connector-side validation ambiguous, and lets the generic settings endpoint become a second representation. A connector-specific versioned map provides a clear migration boundary.
+
+Alternative considered: change the five existing booleans directly to action strings. This is rejected because old code requires booleans and would treat the shared record as invalid during a blue-green deployment.
+
+### 2. Normalize every read path with a restrictive merge
+
+A single Zendesk normalization function produces a complete canonical map for settings reads, MCP inventory, tool execution, and managed runtime generation. It uses the canonical map when present and otherwise migrates legacy values in memory.
+
+For a legacy record, each replacement action combines all applicable values and chooses the most restrictive result using:
+
+```text
+allow < ask < deny
+```
+
+The mappings are:
+
+```text
+search_tickets                         ← allowRead + search_tickets policy
+get_ticket                             ← allowRead + get_ticket policy
+list_ticket_comments                   ← allowRead + list_ticket_comments policy
+create_ticket_public                   ← allowCreateTickets + allowPublicComments + create_ticket policy
+create_ticket_internal                 ← allowCreateTickets + allowInternalComments + create_ticket policy
+update_ticket_fields                   ← allowUpdateTickets + update_ticket policy
+update_ticket_with_public_comment      ← allowUpdateTickets + allowPublicComments + update_ticket policy
+update_ticket_with_internal_note       ← allowUpdateTickets + allowInternalComments + update_ticket policy
+```
+
+A false boolean contributes `deny`; a true or missing boolean contributes `allow`; a missing tool policy contributes `allow`. A complete record with no permission fields therefore retains the current full-access default.
+
+Normalization occurs before validation and does not require the user to open settings. A successful canonical save records the versioned map and refreshes its compatibility projections atomically with the encrypted config update.
+
+Alternative considered: migrate only when settings are saved. This is rejected because workspaces and gateway requests may use a connector before its settings are opened, which could temporarily discard an existing restriction.
+
+### 3. Replace composite writes with visibility-specific tools
+
+Keep the three existing read tool names. Replace `create_ticket` and `update_ticket` in the new inventory with:
+
+- `create_ticket_public`
+- `create_ticket_internal`
+- `update_ticket_fields`
+- `update_ticket_with_public_comment`
+- `update_ticket_with_internal_note`
+
+The creation schemas omit `publicComment`; visibility comes from the tool identity. `update_ticket_fields` omits both `comment` and `publicComment`. Each visibility-specific update requires `comment`, omits `publicComment`, and retains optional subject, priority, status, type, and assignee fields so a comment and field changes remain one Zendesk update.
+
+Tool definitions carry their canonical action key. `tools/list` filters out `deny`; execution resolves the definition and performs the same deny check before argument validation or network I/O. `ask` and `allow` are both executable at this layer because only the managed OpenCode runtime can conduct the approval exchange.
+
+Alternative considered: retain one tool and instruct the model to ask the user before public communication. Prompt instructions are not an authorization boundary and can be skipped, so this is rejected.
+
+Alternative considered: separate comments into `add_public_comment` and `add_internal_note` tools that cannot update fields. This is simpler but changes the current atomic update behavior and can leave a ticket partially changed if a second request fails.
+
+### 4. Derive managed runtime permissions from canonical Zendesk policies
+
+The MCP configuration builder uses a connector-type policy adapter. For Zendesk it receives the normalized canonical map; other connectors continue reading generic `mcpToolPermissions` unchanged. Agent connector-tool remapping then expands every canonical action into the exact sanitized MCP tool name and OpenCode action.
+
+Denied Zendesk actions are still included in the generated exact policy map as `deny`, even though the MCP server omits them. This preserves defense in depth if tool discovery is stale. `ask` and `allow` map directly to OpenCode. Because each public/internal variant has a different tool name, OpenCode's session-wide `always` response remains scoped to that atomic action.
+
+The generic tool-permissions UI is not rendered inside Zendesk settings. During the transition, the generic tool-permissions endpoint either delegates Zendesk updates to the canonical adapter or rejects Zendesk writes with an explicit instruction to use the Zendesk settings endpoint; it must never persist an independent effective Zendesk policy.
+
+Alternative considered: implement approvals in the connector gateway. That requires durable suspended requests, session routing, timeout handling, and a second approval event protocol, duplicating behavior OpenCode already provides.
+
+### 5. Correlate permission requests with tool parts for previews
+
+Keep OpenCode permission transport unchanged. Enrich a visible Zendesk permission in Arche by joining:
+
+```text
+permission.sessionId  → ChatStore.messages[sessionId]
+permission.messageId  → assistant message
+permission.callId     → tool part id
+```
+
+The transformed tool part contains the tool name and validated model-produced input. A Zendesk-specific preview formatter whitelists fields from the known action schema and produces:
+
+- connector display name and human-readable action;
+- public or internal visibility from the atomic tool name;
+- ticket ID for updates;
+- subject and comment body when present;
+- optional status, priority, type, assignee, and tags when present.
+
+The formatter does not render arbitrary metadata or connector configuration. React text rendering remains escaped, long comments are contained in a scrollable/pre-wrapped region, and preview values are not added to audit metadata or logs.
+
+Permission and tool-part events can arrive in either order, so preview selection is reactive. Permission hydration also hydrates the referenced session messages, including delegated child sessions. For a recognized Zendesk action, response controls remain disabled while its referenced tool input is unavailable; the UI shows a loading or retrieval error rather than allowing a blind approval. Generic permission cards retain their existing fallback.
+
+Alternative considered: use permission-event metadata. OpenCode emits empty metadata for MCP tools, and changing the embedded MCP server cannot populate the pre-execution OpenCode request.
+
+### 6. Use one domain-oriented Zendesk editor
+
+Replace boolean switches and the nested generic tool section with segmented `Deny`/`Ask`/`Allow` controls grouped as ticket reading, ticket updates, public communication, and internal communication. The editor loads and saves the complete canonical map through the Zendesk settings route.
+
+There is no longer a cross-field rule requiring ticket creation plus one enabled comment type: public and internal creation are independently valid actions. Saving uses the existing authenticated, CSRF-protected, ownership-checked, encrypted update and audit path, adds the canonical policy values to the existing Zendesk-settings audit event, and emits the workspace-config-changed signal used by generic tool policies.
+
+## Risks / Trade-offs
+
+- [More MCP tools increase prompt size and tool-choice surface] → Keep descriptions concise, encode visibility in names, and test that each action produces the intended payload.
+- [An older runtime cannot express different policies for variants of one composite tool] → Dual-write the most restrictive aggregate legacy tool policy, accepting temporary over-restriction rather than under-enforcement.
+- [`ask` is not enforceable for a client that bypasses managed OpenCode and directly calls the MCP gateway] → Keep `deny` connector-enforced, document managed-workspace approval as the trust boundary, and do not present `ask` as a gateway-level guarantee.
+- [Permission events may precede or outlive their tool part] → Correlate by stable IDs, hydrate referenced sessions, disable Zendesk approval responses until the preview resolves, and retain explicit retry/error UI.
+- [Session-wide approval can authorize later calls] → Atomic tool names limit the grant to one visibility and operation class; keep the existing button copy explicit.
+- [Canonical and compatibility fields can drift] → Centralize normalization and projection, update both in one encrypted-config write, and never read compatibility fields once a valid canonical version is present except for rollback projection checks.
+- [Retiring composite names can interrupt an in-flight workspace] → Treat runtime regeneration/restart as the activation boundary and do not mutate already-running OpenCode config in place.
+
+## Migration Plan
+
+1. **Expand release:** add canonical parsing, restrictive in-memory migration, dual-write compatibility projections, settings API support for both request shapes, and tests. Keep the existing UI and composite tools active during this release so every running web version understands the new config key before it is written by users.
+2. **Activation release:** switch the Zendesk UI to canonical action policies, publish the atomic tool inventory, derive runtime permissions from the canonical adapter, add approval previews, and stop advertising composite tools in newly generated runtime configurations.
+3. Regenerate or restart affected workspace runtimes through the existing config-change lifecycle; already-running runtimes continue with their previous tool inventory until that boundary.
+4. Retain legacy booleans, composite policy projections, and legacy-input parsing for at least one rollback window. Remove them only in a separately reviewed contract change after no deployed version depends on them.
+
+Rollback from the activation release restores the previous UI and composite tools. The compatibility projection remains readable by the older version and is intentionally at least as restrictive as the canonical policies, so rollback may temporarily hide or over-prompt an action but SHALL NOT silently grant broader access. Connector credentials and the canonical map remain intact.

--- a/openspec/changes/unify-zendesk-action-permissions/proposal.md
+++ b/openspec/changes/unify-zendesk-action-permissions/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Zendesk currently has two overlapping permission models: boolean ticket/comment limits enforced by the connector and `deny`/`ask`/`allow` policies applied to MCP tools. This prevents users from requiring approval specifically for public comments or internal notes and makes the settings difficult to reason about.
+
+## What Changes
+
+- Replace Zendesk's boolean permission experience with one `deny`/`ask`/`allow` policy model covering ticket reads, ticket-field updates, public communication, and internal communication.
+- Model public and internal Zendesk writes as distinct atomic MCP actions so OpenCode can apply a different policy to each action.
+- Enforce `deny` as a connector-side hard boundary while routing `ask` through OpenCode's existing approval flow and executing `allow` without prompting.
+- Present Zendesk permissions through one domain-oriented settings surface instead of independent connector-limit and generic tool-policy controls that can conflict.
+- Show the proposed Zendesk operation and relevant arguments when approval is required, so users can review the ticket, visibility, content, and field changes before responding.
+- Migrate existing boolean permissions and stored Zendesk tool policies to equivalent action policies, preserving the effective restriction whenever old settings conflict.
+- **BREAKING**: Replace the composite `create_ticket` and `update_ticket` MCP write tools with visibility-specific and field-update actions; stored policies are migrated to the new tool names.
+
+## Capabilities
+
+### New Capabilities
+
+- `zendesk-action-permissions`: Defines Zendesk's action-level `deny`/`ask`/`allow` policies, approval behavior and previews, atomic MCP operations, and compatibility migration.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Zendesk connector configuration types, parsing, validation, defaults, and encrypted-config migration.
+- Zendesk MCP tool inventory, schemas, execution guards, and tests.
+- Connector tool-policy storage and runtime OpenCode permission generation.
+- Zendesk settings UI, approval-card/tool-call presentation, settings APIs, and audit metadata.
+- Existing workspaces require regenerated runtime configuration to receive the migrated tool names and policies; no new external dependency is expected.

--- a/openspec/changes/unify-zendesk-action-permissions/specs/zendesk-action-permissions/spec.md
+++ b/openspec/changes/unify-zendesk-action-permissions/specs/zendesk-action-permissions/spec.md
@@ -1,0 +1,125 @@
+## Purpose
+
+Defines a single action-level permission model for Zendesk so ticket access, public communication, and internal communication can each be denied, approved interactively, or allowed automatically.
+
+## ADDED Requirements
+
+### Requirement: Configurable Zendesk action policies
+The system SHALL assign exactly one `deny`, `ask`, or `allow` policy to each of the following Zendesk actions: search tickets, read ticket details, list ticket comments, create a ticket with a public comment, create a ticket with an internal note, update ticket fields without a comment, update a ticket with a public comment, and update a ticket with an internal note.
+
+#### Scenario: Configure different public and internal policies
+- **WHEN** a user sets public ticket comments to `ask` and internal ticket notes to `allow`
+- **THEN** the system stores and applies those policies independently to the corresponding Zendesk actions
+
+#### Scenario: Configure every ticket-access action
+- **WHEN** a user selects a policy for a Zendesk read, create, or update action
+- **THEN** the selected action accepts `deny`, `ask`, and `allow` with the same meaning used by connector tool permissions
+
+### Requirement: Atomic Zendesk write actions
+The system SHALL expose visibility-specific Zendesk MCP write actions named `create_ticket_public`, `create_ticket_internal`, `update_ticket_fields`, `update_ticket_with_public_comment`, and `update_ticket_with_internal_note`. A visibility-specific update SHALL require a comment and MAY include ticket-field changes in the same Zendesk request, while `update_ticket_fields` SHALL NOT accept a comment.
+
+#### Scenario: Create a public ticket
+- **WHEN** an agent needs to create a ticket whose initial comment is public
+- **THEN** it invokes `create_ticket_public`, and the resulting Zendesk request marks the initial comment as public
+
+#### Scenario: Create a ticket with an internal note
+- **WHEN** an agent needs to create a ticket whose initial comment is private to Zendesk agents
+- **THEN** it invokes `create_ticket_internal`, and the resulting Zendesk request marks the initial comment as internal
+
+#### Scenario: Update fields and add a comment atomically
+- **WHEN** an agent invokes a visibility-specific update with a comment and ticket-field changes
+- **THEN** the system sends the comment and field changes in one Zendesk ticket update request with the visibility declared by the action name
+
+#### Scenario: Update fields without communication
+- **WHEN** an agent invokes `update_ticket_fields`
+- **THEN** the tool updates only supplied ticket fields and rejects comment input
+
+### Requirement: Denied actions are hard connector boundaries
+The system SHALL omit an action with a `deny` policy from the Zendesk MCP tool inventory and SHALL reject a direct invocation of that action before sending any request to Zendesk.
+
+#### Scenario: Denied action is not advertised
+- **WHEN** a client lists tools for a Zendesk connector with a denied action
+- **THEN** the denied action is absent while non-denied actions remain available
+
+#### Scenario: Denied action is invoked directly
+- **WHEN** a client directly invokes a denied Zendesk action despite its absence from the inventory
+- **THEN** the connector returns an explicit `operation_not_allowed` error and sends no Zendesk request
+
+### Requirement: Managed workspaces honor ask and allow
+For managed workspace execution, the system SHALL translate each non-denied Zendesk action policy into the matching OpenCode permission: `ask` SHALL pause the action for a user response, and `allow` SHALL execute it without a permission prompt.
+
+#### Scenario: Allow action executes directly
+- **WHEN** an agent invokes a Zendesk action configured as `allow`
+- **THEN** the managed workspace executes the action without creating a permission request
+
+#### Scenario: Ask action waits for approval
+- **WHEN** an agent invokes a Zendesk action configured as `ask`
+- **THEN** the managed workspace creates a pending approval and sends no Zendesk request until the user approves the action
+
+#### Scenario: User rejects an ask action
+- **WHEN** the user rejects a pending Zendesk action
+- **THEN** the action does not execute and no Zendesk request is sent
+
+#### Scenario: User allows an action once
+- **WHEN** the user selects `Allow once` for a pending Zendesk action
+- **THEN** only that invocation is approved by the response
+
+#### Scenario: User allows an action for the session
+- **WHEN** the user selects `Allow for this session` for a pending Zendesk action
+- **THEN** later invocations of that same atomic action in the current OpenCode session may execute without another prompt while differently named Zendesk actions retain their own policies
+
+### Requirement: Zendesk approval previews
+The system SHALL present a pending Zendesk approval with the connector identity, human-readable action, and the proposed operation arguments available for review. The preview SHALL identify public versus internal visibility and SHALL show the subject, ticket identifier, comment body, and changed ticket fields when those values apply to the action.
+
+#### Scenario: Review a pending public comment
+- **WHEN** a public-comment action requires approval
+- **THEN** the approval identifies the action as public and displays the target ticket and proposed comment before the user responds
+
+#### Scenario: Review a pending ticket creation
+- **WHEN** a ticket-creation action requires approval
+- **THEN** the approval identifies the initial comment visibility and displays the proposed subject, comment, and optional ticket fields before the user responds
+
+### Requirement: Single Zendesk permission settings surface
+The system SHALL provide one domain-oriented Zendesk settings surface for the action policies and SHALL NOT present a second independently editable generic tool-permission policy for the same Zendesk connector.
+
+#### Scenario: Edit Zendesk permissions
+- **WHEN** a user opens Zendesk connector settings
+- **THEN** every configurable Zendesk action is shown with a `Deny`, `Ask`, and `Allow` selector reflecting the single persisted policy state
+
+#### Scenario: Save Zendesk permissions
+- **WHEN** a user saves valid Zendesk action policies
+- **THEN** the settings API persists the complete policy state, records the sensitive configuration change in the audit log, and signals that workspace runtime configuration must be refreshed
+
+### Requirement: Legacy Zendesk permissions migrate without becoming less restrictive
+The system SHALL normalize legacy Zendesk boolean permissions and legacy `create_ticket` or `update_ticket` tool policies into the new action-policy model. For each new action, the migrated policy SHALL be the most restrictive applicable legacy value using `deny` as more restrictive than `ask`, and `ask` as more restrictive than `allow`.
+
+#### Scenario: Migrate disabled public comments
+- **WHEN** a legacy connector allows ticket updates but disables public comments
+- **THEN** its public create and public update actions migrate to `deny` regardless of a less restrictive legacy create or update tool policy
+
+#### Scenario: Migrate an ask update policy
+- **WHEN** a legacy connector allows ticket updates and internal comments and configures `update_ticket` as `ask`
+- **THEN** `update_ticket_fields` and `update_ticket_with_internal_note` migrate to `ask`
+
+#### Scenario: Migrate a denied update policy
+- **WHEN** a legacy connector allows ticket updates but configures `update_ticket` as `deny`
+- **THEN** every new update action migrates to `deny`
+
+#### Scenario: Load a connector without explicit legacy permissions
+- **WHEN** an existing or newly created Zendesk connector has no explicit permission configuration
+- **THEN** all Zendesk actions default to `allow` to preserve the existing full-access default
+
+#### Scenario: Use migrated settings before an explicit save
+- **WHEN** a legacy Zendesk connector is loaded for tool inventory or managed workspace configuration before the user opens or saves its settings
+- **THEN** the system applies the normalized action policies in memory so legacy restrictions remain effective
+
+### Requirement: Composite Zendesk write tools are retired
+The system SHALL stop advertising the legacy `create_ticket` and `update_ticket` MCP tools after action-policy migration and SHALL migrate their stored policy intent to the replacement actions.
+
+#### Scenario: List tools after migration
+- **WHEN** a migrated Zendesk connector lists its MCP tools
+- **THEN** `create_ticket` and `update_ticket` are absent and their applicable atomic replacement actions are present according to policy
+
+#### Scenario: Regenerate managed workspace configuration
+- **WHEN** runtime configuration is regenerated for a workspace using a migrated Zendesk connector
+- **THEN** permission entries target the replacement action names and no generated permission entry targets the retired composite names

--- a/openspec/changes/unify-zendesk-action-permissions/tasks.md
+++ b/openspec/changes/unify-zendesk-action-permissions/tasks.md
@@ -1,0 +1,48 @@
+## 1. Compatibility Data Model
+
+- [ ] 1.1 Run `pnpm test` from `apps/web/` before implementation and record whether the existing suite passes as the baseline
+- [ ] 1.2 Add the complete versioned Zendesk action-policy type, keys, default-allow value, and strict parser, and verify unit tests accept only complete `deny`/`ask`/`allow` maps with known actions
+- [ ] 1.3 Implement restrictive in-memory normalization from legacy booleans and stored read/create/update tool policies, and verify table-driven tests cover every replacement action, missing settings, and `allow < ask < deny` conflict resolution
+- [ ] 1.4 Implement the conservative legacy boolean and composite-tool policy projection from canonical actions, and verify tests prove an older runtime is never granted broader access than the canonical map
+- [ ] 1.5 Update Zendesk config parsing and validation to expose canonical policies while preserving credentials and legacy compatibility fields, and verify existing connector validation tests plus canonical and legacy fixtures pass
+- [ ] 1.6 Extend the Zendesk settings API to read canonical policies, accept both legacy and canonical request shapes during expansion, dual-write the compatibility projection in one encrypted update, and verify route tests cover authentication, validation, audit metadata, and round trips for both shapes
+- [ ] 1.7 Prevent the generic tool-permissions endpoint from creating independent Zendesk policy state by delegating to the canonical adapter or returning an explicit unsupported-write response, and verify route tests cannot create a conflicting effective Zendesk policy
+
+## 2. Atomic Zendesk MCP Actions
+
+- [ ] 2.1 Define `create_ticket_public`, `create_ticket_internal`, `update_ticket_fields`, `update_ticket_with_public_comment`, and `update_ticket_with_internal_note` schemas, and verify tool-inventory tests assert required fields, omitted `publicComment`, and the absence of legacy composite tools in the activated inventory
+- [ ] 2.2 Implement public and internal creation payloads whose visibility comes from the tool identity, and verify unit tests assert the exact Zendesk request body for each action
+- [ ] 2.3 Implement field-only and visibility-specific update payloads while preserving one-request field-plus-comment updates, and verify tests cover comment rejection for `update_ticket_fields`, required comments for visibility-specific tools, optional fields, and empty-update errors
+- [ ] 2.4 Filter denied actions from `tools/list` and reject direct denied invocations before network I/O, and verify MCP handler and tool tests cover `deny`, `ask`, and `allow` inventory/execution behavior
+- [ ] 2.5 Update connector MCP route integration fixtures for the atomic actions, and verify `pnpm test -- tests/connectors-mcp-route.test.ts src/lib/connectors/mcp/__tests__/zendesk-handler.test.ts` passes from `apps/web/`
+
+## 3. Managed Runtime Policy Generation
+
+- [ ] 3.1 Add a connector-type policy adapter that supplies normalized canonical Zendesk actions while leaving other connectors on generic `mcpToolPermissions`, and verify MCP-config unit tests cover legacy normalization and canonical precedence
+- [ ] 3.2 Expand canonical Zendesk actions into exact sanitized OpenCode permissions for every agent with the connector enabled, and verify transform tests map `deny`, `ask`, and `allow` independently for public, internal, field-update, and read actions
+- [ ] 3.3 Keep explicit `deny` entries in generated runtime policy while excluding retired composite names, and verify runtime artifact and desktop workspace-host tests inspect the resulting tool and permission maps
+- [ ] 3.4 Verify a session-level approval for one atomic Zendesk action does not authorize differently named actions using permission-flow tests against the generated configuration
+
+## 4. Unified Zendesk Settings Experience
+
+- [ ] 4.1 Replace boolean switches with grouped three-way `Deny`/`Ask`/`Allow` selectors backed by the complete canonical action map, and verify component tests cover loading, editing, disabled states, and labels for all eight actions
+- [ ] 4.2 Remove the independently editable generic tool-permissions section from Zendesk settings and remove the old create/comment cross-field constraint, and verify the dialog accepts all-denied creation actions without showing duplicate policy controls
+- [ ] 4.3 Save the full canonical map through the Zendesk settings API, emit the workspace-config-changed signal after success, and verify UI tests cover success, validation failure, network failure, and unchanged credential preservation
+- [ ] 4.4 Update Zendesk settings response/request types and connector error copy without changing other connector dialogs, and verify the connector component and route test suites pass
+
+## 5. Zendesk Approval Previews
+
+- [ ] 5.1 Correlate pending permissions with per-session messages by session, message, and call IDs, and verify selector/reducer tests handle permission-first and tool-part-first event ordering
+- [ ] 5.2 Hydrate messages referenced by pending permissions, including delegated child sessions, and verify reconnect tests resolve previews without grafting child permission cards into the parent transcript
+- [ ] 5.3 Add a Zendesk preview formatter that recognizes atomic tool names and whitelists connector name, visibility, ticket ID, subject, comment, and supported changed fields, and verify unit tests exclude unknown metadata and credentials
+- [ ] 5.4 Render the formatted preview in the approval card with escaped, contained comment text and disable responses while required Zendesk input is unresolved, and verify component tests cover loading, retrieval failure, public/internal labels, creation, and update previews
+- [ ] 5.5 Exercise `Allow once`, `Allow for this session`, and `Reject` from a previewed Zendesk permission, and verify interaction tests send the existing response values and never submit while the preview is unavailable
+
+## 6. Rollout and Verification
+
+- [ ] 6.1 Prepare the compatibility data-model and API work as an independently deployable expand release, and verify legacy UI requests, legacy connector records, and rollback projections pass before enabling the activation work
+- [ ] 6.2 After the expand release is available across the fleet, prepare the atomic tools, runtime mapping, unified UI, and previews as the activation release, and verify a regenerated workspace advertises only policy-eligible atomic Zendesk writes
+- [ ] 6.3 Run `pnpm test` from `apps/web/` and verify the complete Vitest suite passes
+- [ ] 6.4 Run `pnpm lint` and `pnpm build` from `apps/web/` and verify both commands pass
+- [ ] 6.5 Run `bash scripts/check-podman-images.sh` from the repository root and treat any image-build failure as blocking
+- [ ] 6.6 Verify rollback documentation and fixtures retain legacy booleans, composite policy projections, and legacy-input parsing for the agreed rollback window without re-advertising composite tools in activated runtime configuration

--- a/openspec/changes/unify-zendesk-action-permissions/tasks.md
+++ b/openspec/changes/unify-zendesk-action-permissions/tasks.md
@@ -1,48 +1,48 @@
 ## 1. Compatibility Data Model
 
-- [ ] 1.1 Run `pnpm test` from `apps/web/` before implementation and record whether the existing suite passes as the baseline
-- [ ] 1.2 Add the complete versioned Zendesk action-policy type, keys, default-allow value, and strict parser, and verify unit tests accept only complete `deny`/`ask`/`allow` maps with known actions
-- [ ] 1.3 Implement restrictive in-memory normalization from legacy booleans and stored read/create/update tool policies, and verify table-driven tests cover every replacement action, missing settings, and `allow < ask < deny` conflict resolution
-- [ ] 1.4 Implement the conservative legacy boolean and composite-tool policy projection from canonical actions, and verify tests prove an older runtime is never granted broader access than the canonical map
-- [ ] 1.5 Update Zendesk config parsing and validation to expose canonical policies while preserving credentials and legacy compatibility fields, and verify existing connector validation tests plus canonical and legacy fixtures pass
-- [ ] 1.6 Extend the Zendesk settings API to read canonical policies, accept both legacy and canonical request shapes during expansion, dual-write the compatibility projection in one encrypted update, and verify route tests cover authentication, validation, audit metadata, and round trips for both shapes
-- [ ] 1.7 Prevent the generic tool-permissions endpoint from creating independent Zendesk policy state by delegating to the canonical adapter or returning an explicit unsupported-write response, and verify route tests cannot create a conflicting effective Zendesk policy
+- [x] 1.1 Run `pnpm test` from `apps/web/` before implementation and record whether the existing suite passes as the baseline
+- [x] 1.2 Add the complete versioned Zendesk action-policy type, keys, default-allow value, and strict parser, and verify unit tests accept only complete `deny`/`ask`/`allow` maps with known actions
+- [x] 1.3 Implement restrictive in-memory normalization from legacy booleans and stored read/create/update tool policies, and verify table-driven tests cover every replacement action, missing settings, and `allow < ask < deny` conflict resolution
+- [x] 1.4 Implement the conservative legacy boolean and composite-tool policy projection from canonical actions, and verify tests prove an older runtime is never granted broader access than the canonical map
+- [x] 1.5 Update Zendesk config parsing and validation to expose canonical policies while preserving credentials and legacy compatibility fields, and verify existing connector validation tests plus canonical and legacy fixtures pass
+- [x] 1.6 Extend the Zendesk settings API to read canonical policies, accept both legacy and canonical request shapes during expansion, dual-write the compatibility projection in one encrypted update, and verify route tests cover authentication, validation, audit metadata, and round trips for both shapes
+- [x] 1.7 Prevent the generic tool-permissions endpoint from creating independent Zendesk policy state by delegating to the canonical adapter or returning an explicit unsupported-write response, and verify route tests cannot create a conflicting effective Zendesk policy
 
 ## 2. Atomic Zendesk MCP Actions
 
-- [ ] 2.1 Define `create_ticket_public`, `create_ticket_internal`, `update_ticket_fields`, `update_ticket_with_public_comment`, and `update_ticket_with_internal_note` schemas, and verify tool-inventory tests assert required fields, omitted `publicComment`, and the absence of legacy composite tools in the activated inventory
-- [ ] 2.2 Implement public and internal creation payloads whose visibility comes from the tool identity, and verify unit tests assert the exact Zendesk request body for each action
-- [ ] 2.3 Implement field-only and visibility-specific update payloads while preserving one-request field-plus-comment updates, and verify tests cover comment rejection for `update_ticket_fields`, required comments for visibility-specific tools, optional fields, and empty-update errors
-- [ ] 2.4 Filter denied actions from `tools/list` and reject direct denied invocations before network I/O, and verify MCP handler and tool tests cover `deny`, `ask`, and `allow` inventory/execution behavior
-- [ ] 2.5 Update connector MCP route integration fixtures for the atomic actions, and verify `pnpm test -- tests/connectors-mcp-route.test.ts src/lib/connectors/mcp/__tests__/zendesk-handler.test.ts` passes from `apps/web/`
+- [x] 2.1 Define `create_ticket_public`, `create_ticket_internal`, `update_ticket_fields`, `update_ticket_with_public_comment`, and `update_ticket_with_internal_note` schemas, and verify tool-inventory tests assert required fields, omitted `publicComment`, and the absence of legacy composite tools in the activated inventory
+- [x] 2.2 Implement public and internal creation payloads whose visibility comes from the tool identity, and verify unit tests assert the exact Zendesk request body for each action
+- [x] 2.3 Implement field-only and visibility-specific update payloads while preserving one-request field-plus-comment updates, and verify tests cover comment rejection for `update_ticket_fields`, required comments for visibility-specific tools, optional fields, and empty-update errors
+- [x] 2.4 Filter denied actions from `tools/list` and reject direct denied invocations before network I/O, and verify MCP handler and tool tests cover `deny`, `ask`, and `allow` inventory/execution behavior
+- [x] 2.5 Update connector MCP route integration fixtures for the atomic actions, and verify `pnpm test -- tests/connectors-mcp-route.test.ts src/lib/connectors/mcp/__tests__/zendesk-handler.test.ts` passes from `apps/web/`
 
 ## 3. Managed Runtime Policy Generation
 
-- [ ] 3.1 Add a connector-type policy adapter that supplies normalized canonical Zendesk actions while leaving other connectors on generic `mcpToolPermissions`, and verify MCP-config unit tests cover legacy normalization and canonical precedence
-- [ ] 3.2 Expand canonical Zendesk actions into exact sanitized OpenCode permissions for every agent with the connector enabled, and verify transform tests map `deny`, `ask`, and `allow` independently for public, internal, field-update, and read actions
-- [ ] 3.3 Keep explicit `deny` entries in generated runtime policy while excluding retired composite names, and verify runtime artifact and desktop workspace-host tests inspect the resulting tool and permission maps
-- [ ] 3.4 Verify a session-level approval for one atomic Zendesk action does not authorize differently named actions using permission-flow tests against the generated configuration
+- [x] 3.1 Add a connector-type policy adapter that supplies normalized canonical Zendesk actions while leaving other connectors on generic `mcpToolPermissions`, and verify MCP-config unit tests cover legacy normalization and canonical precedence
+- [x] 3.2 Expand canonical Zendesk actions into exact sanitized OpenCode permissions for every agent with the connector enabled, and verify transform tests map `deny`, `ask`, and `allow` independently for public, internal, field-update, and read actions
+- [x] 3.3 Keep explicit `deny` entries in generated runtime policy while excluding retired composite names, and verify runtime artifact and desktop workspace-host tests inspect the resulting tool and permission maps
+- [x] 3.4 Verify a session-level approval for one atomic Zendesk action does not authorize differently named actions using permission-flow tests against the generated configuration
 
 ## 4. Unified Zendesk Settings Experience
 
-- [ ] 4.1 Replace boolean switches with grouped three-way `Deny`/`Ask`/`Allow` selectors backed by the complete canonical action map, and verify component tests cover loading, editing, disabled states, and labels for all eight actions
-- [ ] 4.2 Remove the independently editable generic tool-permissions section from Zendesk settings and remove the old create/comment cross-field constraint, and verify the dialog accepts all-denied creation actions without showing duplicate policy controls
-- [ ] 4.3 Save the full canonical map through the Zendesk settings API, emit the workspace-config-changed signal after success, and verify UI tests cover success, validation failure, network failure, and unchanged credential preservation
-- [ ] 4.4 Update Zendesk settings response/request types and connector error copy without changing other connector dialogs, and verify the connector component and route test suites pass
+- [x] 4.1 Replace boolean switches with grouped three-way `Deny`/`Ask`/`Allow` selectors backed by the complete canonical action map, and verify component tests cover loading, editing, disabled states, and labels for all eight actions
+- [x] 4.2 Remove the independently editable generic tool-permissions section from Zendesk settings and remove the old create/comment cross-field constraint, and verify the dialog accepts all-denied creation actions without showing duplicate policy controls
+- [x] 4.3 Save the full canonical map through the Zendesk settings API, emit the workspace-config-changed signal after success, and verify UI tests cover success, validation failure, network failure, and unchanged credential preservation
+- [x] 4.4 Update Zendesk settings response/request types and connector error copy without changing other connector dialogs, and verify the connector component and route test suites pass
 
 ## 5. Zendesk Approval Previews
 
-- [ ] 5.1 Correlate pending permissions with per-session messages by session, message, and call IDs, and verify selector/reducer tests handle permission-first and tool-part-first event ordering
-- [ ] 5.2 Hydrate messages referenced by pending permissions, including delegated child sessions, and verify reconnect tests resolve previews without grafting child permission cards into the parent transcript
-- [ ] 5.3 Add a Zendesk preview formatter that recognizes atomic tool names and whitelists connector name, visibility, ticket ID, subject, comment, and supported changed fields, and verify unit tests exclude unknown metadata and credentials
-- [ ] 5.4 Render the formatted preview in the approval card with escaped, contained comment text and disable responses while required Zendesk input is unresolved, and verify component tests cover loading, retrieval failure, public/internal labels, creation, and update previews
-- [ ] 5.5 Exercise `Allow once`, `Allow for this session`, and `Reject` from a previewed Zendesk permission, and verify interaction tests send the existing response values and never submit while the preview is unavailable
+- [x] 5.1 Correlate pending permissions with per-session messages by session, message, and call IDs, and verify selector/reducer tests handle permission-first and tool-part-first event ordering
+- [x] 5.2 Hydrate messages referenced by pending permissions, including delegated child sessions, and verify reconnect tests resolve previews without grafting child permission cards into the parent transcript
+- [x] 5.3 Add a Zendesk preview formatter that recognizes atomic tool names and whitelists connector name, visibility, ticket ID, subject, comment, and supported changed fields, and verify unit tests exclude unknown metadata and credentials
+- [x] 5.4 Render the formatted preview in the approval card with escaped, contained comment text and disable responses while required Zendesk input is unresolved, and verify component tests cover loading, retrieval failure, public/internal labels, creation, and update previews
+- [x] 5.5 Exercise `Allow once`, `Allow for this session`, and `Reject` from a previewed Zendesk permission, and verify interaction tests send the existing response values and never submit while the preview is unavailable
 
 ## 6. Rollout and Verification
 
-- [ ] 6.1 Prepare the compatibility data-model and API work as an independently deployable expand release, and verify legacy UI requests, legacy connector records, and rollback projections pass before enabling the activation work
-- [ ] 6.2 After the expand release is available across the fleet, prepare the atomic tools, runtime mapping, unified UI, and previews as the activation release, and verify a regenerated workspace advertises only policy-eligible atomic Zendesk writes
-- [ ] 6.3 Run `pnpm test` from `apps/web/` and verify the complete Vitest suite passes
-- [ ] 6.4 Run `pnpm lint` and `pnpm build` from `apps/web/` and verify both commands pass
-- [ ] 6.5 Run `bash scripts/check-podman-images.sh` from the repository root and treat any image-build failure as blocking
-- [ ] 6.6 Verify rollback documentation and fixtures retain legacy booleans, composite policy projections, and legacy-input parsing for the agreed rollback window without re-advertising composite tools in activated runtime configuration
+- [x] 6.1 Prepare the compatibility data-model and API work as an independently deployable expand release, and verify legacy UI requests, legacy connector records, and rollback projections pass before enabling the activation work
+- [x] 6.2 After the expand release is available across the fleet, prepare the atomic tools, runtime mapping, unified UI, and previews as the activation release, and verify a regenerated workspace advertises only policy-eligible atomic Zendesk writes
+- [x] 6.3 Run `pnpm test` from `apps/web/` and verify the complete Vitest suite passes
+- [x] 6.4 Run `pnpm lint` and `pnpm build` from `apps/web/` and verify both commands pass
+- [x] 6.5 Run `bash scripts/check-podman-images.sh` from the repository root and treat any image-build failure as blocking
+- [x] 6.6 Verify rollback documentation and fixtures retain legacy booleans, composite policy projections, and legacy-input parsing for the agreed rollback window without re-advertising composite tools in activated runtime configuration


### PR DESCRIPTION
- add canonical deny, ask, and allow policy mapping
- add atomic tool-permission and Zendesk settings routes
- update permission cards and connector settings UI
- cover routes, MCP configuration, and permission flows with tests